### PR TITLE
fix(windows): gate chmod behind cfg(unix) to unblock v0.4.0 release

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -2504,8 +2504,6 @@ fn which_rivet() -> String {
 ///
 /// This allows coexistence with pre-commit, husky, lefthook, etc.
 fn install_hook(path: &std::path::Path, content: &str) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
     if path.exists() {
         let prev = path.with_extension("prev");
         // Don't overwrite an existing .prev (user may have modified it)
@@ -2530,8 +2528,13 @@ fn install_hook(path: &std::path::Path, content: &str) -> Result<()> {
 
     let final_content = format!("{content}{chain_snippet}");
     std::fs::write(path, &final_content).with_context(|| format!("writing {}", path.display()))?;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
-        .with_context(|| format!("setting permissions on {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("setting permissions on {}", path.display()))?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
The v0.4.0 release workflow ([run 24649587813](https://github.com/pulseengine/rivet/actions/runs/24649587813)) failed on the Windows target:

\`\`\`
error[E0433]: cannot find \`unix\` in \`os\`
error[E0599]: no function or associated item named \`from_mode\` found for struct \`std::fs::Permissions\`
\`\`\`

\`install_hook()\` used \`std::os::unix::fs::PermissionsExt\` and \`Permissions::from_mode(0o755)\` without a platform gate. Wrapping the chmod in \`#[cfg(unix)]\` fixes it. On Windows, git runs hooks through Git-Bash regardless of NTFS executable bits, so the chmod is a no-op anyway.

\`externals.rs\` already handles this pattern correctly — this is the only remaining unix-only call site.

## Test plan
- [x] \`cargo check\` clean on darwin
- [ ] CI green (Linux + macOS + Windows cross-build via release.yml on tag, but CI's Test job will cover the type check here)

After merge: delete the (unreleased) \`v0.4.0\` tag and re-tag from the fix commit to retry the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)