### PR TITLE
fix: remove duplicate cargo-audit hook, dogfood commit traceability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,15 +86,6 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
-      # ── Security: known vulnerabilities (RustSec advisory DB) ──────
-      - id: cargo-audit
-        name: cargo audit
-        entry: cargo audit
-        language: system
-        pass_filenames: false
-        files: '(Cargo\.toml|Cargo\.lock)$'
-        stages: [pre-push]
-
       # ── Security: license compliance, bans, sources, advisories ────
       - id: cargo-deny
         name: cargo deny check


### PR DESCRIPTION
## Summary
- Remove duplicate `cargo-audit` entry in `.pre-commit-config.yaml`
- First commit with artifact trailers — dogfooding commit traceability

## Bootstrap
To use the commit-msg hook locally:
```bash
cargo install --path rivet-cli    # build rivet first
pre-commit install --hook-type commit-msg --hook-type pre-commit
```

## Test plan
- [x] `rivet validate` passes
- [x] `rivet commit-msg-check` validates trailers
- [x] Pre-commit hooks installed and working

🤖 Generated with [Claude Code](https://claude.com/claude-code)