### PR TITLE
fix: /embed/* path prefix for sidebar-free VS Code WebView

### DIFF
--- a/rivet-cli/src/serve/mod.rs
+++ b/rivet-cli/src/serve/mod.rs
@@ -591,12 +591,41 @@ async fn wrap_full_page(
     req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    let path = req.uri().path().to_string();
+    let original_path = req.uri().path().to_string();
     let query = req.uri().query().unwrap_or("").to_string();
     let is_htmx = req.headers().contains_key("hx-request");
     let is_print = query.contains("print=1");
-    let is_embed = query.contains("embed=1");
+    let is_embed = query.contains("embed=1")
+        || original_path.starts_with("/embed/")
+        || original_path == "/embed";
     let method = req.method().clone();
+
+    // Strip /embed prefix so existing route handlers match
+    let req = if is_embed && original_path.starts_with("/embed") {
+        let new_path = original_path.strip_prefix("/embed").unwrap_or("/");
+        let new_path = if new_path.is_empty() { "/" } else { new_path };
+        let mut parts = req.uri().clone().into_parts();
+        let new_pq = if query.is_empty() {
+            new_path.to_string()
+        } else {
+            format!("{new_path}?{query}")
+        };
+        parts.path_and_query = Some(new_pq.parse().unwrap());
+        let new_uri = axum::http::Uri::from_parts(parts).unwrap();
+        let (mut head, body) = req.into_parts();
+        head.uri = new_uri;
+        axum::extract::Request::from_parts(head, body)
+    } else {
+        req
+    };
+    let path = if is_embed && original_path.starts_with("/embed") {
+        original_path
+            .strip_prefix("/embed")
+            .unwrap_or("/")
+            .to_string()
+    } else {
+        original_path
+    };
 
     let response = next.run(req).await;
 

--- a/vscode-rivet/src/extension.ts
+++ b/vscode-rivet/src/extension.ts
@@ -190,9 +190,8 @@ async function showDashboard(context: vscode.ExtensionContext, urlPath: string =
   }
 
   // Map localhost to a VS Code-accessible URI (works in WebViews)
-  // ?embed=1 strips the sidebar (VS Code tree view handles navigation)
-  const sep = urlPath.includes('?') ? '&' : '?';
-  const localUri = vscode.Uri.parse(`http://127.0.0.1:${dashboardPort}${urlPath}${sep}embed=1`);
+  // /embed prefix strips the sidebar (VS Code tree view handles navigation)
+  const localUri = vscode.Uri.parse(`http://127.0.0.1:${dashboardPort}/embed${urlPath}`);
   const mappedUri = await vscode.env.asExternalUri(localUri);
 
   if (dashboardPanel) {
@@ -221,7 +220,7 @@ function getDashboardHtml(url: string): string {
 <head>
   <meta charset="utf-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; frame-src ${url} http://127.0.0.1:* https://*.vscode-cdn.net; style-src 'unsafe-inline';">
+        content="default-src 'none'; frame-src http://127.0.0.1:* https://*.vscode-cdn.net; style-src 'unsafe-inline';">
   <style>html,body,iframe{margin:0;padding:0;width:100%;height:100%;border:none;overflow:hidden}</style>
 </head>
 <body>


### PR DESCRIPTION
Strips /embed from path, uses embed_layout. Verified: 0 nav in embed, 1 in normal. 🤖