### PR TITLE
feat(build): remove embed-wasm feature gate — build.rs generates stubs

### DIFF
--- a/rivet-cli/Cargo.toml
+++ b/rivet-cli/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 [features]
 default = []
 wasm = ["rivet-core/wasm"]
-embed-wasm = []
 
 [dependencies]
 rivet-core = { path = "../rivet-core" }

--- a/rivet-cli/build.rs
+++ b/rivet-cli/build.rs
@@ -63,13 +63,18 @@ fn main() {
     println!("cargo:rustc-env=RIVET_BUILD_DATE={build_date}");
 }
 
-/// Build spar WASM assets if they are missing and spar repo is available.
+/// Build or stub spar WASM assets.
 ///
-/// Checks `SPAR_DIR` env var, then `../spar` as default location.
-/// Skips silently if spar is not found (WASM features are optional).
+/// If WASM assets exist on disk, they are used as-is.
+/// If a local spar repo is found, the build script is run to compile them.
+/// Otherwise, stub files are generated so `include_str!`/`include_bytes!`
+/// always succeeds — the JS runtime detects empty stubs and shows a fallback.
 fn build_wasm_assets() {
-    let wasm_js = Path::new("assets/wasm/js/spar_wasm.js");
-    let wasm_core = Path::new("assets/wasm/js/spar_wasm.core.wasm");
+    let wasm_dir = Path::new("assets/wasm/js");
+    let wasm_js = wasm_dir.join("spar_wasm.js");
+    let wasm_core = wasm_dir.join("spar_wasm.core.wasm");
+    let wasm_core2 = wasm_dir.join("spar_wasm.core2.wasm");
+    let wasm_core3 = wasm_dir.join("spar_wasm.core3.wasm");
 
     // Rebuild whenever the build script or existing assets change.
     println!("cargo:rerun-if-changed=../scripts/build-wasm.sh");
@@ -86,39 +91,78 @@ fn build_wasm_assets() {
     }
 
     if wasm_js.exists() && wasm_core.exists() {
-        return; // Assets already present, nothing to do.
+        return; // Real assets already present.
     }
 
-    if !spar_wasm_crate.exists() {
-        println!(
-            "cargo:warning=WASM assets missing and spar repo not found at {spar_dir}. \
-             Set SPAR_DIR env var or run: ./scripts/build-wasm.sh /path/to/spar"
-        );
-        return;
+    // Try to build from local spar repo.
+    if spar_wasm_crate.exists() {
+        // Check out the pinned rev before building so WASM matches the dependency.
+        if let Some(pinned_rev) = get_pinned_spar_rev() {
+            let checkout = Command::new("git")
+                .args(["checkout", &pinned_rev])
+                .current_dir(&spar_dir)
+                .status();
+            if let Ok(s) = checkout {
+                if s.success() {
+                    println!("cargo:warning=Checked out spar at pinned rev {pinned_rev}");
+                }
+            }
+        }
+
+        println!("cargo:warning=Building spar WASM assets from {spar_dir}...");
+        let status = Command::new("bash")
+            .arg("../scripts/build-wasm.sh")
+            .arg(&spar_dir)
+            .status();
+
+        match status {
+            Ok(s) if s.success() => {
+                println!("cargo:warning=spar WASM assets built successfully.");
+                return;
+            }
+            Ok(s) => {
+                println!(
+                    "cargo:warning=WASM build script exited with {}. Generating stubs.",
+                    s
+                );
+            }
+            Err(e) => {
+                println!("cargo:warning=Failed to run WASM build script: {e}. Generating stubs.");
+            }
+        }
     }
 
-    // Run the build script from the workspace root.
-    println!("cargo:warning=Building spar WASM assets from {spar_dir}...");
-    let status = Command::new("bash")
-        .arg("../scripts/build-wasm.sh")
-        .arg(&spar_dir)
-        .status();
-
-    match status {
-        Ok(s) if s.success() => {
-            println!("cargo:warning=spar WASM assets built successfully.");
-        }
-        Ok(s) => {
-            println!(
-                "cargo:warning=WASM build script exited with {}. \
-                 Dashboard AADL rendering may not work.",
-                s
-            );
-        }
-        Err(e) => {
-            println!("cargo:warning=Failed to run WASM build script: {e}");
-        }
+    // Generate stub files so include_str!/include_bytes! always succeeds.
+    // The JS runtime detects empty stubs via the HEAD probe and shows a fallback.
+    std::fs::create_dir_all(wasm_dir).ok();
+    if !wasm_js.exists() {
+        std::fs::write(&wasm_js, "// stub: spar WASM not available\n").ok();
     }
+    if !wasm_core.exists() {
+        std::fs::write(&wasm_core, b"").ok();
+    }
+    if !wasm_core2.exists() {
+        std::fs::write(&wasm_core2, b"").ok();
+    }
+    if !wasm_core3.exists() {
+        std::fs::write(&wasm_core3, b"").ok();
+    }
+    println!(
+        "cargo:warning=WASM assets not found — generated stubs. AADL diagrams will show a fallback."
+    );
+}
+
+/// Extract the pinned spar rev from workspace Cargo.toml.
+fn get_pinned_spar_rev() -> Option<String> {
+    let cargo_toml = Path::new("../Cargo.toml");
+    let content = std::fs::read_to_string(cargo_toml).ok()?;
+    content
+        .lines()
+        .find(|l| l.contains("spar-hir") && l.contains("rev"))
+        .and_then(|line| {
+            let after_rev = line.split("rev = \"").nth(1)?;
+            Some(after_rev.split('"').next()?.to_string())
+        })
 }
 
 /// Compare the local spar repo HEAD against the rev pinned in workspace Cargo.toml.

--- a/rivet-cli/src/serve/js.rs
+++ b/rivet-cli/src/serve/js.rs
@@ -660,7 +660,7 @@ async function checkWasmAvailable(){
 
 async function getSparRenderer(aadlFiles){
   if(!wasmAvailable){
-    throw new Error('AADL WASM renderer not available (build with --features embed-wasm)');
+    throw new Error('AADL WASM renderer not available (run ./scripts/build-wasm.sh and rebuild)');
   }
   if(!wasmModulePromise){
     wasmModulePromise = import('/wasm/spar_wasm.js');
@@ -690,7 +690,7 @@ async function initAadlDiagrams(){
     containers.forEach(function(c){
       c.setAttribute('data-loaded','true');
       var ld = c.querySelector('.aadl-loading');
-      if(ld) ld.textContent = 'AADL diagram requires spar WASM (build with --features embed-wasm)';
+      if(ld) ld.textContent = 'AADL diagram requires spar WASM (run ./scripts/build-wasm.sh and rebuild)';
     });
     return;
   }

--- a/rivet-cli/src/serve/mod.rs
+++ b/rivet-cli/src/serve/mod.rs
@@ -16,8 +16,8 @@ const HTMX_JS: &str = include_str!("../../assets/htmx.min.js");
 const MERMAID_JS: &str = include_str!("../../assets/mermaid.min.js");
 
 /// Embedded WASM/JS assets for single-binary distribution.
-/// Only available when built with `--features embed-wasm` and assets exist.
-#[cfg(feature = "embed-wasm")]
+/// build.rs generates stub files when spar WASM is not built, so these
+/// always compile. The JS runtime detects stubs via a HEAD probe.
 mod embedded_wasm {
     pub const SPAR_JS: &str = include_str!("../../assets/wasm/js/spar_wasm.js");
     pub const CORE_WASM: &[u8] = include_bytes!("../../assets/wasm/js/spar_wasm.core.wasm");
@@ -589,8 +589,7 @@ async fn wasm_asset(Path(path): Path<String>) -> impl IntoResponse {
         "application/octet-stream"
     };
 
-    // Try embedded assets first (when built with embed-wasm feature).
-    #[cfg(feature = "embed-wasm")]
+    // Try embedded assets (build.rs generates stubs when spar WASM is not built).
     {
         let bytes: Option<&[u8]> = match path.as_str() {
             "spar_wasm.js" => Some(embedded_wasm::SPAR_JS.as_bytes()),
@@ -600,6 +599,11 @@ async fn wasm_asset(Path(path): Path<String>) -> impl IntoResponse {
             _ => None,
         };
         if let Some(data) = bytes {
+            // Stub detection: if the JS is just a comment, return 404 so the
+            // HEAD probe in the client knows WASM is unavailable.
+            if data.len() < 100 && data.starts_with(b"// stub") {
+                return axum::http::StatusCode::NOT_FOUND.into_response();
+            }
             return (
                 axum::http::StatusCode::OK,
                 [


### PR DESCRIPTION
## Summary

- `--features embed-wasm` is gone — WASM is always embedded
- build.rs generates stub files when spar WASM isn't built, so compilation always works
- Stubs return 404 at runtime → client shows inline fallback
- When spar repo is available, build.rs checks out the pinned Cargo.toml rev before building WASM

## Test plan

- [x] All tests pass
- [x] Builds without spar WASM (stubs generated)
- [x] Builds with spar WASM (real assets used)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)