### PR TITLE
feat(release): VSIX on GitHub Release + actually publish to Marketplace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,55 +128,12 @@ jobs:
         env:
           DISPLAY: ':99.0'
 
-  # ── Build VS Code VSIX (release tags only) ───────────────────────────
-  build-vsix:
-    name: Build VS Code Extension VSIX
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Install extension dependencies
-        working-directory: vscode-rivet
-        run: npm ci
-      - name: Compile extension
-        working-directory: vscode-rivet
-        run: npm run compile
-      - name: Package VSIX
-        working-directory: vscode-rivet
-        run: npx @vscode/vsce package --no-dependencies
-      - uses: actions/upload-artifact@v4
-        with:
-          name: vsix
-          path: vscode-rivet/*.vsix
-
-  # ── Publish VS Code Extension to Marketplace (release tags only) ─────
-  publish-vsix:
-    name: Publish to VS Code Marketplace
-    needs: [build-vsix, release-results]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: vsix
-          path: vsix
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Publish to Marketplace
-        # Requires VSCE_PAT secret in GitHub repo settings.
-        # See: https://code.visualstudio.com/api/working-with-extensions/publishing-extension
-        run: |
-          if [ -n "$VSCE_PAT" ]; then
-            npx @vscode/vsce publish --packagePath vsix/*.vsix
-          else
-            echo "VSCE_PAT not set, skipping marketplace publish"
-          fi
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+  # VSIX build + publish live in release.yml now so the extension attaches
+  # to the GitHub Release on tag push AND flows to the Marketplace in the
+  # same pipeline. The previous `publish-vsix` here depended on a
+  # non-existent `release-results` job, so the Marketplace push never
+  # actually ran (which is why only the spar extension is currently on the
+  # Marketplace — its workflow is scoped differently). See release.yml.
 
   # ── Security audits ──────────────────────────────────────────────────
   audit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,10 +221,35 @@ jobs:
           name: test-evidence
           path: rivet-*-test-evidence.tar.gz
 
+  # ── VS Code Extension VSIX ────────────────────────────────────────────
+  # Builds the VSIX so it can be attached to the GitHub Release and
+  # separately published to the VS Code Marketplace.
+  build-vsix:
+    name: Build VS Code Extension VSIX
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install extension dependencies
+        working-directory: vscode-rivet
+        run: npm ci
+      - name: Compile extension
+        working-directory: vscode-rivet
+        run: npm run compile
+      - name: Package VSIX
+        working-directory: vscode-rivet
+        run: npx @vscode/vsce package --no-dependencies
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vsix
+          path: vscode-rivet/*.vsix
+
   # ── Create GitHub Release ─────────────────────────────────────────────
   create-release:
     name: Create GitHub Release
-    needs: [build-binaries, build-compliance, build-test-evidence]
+    needs: [build-binaries, build-compliance, build-test-evidence, build-vsix]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -237,7 +262,7 @@ jobs:
       - name: Collect assets
         run: |
           mkdir -p release
-          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} release/ \;
+          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.vsix" \) -exec mv {} release/ \;
           ls -la release/
 
       - name: Generate checksums
@@ -255,3 +280,32 @@ jobs:
             --title "Rivet $VERSION" \
             --generate-notes \
             release/*
+
+  # ── Publish VS Code Extension to Marketplace ──────────────────────────
+  # Runs after create-release so the VSIX is always on the Release page
+  # even if Marketplace publish fails or VSCE_PAT isn't set. The
+  # conditional guard prints a visible warning rather than silently
+  # skipping, which is how the previous ci.yml flow made "rivet extension
+  # never reaches Marketplace" invisible.
+  publish-vsix-marketplace:
+    name: Publish VSIX to VS Code Marketplace
+    needs: [create-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: vsix
+          path: vsix
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Publish to Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "::warning::VSCE_PAT secret is not configured. VSIX is attached to the GitHub Release but WILL NOT be published to the Marketplace."
+            echo "::warning::See https://code.visualstudio.com/api/working-with-extensions/publishing-extension for PAT setup."
+            exit 0
+          fi
+          npx @vscode/vsce publish --packagePath vsix/*.vsix

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Two bugs in the VS Code extension release flow

### Bug 1 — VSIX wasn't on the GitHub Release page

\`build-vsix\` in ci.yml uploaded the VSIX as a workflow artifact only. Users who wanted to sideload the extension had to dig through the Actions tab. Should be on the Release page with the binaries.

### Bug 2 — Marketplace publish never actually ran

\`publish-vsix\` was gated on \`needs: [build-vsix, release-results]\`. \`release-results\` doesn't exist as a job in ci.yml — it lives in release.yml, a **separate workflow**. GitHub Actions can't express cross-workflow job dependencies, so the publish job was never scheduled on any tag. **This is why only the spar extension currently appears on the VS Code Marketplace — rivet's has never actually shipped**, despite the YAML pretending to publish.

## Fix

Move both jobs to \`release.yml\` where they belong:

- \`build-vsix\` runs alongside \`build-binaries\`
- \`create-release\` now depends on build-vsix and globs \`*.vsix\` in the asset collection step → VSIX attaches to the GH Release
- New \`publish-vsix-marketplace\` runs after create-release so the VSIX is guaranteed on the Release page even if Marketplace publish fails
- If \`VSCE_PAT\` secret is missing, emits a \`::warning::\` instead of silently skipping — the silent-skip is exactly what hid Bug 2

Also bumps \`vscode-rivet/package.json\` 0.3.0 → 0.4.0 to match the workspace.

## Post-merge checklist for the repo admin
- [ ] Configure \`VSCE_PAT\` in repo settings → Secrets → Actions. PAT needs **Marketplace > Manage** scope on Azure DevOps. Without it the extension will still attach to the Release but won't reach the Marketplace.

## Test plan
- [x] \`yamllint\` on both workflow files
- [ ] Next tag push exercises the full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)