### PR TITLE
build(npm): add @pulseengine/rivet distribution

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,179 @@
+name: Release NPM
+
+# Runs after the main Release workflow (release.yml) publishes a GitHub
+# Release with the per-target binary archives. Downloads those archives,
+# assembles one npm platform package per target, publishes them, and finally
+# publishes the root @pulseengine/rivet package that depends on them via
+# optionalDependencies.
+#
+# Platform packages MUST be published before the root package so npm can
+# resolve optionalDependencies on the first install after tag.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to publish (e.g. v0.4.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish-platform-packages:
+    name: Publish platform package (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            platform: darwin-arm64
+            binary: rivet
+            archive_ext: tar.gz
+          - target: x86_64-apple-darwin
+            platform: darwin-x64
+            binary: rivet
+            archive_ext: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            platform: linux-arm64
+            binary: rivet
+            archive_ext: tar.gz
+          - target: x86_64-unknown-linux-gnu
+            platform: linux-x64
+            binary: rivet
+            archive_ext: tar.gz
+          - target: x86_64-pc-windows-msvc
+            platform: win32-x64
+            binary: rivet.exe
+            archive_ext: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.version }}
+        run: |
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "No tag provided" >&2
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download release asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          TARGET: ${{ matrix.target }}
+          PLATFORM: ${{ matrix.platform }}
+          BINARY: ${{ matrix.binary }}
+          ARCHIVE_EXT: ${{ matrix.archive_ext }}
+        run: |
+          ASSET="rivet-${TAG}-${TARGET}.${ARCHIVE_EXT}"
+          mkdir -p staging
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "$ASSET" --dir staging
+          ls -la staging
+          if [ "$ARCHIVE_EXT" = "zip" ]; then
+            unzip -q "staging/$ASSET" -d staging
+          else
+            tar -xzf "staging/$ASSET" -C staging
+          fi
+          cp "staging/$BINARY" "platform-packages/$PLATFORM/$BINARY"
+          if [ "$ARCHIVE_EXT" != "zip" ]; then
+            chmod +x "platform-packages/$PLATFORM/$BINARY"
+          fi
+
+      - name: Update package version
+        working-directory: platform-packages/${{ matrix.platform }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          cat package.json
+
+      - name: Publish to npm
+        working-directory: platform-packages/${{ matrix.platform }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+  publish-root-package:
+    name: Publish root package (@pulseengine/rivet)
+    needs: publish-platform-packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.version }}
+        run: |
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update root package version and optionalDependencies
+        working-directory: npm
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          jq --arg v "$VERSION" '
+            .version = $v |
+            .optionalDependencies = {
+              "@pulseengine/rivet-darwin-arm64": $v,
+              "@pulseengine/rivet-darwin-x64":   $v,
+              "@pulseengine/rivet-linux-arm64":  $v,
+              "@pulseengine/rivet-linux-x64":    $v,
+              "@pulseengine/rivet-win32-x64":    $v
+            }
+          ' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          cat package.json
+
+      - name: Publish to npm
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "## NPM packages published";
+            echo "";
+            echo "- \`@pulseengine/rivet@$VERSION\`";
+            echo "- \`@pulseengine/rivet-darwin-arm64@$VERSION\`";
+            echo "- \`@pulseengine/rivet-darwin-x64@$VERSION\`";
+            echo "- \`@pulseengine/rivet-linux-arm64@$VERSION\`";
+            echo "- \`@pulseengine/rivet-linux-x64@$VERSION\`";
+            echo "- \`@pulseengine/rivet-win32-x64@$VERSION\`";
+            echo "";
+            echo "### Usage";
+            echo '```bash';
+            echo "npx @pulseengine/rivet --version";
+            echo "claude mcp add rivet npx -y @pulseengine/rivet mcp";
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ vscode-rivet/node_modules/
 vscode-rivet/bin/rivet
 vscode-rivet/out/
 vscode-rivet/*.vsix
+
+# npm distribution: binaries are populated by release-npm.yml at publish time,
+# never committed. node_modules from local npm installs should also be ignored.
+platform-packages/*/rivet
+platform-packages/*/rivet.exe
+npm/bin/
+npm/node_modules/
+platform-packages/*/node_modules/

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,0 +1,4 @@
+bin/
+*.tmp
+.DS_Store
+Thumbs.db

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,40 @@
+# @pulseengine/rivet
+
+SDLC traceability, validation, and MCP server for safety-critical systems.
+
+Rivet links requirements, features, architecture, decisions, and verification
+evidence across ISO 26262, DO-178C, ASPICE, and STPA. This npm package bundles
+the `rivet` CLI binary (shipped per-platform via `optionalDependencies`) so it
+can be invoked from any Node.js environment — including as a Claude Code MCP
+server.
+
+## Install
+
+```bash
+# One-shot (no install) — preferred for CI and MCP registration
+npx @pulseengine/rivet --version
+
+# Global install
+npm install -g @pulseengine/rivet
+rivet --version
+```
+
+## Claude Code MCP server
+
+```bash
+claude mcp add rivet npx -y @pulseengine/rivet mcp
+```
+
+## Supported platforms
+
+- `darwin-arm64`, `darwin-x64`
+- `linux-arm64`, `linux-x64`
+- `win32-x64`
+
+Binaries are pre-built and published alongside each GitHub release at
+<https://github.com/pulseengine/rivet/releases>.
+
+## License
+
+Apache-2.0. See the [repository](https://github.com/pulseengine/rivet) for
+source, documentation, and issues.

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+// Platform detection and binary-path resolution for @pulseengine/rivet.
+// Chooses the correct platform-specific optional dependency, or falls back
+// to a locally downloaded binary under ./bin (populated by install.js when
+// optionalDependencies fail to resolve — e.g., on an unsupported platform
+// triplet or with --no-optional).
+
+const os = require("os");
+const path = require("path");
+
+/**
+ * Map (process.platform, process.arch) to the matching @pulseengine platform
+ * package name. Throws for unsupported combinations so the caller can surface
+ * a clear error.
+ */
+function getPlatformPackageName() {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  let platformName;
+  switch (platform) {
+    case "darwin":
+      platformName = "darwin";
+      break;
+    case "linux":
+      platformName = "linux";
+      break;
+    case "win32":
+      platformName = "win32";
+      break;
+    default:
+      throw new Error(`Unsupported platform: ${platform}`);
+  }
+
+  let archName;
+  switch (arch) {
+    case "x64":
+      archName = "x64";
+      break;
+    case "arm64":
+      archName = "arm64";
+      break;
+    default:
+      throw new Error(`Unsupported architecture: ${arch}`);
+  }
+
+  return `@pulseengine/rivet-${platformName}-${archName}`;
+}
+
+/**
+ * Resolve the absolute path to the rivet binary for the current platform.
+ * Prefers the optional-dependency platform package; falls back to ./bin
+ * (populated by install.js downloading from the GitHub Release).
+ */
+function getBinaryPath() {
+  const platform = os.platform();
+  const binaryName = platform === "win32" ? "rivet.exe" : "rivet";
+
+  try {
+    const platformPackage = getPlatformPackageName();
+    const platformPackagePath = require.resolve(`${platformPackage}/package.json`);
+    const platformPackageDir = path.dirname(platformPackagePath);
+    return path.join(platformPackageDir, binaryName);
+  } catch (_err) {
+    // Fallback: binary downloaded directly from GitHub release by install.js.
+    return path.join(__dirname, "bin", binaryName);
+  }
+}
+
+function getPlatformInfo() {
+  return {
+    platform: os.platform(),
+    arch: os.arch(),
+    platformPackage: getPlatformPackageName(),
+    binaryPath: getBinaryPath(),
+    binaryName: os.platform() === "win32" ? "rivet.exe" : "rivet",
+  };
+}
+
+module.exports = {
+  getPlatformPackageName,
+  getBinaryPath,
+  getPlatformInfo,
+};
+
+// When invoked directly, print platform info (useful for debugging installs).
+if (require.main === module) {
+  try {
+    const info = getPlatformInfo();
+    console.log("Platform Information:");
+    console.log(`  Platform:         ${info.platform}`);
+    console.log(`  Architecture:     ${info.arch}`);
+    console.log(`  Platform Package: ${info.platformPackage}`);
+    console.log(`  Binary Name:      ${info.binaryName}`);
+    console.log(`  Binary Path:      ${info.binaryPath}`);
+  } catch (err) {
+    console.error("Error:", err.message);
+    process.exit(1);
+  }
+}

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+// Post-install hook for @pulseengine/rivet.
+//
+// Preferred path: the platform-specific optional dependency
+// (@pulseengine/rivet-<platform>-<arch>) is already resolved and ships its
+// own pre-built binary — nothing to do.
+//
+// Fallback path: optionalDependencies were skipped (e.g., --no-optional,
+// unusual platform triplet, or npm bug) — download the matching archive
+// from the GitHub Release and extract the binary into ./bin so run.js can
+// find it.
+
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+const https = require("https");
+const { execFileSync } = require("child_process");
+
+const { getPlatformPackageName } = require("./index.js");
+
+// Fast path: platform package resolved => nothing to do.
+try {
+  const platformPackage = getPlatformPackageName();
+  try {
+    require.resolve(`${platformPackage}/package.json`);
+    console.log(`Platform package ${platformPackage} is available, skipping binary download.`);
+    process.exit(0);
+  } catch (_err) {
+    console.log(
+      `Platform package ${platformPackage} not found, falling back to GitHub release download.`,
+    );
+  }
+} catch (_err) {
+  console.log(
+    "Platform not supported by platform packages, attempting GitHub release download.",
+  );
+}
+
+// --- Fallback: download from GitHub release ---------------------------------
+
+function getRustTarget() {
+  const type = os.type();
+  const arch = os.arch();
+
+  let platform;
+  if (type === "Windows_NT") platform = "pc-windows-msvc";
+  else if (type === "Linux") platform = "unknown-linux-gnu";
+  else if (type === "Darwin") platform = "apple-darwin";
+  else throw new Error(`Unsupported OS: ${type}`);
+
+  let archSuffix;
+  if (arch === "x64") archSuffix = "x86_64";
+  else if (arch === "arm64") archSuffix = "aarch64";
+  else throw new Error(`Unsupported architecture: ${arch}`);
+
+  return `${archSuffix}-${platform}`;
+}
+
+function getBinaryName() {
+  return os.type() === "Windows_NT" ? "rivet.exe" : "rivet";
+}
+
+function getDownloadUrl() {
+  const version = require("./package.json").version;
+  const target = getRustTarget();
+  const ext = os.type() === "Windows_NT" ? "zip" : "tar.gz";
+  // release.yml uploads archives named: rivet-v<version>-<target>.<ext>
+  return `https://github.com/pulseengine/rivet/releases/download/v${version}/rivet-v${version}-${target}.${ext}`;
+}
+
+function downloadFile(url, destination) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(destination);
+
+    https
+      .get(url, (response) => {
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          file.close();
+          fs.unlink(destination, () => {});
+          return downloadFile(response.headers.location, destination)
+            .then(resolve)
+            .catch(reject);
+        }
+        if (response.statusCode !== 200) {
+          file.close();
+          fs.unlink(destination, () => {});
+          return reject(
+            new Error(`HTTP ${response.statusCode}: ${response.statusMessage} (${url})`),
+          );
+        }
+
+        response.pipe(file);
+        file.on("finish", () => {
+          file.close();
+          resolve();
+        });
+        file.on("error", (err) => {
+          fs.unlink(destination, () => {});
+          reject(err);
+        });
+      })
+      .on("error", (err) => {
+        fs.unlink(destination, () => {});
+        reject(err);
+      });
+  });
+}
+
+// Extract via execFile (no shell) to avoid any injection surface. Inputs are
+// already hardcoded paths we just constructed, but the argv form is the
+// correct idiom regardless.
+function extractArchive(archivePath, destDir) {
+  if (os.type() === "Windows_NT") {
+    execFileSync(
+      "powershell",
+      [
+        "-NoProfile",
+        "-Command",
+        `Expand-Archive -Path '${archivePath}' -DestinationPath '${destDir}' -Force`,
+      ],
+      { stdio: "inherit" },
+    );
+  } else {
+    execFileSync("tar", ["-xzf", archivePath, "-C", destDir], { stdio: "inherit" });
+  }
+}
+
+async function installBinary() {
+  const binaryName = getBinaryName();
+  const url = getDownloadUrl();
+  const target = getRustTarget();
+
+  console.log(`Platform: ${os.type()} ${os.arch()}`);
+  console.log(`Target:   ${target}`);
+  console.log(`Binary:   ${binaryName}`);
+  console.log(`URL:      ${url}`);
+
+  const binDir = path.join(__dirname, "bin");
+  if (!fs.existsSync(binDir)) fs.mkdirSync(binDir, { recursive: true });
+
+  const ext = os.type() === "Windows_NT" ? "zip" : "tar.gz";
+  const archivePath = path.join(binDir, `rivet.${ext}`);
+
+  console.log("Downloading binary...");
+  await downloadFile(url, archivePath);
+
+  console.log("Extracting...");
+  extractArchive(archivePath, binDir);
+
+  fs.unlinkSync(archivePath);
+
+  if (os.type() !== "Windows_NT") {
+    const binaryPath = path.join(binDir, binaryName);
+    if (fs.existsSync(binaryPath)) fs.chmodSync(binaryPath, 0o755);
+  }
+
+  console.log("rivet binary installed.");
+}
+
+installBinary().catch((err) => {
+  console.error("Failed to install rivet binary:", err.message);
+  console.error("");
+  console.error("You can:");
+  console.error("  1. Install from source:");
+  console.error(
+    "     cargo install --git https://github.com/pulseengine/rivet.git rivet-cli",
+  );
+  console.error("  2. Download a release manually:");
+  console.error("     https://github.com/pulseengine/rivet/releases");
+  // Do not fail the install: optionalDependencies are the primary path and a
+  // hard failure here would make `npm install` fail on platforms where the
+  // platform package was actually resolved (npm runs postinstall regardless).
+  process.exit(0);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@pulseengine/rivet",
+  "version": "0.4.0",
+  "description": "Rivet — SDLC traceability, validation, and MCP server for safety-critical systems (ISO 26262, DO-178C, ASPICE, STPA)",
+  "main": "index.js",
+  "bin": {
+    "rivet": "./run.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js",
+    "preuninstall": "node uninstall.js"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "sdlc",
+    "traceability",
+    "safety",
+    "iso-26262",
+    "do-178c",
+    "aspice",
+    "stpa",
+    "requirements",
+    "verification",
+    "rust",
+    "cli"
+  ],
+  "author": "PulseEngine <https://github.com/pulseengine>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pulseengine/rivet.git"
+  },
+  "homepage": "https://github.com/pulseengine/rivet#readme",
+  "bugs": {
+    "url": "https://github.com/pulseengine/rivet/issues"
+  },
+  "optionalDependencies": {
+    "@pulseengine/rivet-darwin-arm64": "0.4.0",
+    "@pulseengine/rivet-darwin-x64": "0.4.0",
+    "@pulseengine/rivet-linux-arm64": "0.4.0",
+    "@pulseengine/rivet-linux-x64": "0.4.0",
+    "@pulseengine/rivet-win32-x64": "0.4.0"
+  },
+  "engines": {
+    "node": ">=14"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "files": [
+    "index.js",
+    "install.js",
+    "run.js",
+    "uninstall.js",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/npm/run.js
+++ b/npm/run.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+// Thin wrapper that spawns the rivet binary resolved via ./index.js.
+// Forwards argv, stdio, and exit code; propagates signals to the child.
+
+const { spawn } = require("child_process");
+const fs = require("fs");
+const { getBinaryPath } = require("./index.js");
+
+function runRivet() {
+  let binaryPath;
+  try {
+    binaryPath = getBinaryPath();
+  } catch (err) {
+    console.error("Error resolving rivet binary:", err.message);
+    console.error("");
+    console.error("Your platform may not be supported. Supported targets:");
+    console.error("  - darwin-arm64, darwin-x64");
+    console.error("  - linux-arm64, linux-x64");
+    console.error("  - win32-x64");
+    console.error("");
+    console.error(
+      "Install from source: cargo install --git https://github.com/pulseengine/rivet.git rivet-cli",
+    );
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(binaryPath)) {
+    console.error("rivet binary not found at:", binaryPath);
+    console.error("");
+    console.error("This usually means:");
+    console.error("  1. optionalDependencies failed to install for your platform");
+    console.error("  2. The GitHub release fallback download failed");
+    console.error("  3. Your platform is not supported");
+    console.error("");
+    console.error("Try: npm install --force @pulseengine/rivet");
+    console.error(
+      "Or install from source: cargo install --git https://github.com/pulseengine/rivet.git rivet-cli",
+    );
+    process.exit(1);
+  }
+
+  const child = spawn(binaryPath, process.argv.slice(2), {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  child.on("error", (err) => {
+    console.error("Failed to start rivet:", err.message);
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code == null ? 0 : code);
+    }
+  });
+
+  process.on("SIGINT", () => child.kill("SIGINT"));
+  process.on("SIGTERM", () => child.kill("SIGTERM"));
+}
+
+runRivet();

--- a/npm/uninstall.js
+++ b/npm/uninstall.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// Pre-uninstall hook: remove binaries downloaded into ./bin by install.js.
+// Platform packages (optional deps) clean themselves up via normal npm
+// lifecycle — no action needed for those.
+
+const fs = require("fs");
+const path = require("path");
+
+const binDir = path.join(__dirname, "bin");
+
+if (fs.existsSync(binDir)) {
+  try {
+    fs.rmSync(binDir, { recursive: true, force: true });
+  } catch (err) {
+    console.error("Failed to clean rivet bin/:", err.message);
+  }
+}

--- a/platform-packages/darwin-arm64/index.js
+++ b/platform-packages/darwin-arm64/index.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+// Absolute path to the rivet binary shipped in this platform package.
+module.exports = path.join(__dirname, "rivet");

--- a/platform-packages/darwin-arm64/package.json
+++ b/platform-packages/darwin-arm64/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@pulseengine/rivet-darwin-arm64",
+  "version": "0.4.0",
+  "description": "Rivet CLI binary for macOS ARM64 (Apple Silicon)",
+  "main": "index.js",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "keywords": [
+    "rivet",
+    "sdlc",
+    "traceability",
+    "mcp",
+    "binary",
+    "macos",
+    "arm64"
+  ],
+  "author": "PulseEngine <https://github.com/pulseengine>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pulseengine/rivet.git"
+  },
+  "homepage": "https://github.com/pulseengine/rivet#readme",
+  "bugs": {
+    "url": "https://github.com/pulseengine/rivet/issues"
+  },
+  "files": [
+    "index.js",
+    "rivet"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/platform-packages/darwin-x64/index.js
+++ b/platform-packages/darwin-x64/index.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+module.exports = path.join(__dirname, "rivet");

--- a/platform-packages/darwin-x64/package.json
+++ b/platform-packages/darwin-x64/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@pulseengine/rivet-darwin-x64",
+  "version": "0.4.0",
+  "description": "Rivet CLI binary for macOS x64 (Intel)",
+  "main": "index.js",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "keywords": [
+    "rivet",
+    "sdlc",
+    "traceability",
+    "mcp",
+    "binary",
+    "macos",
+    "x64"
+  ],
+  "author": "PulseEngine <https://github.com/pulseengine>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pulseengine/rivet.git"
+  },
+  "homepage": "https://github.com/pulseengine/rivet#readme",
+  "bugs": {
+    "url": "https://github.com/pulseengine/rivet/issues"
+  },
+  "files": [
+    "index.js",
+    "rivet"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/platform-packages/linux-arm64/index.js
+++ b/platform-packages/linux-arm64/index.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+module.exports = path.join(__dirname, "rivet");

--- a/platform-packages/linux-arm64/package.json
+++ b/platform-packages/linux-arm64/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@pulseengine/rivet-linux-arm64",
+  "version": "0.4.0",
+  "description": "Rivet CLI binary for Linux ARM64 (glibc)",
+  "main": "index.js",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "keywords": [
+    "rivet",
+    "sdlc",
+    "traceability",
+    "mcp",
+    "binary",
+    "linux",
+    "arm64"
+  ],
+  "author": "PulseEngine <https://github.com/pulseengine>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pulseengine/rivet.git"
+  },
+  "homepage": "https://github.com/pulseengine/rivet#readme",
+  "bugs": {
+    "url": "https://github.com/pulseengine/rivet/issues"
+  },
+  "files": [
+    "index.js",
+    "rivet"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/platform-packages/linux-x64/index.js
+++ b/platform-packages/linux-x64/index.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+module.exports = path.join(__dirname, "rivet");

--- a/platform-packages/linux-x64/package.json
+++ b/platform-packages/linux-x64/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@pulseengine/rivet-linux-x64",
+  "version": "0.4.0",
+  "description": "Rivet CLI binary for Linux x64 (glibc)",
+  "main": "index.js",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "keywords": [
+    "rivet",
+    "sdlc",
+    "traceability",
+    "mcp",
+    "binary",
+    "linux",
+    "x64"
+  ],
+  "author": "PulseEngine <https://github.com/pulseengine>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pulseengine/rivet.git"
+  },
+  "homepage": "https://github.com/pulseengine/rivet#readme",
+  "bugs": {
+    "url": "https://github.com/pulseengine/rivet/issues"
+  },
+  "files": [
+    "index.js",
+    "rivet"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/platform-packages/win32-x64/index.js
+++ b/platform-packages/win32-x64/index.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+module.exports = path.join(__dirname, "rivet.exe");

--- a/platform-packages/win32-x64/package.json
+++ b/platform-packages/win32-x64/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@pulseengine/rivet-win32-x64",
+  "version": "0.4.0",
+  "description": "Rivet CLI binary for Windows x64 (MSVC)",
+  "main": "index.js",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "keywords": [
+    "rivet",
+    "sdlc",
+    "traceability",
+    "mcp",
+    "binary",
+    "windows",
+    "x64"
+  ],
+  "author": "PulseEngine <https://github.com/pulseengine>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pulseengine/rivet.git"
+  },
+  "homepage": "https://github.com/pulseengine/rivet#readme",
+  "bugs": {
+    "url": "https://github.com/pulseengine/rivet/issues"
+  },
+  "files": [
+    "index.js",
+    "rivet.exe"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the machinery to publish `rivet` as an npm package so it can be used
via `npx @pulseengine/rivet` and registered as a Claude Code MCP server
with `claude mcp add rivet npx -y @pulseengine/rivet mcp`.

- **`npm/`** — root package `@pulseengine/rivet`. Uses per-platform
  `optionalDependencies`; `index.js` resolves the current platform's
  package, `run.js` spawns the binary (stdin/stdout/stderr + signals
  forwarded), `install.js` is a no-op when the platform package
  resolved and falls back to downloading the archive from the GitHub
  Release otherwise.
- **`platform-packages/{darwin-arm64,darwin-x64,linux-arm64,linux-x64,win32-x64}/`**
  — five per-platform packages. Each ships exactly one pre-built binary
  (gitignored in source, populated at publish time by the workflow).
- **`.github/workflows/release-npm.yml`** — triggers on `release: published`
  (so it runs after the existing `release.yml` creates the GitHub Release
  and uploads the archives). Downloads the archives via
  `gh release download`, assembles each platform package, publishes all
  platform packages in parallel, then publishes the root package last so
  `optionalDependencies` resolve on the very first install.

Pattern mirrors [`pulseengine/template-mcp-server`](https://github.com/pulseengine/template-mcp-server)
and the live `@pulseengine/timedate-mcp-server` package.

### Deviations from the template
- **Added `linux-arm64`.** The template only ships `linux-x64`; `rivet`'s
  existing `release.yml` already builds `aarch64-unknown-linux-gnu` via
  `cross`, so we publish that too.
- **Workflow is decoupled from `release.yml`.** The template's workflow
  also builds binaries — we only download the ones `release.yml` already
  produced, which keeps the existing release flow unchanged.
- **`execFileSync` (no shell) for archive extraction** in `install.js`
  instead of `execSync` string commands, to avoid any injection surface
  even though inputs are hardcoded.
- **License:** `Apache-2.0` (matches workspace `Cargo.toml`), not `MIT`
  like the template.

### Availability check
- `@pulseengine/rivet` — currently **404 on npmjs.org** (available to claim).
- `@pulseengine` scope is already owned (`@pulseengine/timedate-mcp-server`
  is live under maintainer `avrabe` / `ralf_beier@me.com`).

### Required repo configuration — ACTION REQUIRED

The publish workflow is gated on a repository secret named **`NPM_TOKEN`**.

I checked `/repos/pulseengine/rivet/actions/secrets` and it is currently
**empty** — the repo admin must add an automation `NPM_TOKEN` before the
first tag push will actually publish to npm. Until then the workflow will
start and fail at the `npm publish` step; it will **not** damage anything.

### Non-goals
- Does not modify `release.yml`.
- Does not publish anything. Publishing only happens on tag push
  (`v*`) after `release.yml` creates the release **and** `NPM_TOKEN` is set.

## Test plan

- [ ] Repo admin adds `NPM_TOKEN` secret (automation token from npmjs.com
      for the `@pulseengine` scope, `publish` permission).
- [ ] (Optional) Dry-run via `workflow_dispatch` against an existing tag
      to watch the publish steps before next release.
- [ ] First real tag push after merge publishes all six packages to npm.
- [ ] `npm view @pulseengine/rivet` shows the new version.
- [ ] `npx @pulseengine/rivet --version` prints the same string as
      `cargo run -p rivet-cli -- --version`.
- [ ] `claude mcp add rivet npx -y @pulseengine/rivet mcp` registers
      successfully and `claude mcp list` shows the server.
- [ ] Install on at least one Linux x64 and one macOS arm64 box to
      confirm `optionalDependencies` resolution.