### PR TITLE
fix(serve): exclude /assets/ from layout middleware, allow data: fonts in CSP

### DIFF
--- a/rivet-cli/src/serve/mod.rs
+++ b/rivet-cli/src/serve/mod.rs
@@ -397,7 +397,7 @@ pub async fn run(
             |mut response: axum::response::Response| async move {
                 response.headers_mut().insert(
                     "Content-Security-Policy",
-                    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
+                    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'"
                         .parse()
                         .unwrap(),
                 );
@@ -435,6 +435,7 @@ async fn wrap_full_page(
         && !is_htmx
         && path != "/"
         && !path.starts_with("/api/")
+        && !path.starts_with("/assets/")
         && !path.starts_with("/wasm/")
         && !path.starts_with("/source-raw/")
         && !path.starts_with("/docs-asset/")


### PR DESCRIPTION
## Summary

- `/assets/htmx.js` and `/assets/mermaid.js` were being wrapped in the HTML page shell by the redirect middleware, causing JS parse errors
- CSP header was blocking base64-embedded fonts (data: URIs)

Two-line fix in `mod.rs`.

## Test plan

- [x] All tests pass
- [ ] Playwright E2E (CI)
- [ ] Manual: `rivet serve` → no console errors, HTMX navigation works, fonts load

🤖 Generated with [Claude Code](https://claude.com/claude-code)