### PR TITLE
fix(v0.4.1): 5 user-reported pain points (#3, #4, #6, #7, #8)

### DIFF
--- a/docs/feature-model-bindings.md
+++ b/docs/feature-model-bindings.md
@@ -1,0 +1,77 @@
+# Feature Binding File Format
+
+A binding file maps features from the feature model to the artifacts and
+source code that implement them. This is a separate file from the feature
+model and the variant configuration: the feature model describes *what*
+can be chosen, the variant says *what was chosen*, the binding says
+*where the implementation lives*.
+
+See [feature-model-schema.md](feature-model-schema.md) for the feature
+model reference.
+
+## File shape
+
+```yaml
+# artifacts/bindings.yaml
+bindings:
+  <feature-name>:
+    artifacts: [<ID>, <ID>, …]   # optional; artifact IDs from the project
+    source:    [<glob>, …]       # optional; source globs, e.g. src/auth/**
+```
+
+| Field     | Type         | Required | Meaning                                                |
+| --------- | ------------ | -------- | ------------------------------------------------------ |
+| `bindings`| map          | yes      | Keyed by feature name; every key must appear in the   |
+|           |              |          | feature model.                                         |
+
+Each binding entry:
+
+| Field       | Type         | Default | Meaning                                               |
+| ----------- | ------------ | ------- | ----------------------------------------------------- |
+| `artifacts` | list<string> | `[]`    | Artifact IDs (e.g. `REQ-042`) implemented by feature. |
+| `source`    | list<string> | `[]`    | Glob patterns for the implementing source files.      |
+
+Features not listed in `bindings` are treated as having no artifact or
+source coverage — validation reports them as `unbound`.
+
+## Worked example
+
+```yaml
+# examples/variant/bindings.yaml
+bindings:
+  pedestrian-detection:
+    artifacts: [REQ-042, REQ-043]
+    source: ["src/perception/pedestrian/**"]
+  lane-keeping:
+    artifacts: [REQ-050]
+    source: ["src/control/lane_keep/**"]
+  adaptive-cruise:
+    artifacts: [REQ-051]
+    source: ["src/control/cruise/**"]
+  eu:
+    artifacts: [REQ-200]
+  asil-c:
+    artifacts: [REQ-101]
+```
+
+## Optional: per-variant declarations
+
+The binding file may also declare named variants that `rivet variant
+check-all` will iterate:
+
+```yaml
+variants:
+  - name: eu-adas-c
+    selects: [eu, adas, asil-c]
+  - name: us-autonomous-d
+    selects: [us, autonomous, asil-d]
+
+bindings:
+  …
+```
+
+When present, `rivet variant check-all --model fm.yaml --binding b.yaml`
+resolves every entry under `variants:` and exits non-zero if any fail.
+
+If a binding file has no `variants` block, `check-all` reports an empty
+result and exits successfully.

--- a/docs/feature-model-schema.md
+++ b/docs/feature-model-schema.md
@@ -1,0 +1,176 @@
+# Feature Model Schema
+
+This document is the reference for `rivet variant` YAML files:
+
+1. **Feature model** — `feature-model.yaml` (the logical problem space).
+2. **Variant configuration** — the user's feature selection.
+3. **Binding model** — maps features to artifacts and source globs (see also
+   [feature-model-bindings.md](feature-model-bindings.md)).
+
+Product-line engineering in rivet separates these three concerns into
+independent files. A feature model captures what variants *could* exist;
+a variant configuration is one user-level selection; a binding model
+ties features to implementation artifacts.
+
+Worked examples live in [`examples/variant/`](../examples/variant/).
+
+## 1. Feature model
+
+A FODA-style feature tree with group types and optional cross-tree
+constraints expressed as s-expressions.
+
+### Top-level keys
+
+| Key            | Type               | Required | Meaning                                                  |
+| -------------- | ------------------ | -------- | -------------------------------------------------------- |
+| `kind`         | string             | no       | Informational tag; conventionally `feature-model`.       |
+| `root`         | string             | yes      | Name of the root feature — the variable always selected. |
+| `features`     | map<name, feature> | yes      | Every feature in the tree, keyed by unique name.         |
+| `constraints`  | list<s-expression> | no       | Cross-tree boolean constraints (see below).              |
+
+### Feature entry (`features[name]`)
+
+| Field        | Type          | Default   | Meaning                                              |
+| ------------ | ------------- | --------- | ---------------------------------------------------- |
+| `group`      | enum          | `leaf`    | `mandatory`, `optional`, `alternative`, `or`, `leaf` |
+| `children`   | list<string>  | `[]`      | Names of child features.                             |
+
+Group semantics when the feature is selected:
+
+- `mandatory` — every child is auto-selected.
+- `optional` — each child may be selected independently.
+- `alternative` — **exactly one** child must be selected (XOR).
+- `or` — **at least one** child must be selected.
+- `leaf` — terminal feature, must have no children.
+
+If a feature is listed as a child of another but has no entry in
+`features`, rivet auto-inserts it as a `leaf`.
+
+### Constraint syntax
+
+Constraints are s-expressions. Bare feature names stand for "this feature
+is selected". The supported logical forms are:
+
+| Form              | Meaning                                |
+| ----------------- | -------------------------------------- |
+| `(and A B …)`     | All of A, B, … are selected.           |
+| `(or  A B …)`     | At least one of A, B, … is selected.   |
+| `(not A)`         | A is not selected.                     |
+| `(implies A B)`   | If A is selected then B is selected.   |
+| `(excludes A B)`  | A and B may not both be selected.      |
+| `(forall …)`      | Universally quantified predicate.      |
+| `(exists …)`      | Existentially quantified predicate.    |
+
+Examples from `examples/variant/feature-model.yaml`:
+
+```s-expr
+(implies eu pedestrian-detection)
+(implies autonomous (and adas asil-d))
+(implies adas (or asil-b asil-c asil-d))
+```
+
+The solver fails with a semantic error (not a positional one) when you
+use infix notation — e.g. `A and B` produces a diagnostic pointing you at
+`(and A B)`.
+
+### Worked example
+
+```yaml
+# artifacts/feature-model.yaml
+kind: feature-model
+root: vehicle-platform
+
+features:
+  vehicle-platform:
+    group: mandatory
+    children: [market, safety-level, feature-set]
+
+  market:
+    group: alternative
+    children: [eu, us, cn]
+  eu: { group: leaf }
+  us: { group: leaf }
+  cn: { group: leaf }
+
+  safety-level:
+    group: alternative
+    children: [qm, asil-a, asil-b, asil-c, asil-d]
+  qm:      { group: leaf }
+  asil-a:  { group: leaf }
+  asil-b:  { group: leaf }
+  asil-c:  { group: leaf }
+  asil-d:  { group: leaf }
+
+  feature-set:
+    group: or
+    children: [base, adas, autonomous]
+
+  base: { group: leaf }
+
+  adas:
+    group: mandatory
+    children: [lane-keeping, adaptive-cruise, pedestrian-detection]
+  lane-keeping:         { group: leaf }
+  adaptive-cruise:      { group: leaf }
+  pedestrian-detection: { group: leaf }
+
+  autonomous:
+    group: mandatory
+    children: [path-planning, sensor-fusion]
+  path-planning: { group: leaf }
+  sensor-fusion: { group: leaf }
+
+constraints:
+  - (implies eu pedestrian-detection)
+  - (implies autonomous (and adas asil-d))
+  - (implies adas (or asil-b asil-c asil-d))
+```
+
+## 2. Variant configuration
+
+A user-level selection against a feature model.
+
+| Field     | Type         | Required | Meaning                                          |
+| --------- | ------------ | -------- | ------------------------------------------------ |
+| `name`    | string       | yes      | Unique variant name — referenced by `check-all`. |
+| `selects` | list<string> | yes      | Feature names the user explicitly picks.         |
+
+```yaml
+# eu-adas-c.yaml
+name: eu-adas-c
+selects: [eu, adas, asil-c]
+```
+
+The solver adds the root, every ancestor of each `selects` entry, every
+mandatory descendant, and any constraint-implied feature. Output
+distinguishes `mandatory`, user-`selected`, constraint-`implied by …`,
+and `allowed but unbound` features.
+
+## 3. Binding model
+
+Maps features to the artifacts and source files that implement them.
+See [feature-model-bindings.md](feature-model-bindings.md).
+
+## CLI reference
+
+```sh
+# Create a starter feature-model.yaml + bindings/<name>.yaml pair.
+rivet variant init <name>
+
+# Inspect the feature tree.
+rivet variant list --model feature-model.yaml
+
+# Resolve a single variant (PASS/FAIL).
+rivet variant check --model feature-model.yaml --variant eu-adas-c.yaml
+
+# Iterate all variants declared in bindings and report per-variant status.
+rivet variant check-all --model feature-model.yaml --binding bindings.yaml
+
+# Solve + show bound artifacts with origin tags.
+rivet variant solve --model fm.yaml --variant v.yaml --binding bindings.yaml
+
+# Variant-scoped validation (variant is optional — model+binding validates
+# the model/binding pair without resolving a specific variant).
+rivet validate --model fm.yaml --binding bindings.yaml
+rivet validate --model fm.yaml --variant v.yaml --binding bindings.yaml
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -757,6 +757,9 @@ Graph: `reachable-from`, `reachable-to`.
 
 Manage product variants with feature models, constraint solving, and artifact scoping.
 
+Full schema reference: [feature-model-schema.md](feature-model-schema.md).
+Binding file format: [feature-model-bindings.md](feature-model-bindings.md).
+
 ### Feature Model
 
 Define your product line as a YAML feature tree:

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -7249,26 +7249,65 @@ fn cmd_variant_solve(
     };
 
     if format == "json" {
+        // Serialise origins alongside effective_features so downstream
+        // tooling can distinguish user-selected / mandatory / implied.
+        // The legacy `effective_features` + `feature_count` fields are
+        // preserved verbatim for backwards compatibility.
+        use rivet_core::feature_model::FeatureOrigin;
+        let origins_json: serde_json::Map<String, serde_json::Value> = resolved
+            .origins
+            .iter()
+            .map(|(name, origin)| {
+                let v = match origin {
+                    FeatureOrigin::UserSelected => serde_json::json!({ "kind": "selected" }),
+                    FeatureOrigin::Mandatory => serde_json::json!({ "kind": "mandatory" }),
+                    FeatureOrigin::ImpliedBy(cause) => {
+                        serde_json::json!({ "kind": "implied", "by": cause })
+                    }
+                    FeatureOrigin::AllowedButUnbound => {
+                        serde_json::json!({ "kind": "allowed" })
+                    }
+                };
+                (name.clone(), v)
+            })
+            .collect();
         let output = serde_json::json!({
             "variant": resolved.name,
             "effective_features": resolved.effective_features,
             "feature_count": resolved.effective_features.len(),
+            "origins": origins_json,
             "bound_artifacts": bound_artifacts,
             "bound_artifact_count": bound_artifacts.len(),
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
+        use rivet_core::feature_model::FeatureOrigin;
         println!("Variant '{}': PASS", resolved.name);
-        let features_list: Vec<&str> = resolved
+        println!(
+            "Effective features ({}):",
+            resolved.effective_features.len()
+        );
+        // Width = longest feature name, padded for alignment.
+        let name_col = resolved
             .effective_features
             .iter()
-            .map(|s| s.as_str())
-            .collect();
-        println!(
-            "Effective features ({}): {}",
-            features_list.len(),
-            features_list.join(", ")
-        );
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0);
+        for name in &resolved.effective_features {
+            let origin = resolved
+                .origins
+                .get(name)
+                .cloned()
+                .unwrap_or(FeatureOrigin::AllowedButUnbound);
+            let label = match &origin {
+                FeatureOrigin::UserSelected => "selected".to_string(),
+                FeatureOrigin::Mandatory => "mandatory".to_string(),
+                FeatureOrigin::ImpliedBy(cause) => format!("implied by {cause}"),
+                FeatureOrigin::AllowedButUnbound => "allowed".to_string(),
+            };
+            println!("  + {name:<name_col$}  ({label})");
+        }
 
         if !bound_artifacts.is_empty() {
             println!("\nBound artifacts ({}):", bound_artifacts.len());

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -524,7 +524,10 @@ enum Command {
         action: SnapshotAction,
     },
 
-    /// Product line variant management (feature model + constraint solver)
+    /// Product line variant management (feature model + constraint solver).
+    ///
+    /// YAML schema reference: docs/feature-model-schema.md.
+    /// Binding file format:   docs/feature-model-bindings.md.
     Variant {
         #[command(subcommand)]
         action: VariantAction,
@@ -795,6 +798,20 @@ enum SnapshotAction {
 
 #[derive(Subcommand)]
 enum VariantAction {
+    /// Scaffold a starter feature-model.yaml + bindings/<name>.yaml with
+    /// commented fields. See docs/feature-model-schema.md.
+    Init {
+        /// Variant / project name (used for the bindings file name).
+        name: String,
+
+        /// Target directory (default: current directory).
+        #[arg(long, default_value = ".")]
+        dir: PathBuf,
+
+        /// Overwrite existing files.
+        #[arg(long)]
+        force: bool,
+    },
     /// Check a variant configuration against a feature model
     Check {
         /// Path to feature model YAML file
@@ -1066,6 +1083,7 @@ fn run(cli: Cli) -> Result<bool> {
             SnapshotAction::List => cmd_snapshot_list(&cli),
         },
         Command::Variant { action } => match action {
+            VariantAction::Init { name, dir, force } => cmd_variant_init(name, dir, *force),
             VariantAction::Check {
                 model,
                 variant,
@@ -6773,6 +6791,121 @@ fn cmd_snapshot_list(cli: &Cli) -> Result<bool> {
 }
 
 // ── Variant commands ────────────────────────────────────────────────────
+
+/// Scaffold a starter feature-model.yaml + bindings/<name>.yaml pair.
+///
+/// Files are annotated with comments documenting every field so the user
+/// does not need to open `docs/feature-model-schema.md` to get started.
+/// See that document for the full schema reference.
+fn cmd_variant_init(name: &str, dir: &std::path::Path, force: bool) -> Result<bool> {
+    if name.trim().is_empty() {
+        anyhow::bail!("variant name cannot be empty");
+    }
+
+    let target = if dir == std::path::Path::new(".") {
+        std::env::current_dir().context("resolving current directory")?
+    } else {
+        dir.to_path_buf()
+    };
+
+    std::fs::create_dir_all(&target)
+        .with_context(|| format!("creating {}", target.display()))?;
+    let bindings_dir = target.join("bindings");
+    std::fs::create_dir_all(&bindings_dir)
+        .with_context(|| format!("creating {}", bindings_dir.display()))?;
+
+    let fm_path = target.join("feature-model.yaml");
+    let binding_path = bindings_dir.join(format!("{name}.yaml"));
+
+    if !force {
+        for p in [&fm_path, &binding_path] {
+            if p.exists() {
+                anyhow::bail!(
+                    "refusing to overwrite {} (use --force)",
+                    p.display()
+                );
+            }
+        }
+    }
+
+    let fm_yaml = r#"# feature-model.yaml — starter template.
+# Full reference: docs/feature-model-schema.md
+kind: feature-model
+
+# `root` is the always-selected top of the feature tree.
+root: product
+
+# Every feature is declared under `features`.
+#   group: one of `mandatory`, `optional`, `alternative`, `or`, `leaf`.
+#   children: names of child features.
+features:
+  product:
+    group: mandatory
+    children: [base, extras]
+
+  base:
+    group: leaf
+
+  extras:
+    group: or
+    children: [telemetry, auth]
+
+  telemetry:
+    group: leaf
+
+  auth:
+    group: leaf
+
+# Cross-tree constraints (s-expression syntax).
+#   Bare feature names mean "this feature is selected".
+#   Supported forms: and, or, not, implies, excludes, forall, exists.
+constraints:
+  # - (implies auth telemetry)
+  # - (excludes base telemetry)
+"#;
+
+    let binding_yaml = format!(
+        r#"# bindings/{name}.yaml — starter template.
+# Full reference: docs/feature-model-bindings.md
+
+# `variant:` identifies which variant this file configures and records
+# the user's feature selection. The solver adds root, ancestors, mandatory
+# descendants, and constraint-implied features on top of `selects`.
+variant:
+  name: {name}
+  selects: [telemetry]
+
+# `bindings:` maps feature names to the artifacts and source files that
+# implement them.
+bindings:
+  telemetry:
+    artifacts: []           # e.g. [REQ-001, REQ-002]
+    source: []              # e.g. ["src/telemetry/**"]
+  auth:
+    artifacts: []
+    source: []
+"#
+    );
+
+    std::fs::write(&fm_path, fm_yaml)
+        .with_context(|| format!("writing {}", fm_path.display()))?;
+    std::fs::write(&binding_path, binding_yaml)
+        .with_context(|| format!("writing {}", binding_path.display()))?;
+
+    println!("  wrote {}", fm_path.display());
+    println!("  wrote {}", binding_path.display());
+    println!();
+    println!("Edit the files above, then run:");
+    println!("  rivet variant list  --model {}", fm_path.display());
+    println!(
+        "  rivet variant check --model {} --variant {}",
+        fm_path.display(),
+        binding_path.display()
+    );
+    println!("See docs/feature-model-schema.md for the full schema.");
+
+    Ok(true)
+}
 
 /// Check a variant configuration against a feature model.
 fn cmd_variant_check(

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -826,6 +826,24 @@ enum VariantAction {
         #[arg(short, long, default_value = "text")]
         format: String,
     },
+    /// Check every variant declared in a binding file.
+    ///
+    /// Exits 0 if all declared variants pass, 1 if any fail. The binding
+    /// file may carry a `variants:` list alongside `bindings:` — see
+    /// docs/feature-model-bindings.md.
+    CheckAll {
+        /// Path to feature model YAML file
+        #[arg(long)]
+        model: PathBuf,
+
+        /// Path to binding YAML file containing `variants:` declarations
+        #[arg(long)]
+        binding: PathBuf,
+
+        /// Output format: "text" (default) or "json"
+        #[arg(short, long, default_value = "text")]
+        format: String,
+    },
     /// List features in a feature model
     List {
         /// Path to feature model YAML file
@@ -1089,6 +1107,11 @@ fn run(cli: Cli) -> Result<bool> {
                 variant,
                 format,
             } => cmd_variant_check(model, variant, format),
+            VariantAction::CheckAll {
+                model,
+                binding,
+                format,
+            } => cmd_variant_check_all(model, binding, format),
             VariantAction::List { model, format } => cmd_variant_list(model, format),
             VariantAction::Solve {
                 model,
@@ -3157,58 +3180,101 @@ fn cmd_validate(
         (store, graph)
     };
 
-    // Apply variant scoping if --model + --variant + --binding are all provided
-    let (store, graph, variant_scope_name) = if let (Some(mp), Some(vp), Some(bp)) =
-        (model_path, variant_path, binding_path)
-    {
-        let model_yaml = std::fs::read_to_string(mp)
-            .with_context(|| format!("reading feature model {}", mp.display()))?;
-        let fm = rivet_core::feature_model::FeatureModel::from_yaml(&model_yaml)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    // Apply variant scoping.
+    //
+    // Three modes:
+    //   --model + --variant + --binding : validate the subset bound to the
+    //     variant's effective feature set (variant-scoped).
+    //   --model + --binding (no variant) : validate the feature model +
+    //     binding file pair (parse model, parse binding, check every
+    //     feature name in the binding exists in the model). Does not
+    //     scope the store.
+    //   --variant alone: legacy error — --variant requires --model and
+    //     a binding to resolve against.
+    let (store, graph, variant_scope_name) = match (model_path, variant_path, binding_path) {
+        (Some(mp), Some(vp), Some(bp)) => {
+            let model_yaml = std::fs::read_to_string(mp)
+                .with_context(|| format!("reading feature model {}", mp.display()))?;
+            let fm = rivet_core::feature_model::FeatureModel::from_yaml(&model_yaml)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-        let variant_yaml = std::fs::read_to_string(vp)
-            .with_context(|| format!("reading variant config {}", vp.display()))?;
-        let vc: rivet_core::feature_model::VariantConfig =
-            serde_yaml::from_str(&variant_yaml).context("parsing variant config")?;
+            let variant_yaml = std::fs::read_to_string(vp)
+                .with_context(|| format!("reading variant config {}", vp.display()))?;
+            let vc: rivet_core::feature_model::VariantConfig =
+                serde_yaml::from_str(&variant_yaml).context("parsing variant config")?;
 
-        let resolved = rivet_core::feature_model::solve(&fm, &vc).map_err(|errs| {
-            let msgs: Vec<String> = errs.iter().map(|e| format!("{e}")).collect();
-            anyhow::anyhow!("variant solve failed:\n  {}", msgs.join("\n  "))
-        })?;
+            let resolved = rivet_core::feature_model::solve(&fm, &vc).map_err(|errs| {
+                let msgs: Vec<String> = errs.iter().map(|e| format!("{e}")).collect();
+                anyhow::anyhow!("variant solve failed:\n  {}", msgs.join("\n  "))
+            })?;
 
-        let binding_yaml = std::fs::read_to_string(bp)
-            .with_context(|| format!("reading binding {}", bp.display()))?;
-        let fb: rivet_core::feature_model::FeatureBinding =
-            serde_yaml::from_str(&binding_yaml).context("parsing feature binding")?;
+            let binding_yaml = std::fs::read_to_string(bp)
+                .with_context(|| format!("reading binding {}", bp.display()))?;
+            let fb: rivet_core::feature_model::FeatureBinding =
+                serde_yaml::from_str(&binding_yaml).context("parsing feature binding")?;
 
-        // Collect bound artifact IDs from effective features
-        let bound_ids: std::collections::BTreeSet<String> = resolved
-            .effective_features
-            .iter()
-            .flat_map(|f| {
-                fb.bindings
-                    .get(f)
-                    .map(|b| b.artifacts.clone())
-                    .unwrap_or_default()
-            })
-            .collect();
+            // Collect bound artifact IDs from effective features
+            let bound_ids: std::collections::BTreeSet<String> = resolved
+                .effective_features
+                .iter()
+                .flat_map(|f| {
+                    fb.bindings
+                        .get(f)
+                        .map(|b| b.artifacts.clone())
+                        .unwrap_or_default()
+                })
+                .collect();
 
-        // Build a scoped store containing only bound artifacts
-        let mut scoped = Store::new();
-        for id in &bound_ids {
-            if let Some(art) = store.get(id) {
-                scoped.upsert(art.clone());
+            // Build a scoped store containing only bound artifacts
+            let mut scoped = Store::new();
+            for id in &bound_ids {
+                if let Some(art) = store.get(id) {
+                    scoped.upsert(art.clone());
+                }
             }
+            let scoped_graph = LinkGraph::build(&scoped, &schema);
+            let vname = resolved.name.clone();
+            (scoped, scoped_graph, Some((vname, bound_ids.len())))
         }
-        let scoped_graph = LinkGraph::build(&scoped, &schema);
-        let vname = resolved.name.clone();
-        (scoped, scoped_graph, Some((vname, bound_ids.len())))
-    } else if model_path.is_some() || variant_path.is_some() || binding_path.is_some() {
-        anyhow::bail!(
-            "--model, --variant, and --binding must all be provided together for variant-scoped validation"
-        );
-    } else {
-        (store, graph, None)
+        (Some(mp), None, Some(bp)) => {
+            // Model + binding, no variant: validate model/binding consistency
+            // without resolving a specific variant. Unknown feature names in
+            // the binding file are reported as errors.
+            let model_yaml = std::fs::read_to_string(mp)
+                .with_context(|| format!("reading feature model {}", mp.display()))?;
+            let fm = rivet_core::feature_model::FeatureModel::from_yaml(&model_yaml)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let binding_yaml = std::fs::read_to_string(bp)
+                .with_context(|| format!("reading binding {}", bp.display()))?;
+            let fb: rivet_core::feature_model::FeatureBinding =
+                serde_yaml::from_str(&binding_yaml).context("parsing feature binding")?;
+
+            let unknown: Vec<String> = fb
+                .bindings
+                .keys()
+                .filter(|name| !fm.features.contains_key(name.as_str()))
+                .cloned()
+                .collect();
+            if !unknown.is_empty() {
+                anyhow::bail!(
+                    "binding references unknown features: {}",
+                    unknown.join(", ")
+                );
+            }
+            if format != "json" {
+                println!(
+                    "Feature model + binding: {} features, {} bindings (OK)\n",
+                    fm.features.len(),
+                    fb.bindings.len()
+                );
+            }
+            (store, graph, None)
+        }
+        (None, None, None) => (store, graph, None),
+        _ => anyhow::bail!(
+            "variant-scoped validation requires --model and --binding; --variant is optional"
+        ),
     };
 
     let doc_store = doc_store.unwrap_or_default();
@@ -6984,6 +7050,92 @@ fn cmd_variant_check(
             Ok(false)
         }
     }
+}
+
+/// Check every variant declared in a binding file against the feature model.
+///
+/// Exits 0 iff every declared variant solves successfully; exits 1 as soon
+/// as any fails. Binding files without a `variants:` block are reported
+/// as an empty pass.
+fn cmd_variant_check_all(
+    model_path: &std::path::Path,
+    binding_path: &std::path::Path,
+    format: &str,
+) -> Result<bool> {
+    validate_format(format, &["text", "json"])?;
+
+    let model_yaml = std::fs::read_to_string(model_path)
+        .with_context(|| format!("reading {}", model_path.display()))?;
+    let model = rivet_core::feature_model::FeatureModel::from_yaml(&model_yaml)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let binding_yaml = std::fs::read_to_string(binding_path)
+        .with_context(|| format!("reading {}", binding_path.display()))?;
+    let binding: rivet_core::feature_model::FeatureBinding =
+        serde_yaml::from_str(&binding_yaml).context("parsing binding")?;
+
+    let mut results: Vec<(String, std::result::Result<(), Vec<String>>)> = Vec::new();
+    for vc in &binding.variants {
+        match rivet_core::feature_model::solve(&model, vc) {
+            Ok(_) => results.push((vc.name.clone(), Ok(()))),
+            Err(errs) => {
+                let msgs: Vec<String> = errs.iter().map(|e| e.to_string()).collect();
+                results.push((vc.name.clone(), Err(msgs)));
+            }
+        }
+    }
+
+    let pass_count = results.iter().filter(|(_, r)| r.is_ok()).count();
+    let fail_count = results.len() - pass_count;
+
+    if format == "json" {
+        let rows: Vec<serde_json::Value> = results
+            .iter()
+            .map(|(name, r)| match r {
+                Ok(()) => serde_json::json!({ "variant": name, "result": "PASS" }),
+                Err(msgs) => serde_json::json!({
+                    "variant": name,
+                    "result": "FAIL",
+                    "errors": msgs,
+                }),
+            })
+            .collect();
+        let output = serde_json::json!({
+            "result": if fail_count == 0 { "PASS" } else { "FAIL" },
+            "total": results.len(),
+            "passed": pass_count,
+            "failed": fail_count,
+            "variants": rows,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        if results.is_empty() {
+            println!(
+                "No variants declared in {}. Add a `variants:` list to exercise the check.",
+                binding_path.display()
+            );
+        } else {
+            for (name, r) in &results {
+                match r {
+                    Ok(()) => println!("  PASS  {name}"),
+                    Err(msgs) => {
+                        println!("  FAIL  {name}");
+                        for m in msgs {
+                            println!("        {m}");
+                        }
+                    }
+                }
+            }
+            println!(
+                "\n{}/{} variants passed ({} failed)",
+                pass_count,
+                results.len(),
+                fail_count
+            );
+        }
+    }
+
+    Ok(fail_count == 0)
 }
 
 /// List features in a feature model.

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -2487,6 +2487,10 @@ fn cmd_init_hooks(dir: &std::path::Path) -> Result<bool> {
     println!("  installed {}", commit_msg_path.display());
 
     // ── pre-commit hook ─────────────────────────────────────────────
+    // Marker-discovery walks up from $PWD to find rivet.yaml. This
+    // survives relocation of the project within the working tree (a
+    // hard-coded `-p <path>` would silently validate the wrong directory
+    // or skip validation after a move).
     let pre_commit_path = hooks_dir.join("pre-commit");
     install_hook(
         &pre_commit_path,
@@ -2494,6 +2498,21 @@ fn cmd_init_hooks(dir: &std::path::Path) -> Result<bool> {
             r#"#!/usr/bin/env bash
 # Installed by: rivet init --hooks
 # Runs rivet validate and blocks on errors.
+#
+# Marker discovery: walk up from $PWD until we find rivet.yaml, then cd
+# into that directory before running rivet. This keeps the hook working
+# after the rivet project is moved inside the git tree.
+dir="$PWD"
+while [ "$dir" != "/" ] && [ ! -f "$dir/rivet.yaml" ]; do
+    dir="$(dirname "$dir")"
+done
+if [ ! -f "$dir/rivet.yaml" ]; then
+    # No rivet project in the ancestor chain — skip silently so the hook
+    # does not block commits in unrelated repositories.
+    exit 0
+fi
+cd "$dir" || exit 0
+
 output=$("{rivet_bin}" validate --format json 2>/dev/null)
 errors=$(echo "$output" | python3 -c "import json,sys; print(json.load(sys.stdin).get('errors',0))" 2>/dev/null || echo "0")
 if [ "$errors" -gt 0 ]; then

--- a/rivet-cli/tests/hooks_install.rs
+++ b/rivet-cli/tests/hooks_install.rs
@@ -1,0 +1,165 @@
+//! Integration tests for the `rivet init --hooks` pre-commit hook generator.
+//!
+//! Pain point #4: the hook must survive relocation of `rivet.yaml` within
+//! the git tree via marker discovery — walk up from `$PWD` until a
+//! `rivet.yaml` is found, then `cd` there before validating. A hard-coded
+//! `-p <path>` would silently validate the wrong project after a move.
+
+use std::process::Command;
+
+fn rivet_bin() -> std::path::PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_rivet") {
+        return std::path::PathBuf::from(bin);
+    }
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest.parent().expect("workspace root");
+    workspace_root.join("target").join("debug").join("rivet")
+}
+
+/// Build a fresh git repo with a rivet project inside, then install hooks.
+/// Returns (tempdir keep-alive, project dir, hooks dir).
+fn setup_with_hooks() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    std::path::PathBuf,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path().to_path_buf();
+
+    // `git init` so `rivet init --hooks` has somewhere to install.
+    let status = Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(&dir)
+        .output()
+        .expect("git init");
+    assert!(status.status.success());
+
+    // Create a rivet project at the git root.
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dir.to_str().unwrap()])
+        .output()
+        .expect("rivet init");
+    assert!(
+        init.status.success(),
+        "rivet init must succeed. stderr: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let hooks_install = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "init",
+            "--hooks",
+            "--dir",
+            dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet init --hooks");
+    assert!(
+        hooks_install.status.success(),
+        "rivet init --hooks must succeed. stderr: {}",
+        String::from_utf8_lossy(&hooks_install.stderr)
+    );
+
+    let hooks_dir = dir.join(".git").join("hooks");
+    (tmp, dir, hooks_dir)
+}
+
+/// The installed pre-commit hook must not embed a hard-coded `-p <path>`
+/// flag (relocation hazard); it must use marker discovery.
+#[test]
+fn pre_commit_hook_uses_marker_discovery_not_hardcoded_path() {
+    let (_keep, _dir, hooks_dir) = setup_with_hooks();
+
+    let pre_commit = hooks_dir.join("pre-commit");
+    assert!(pre_commit.exists(), "pre-commit hook not installed");
+
+    let body = std::fs::read_to_string(&pre_commit).expect("read pre-commit");
+
+    // Regression against the hard-coded path hazard: a previous generator
+    // emitted `rivet -p <path> validate`. The replacement walks up to find
+    // rivet.yaml — `-p` must be absent.
+    assert!(
+        !body.contains(" -p "),
+        "pre-commit must not embed a hard-coded `-p <path>`. body:\n{body}"
+    );
+    assert!(
+        !body.contains("--project "),
+        "pre-commit must not embed a hard-coded `--project <path>`. body:\n{body}"
+    );
+
+    // Marker-discovery contract: must walk up to find rivet.yaml and cd there.
+    assert!(
+        body.contains("rivet.yaml"),
+        "pre-commit must look for rivet.yaml. body:\n{body}"
+    );
+    assert!(
+        body.contains("dirname") && body.contains("while"),
+        "pre-commit must walk up parent directories. body:\n{body}"
+    );
+    assert!(
+        body.contains("cd \""),
+        "pre-commit must `cd` into the discovered project dir. body:\n{body}"
+    );
+}
+
+/// End-to-end: if the user relocates `rivet.yaml` to a subdirectory
+/// inside the git tree, the installed hook must still find it via
+/// marker discovery when executed from that subdirectory.
+#[test]
+fn pre_commit_hook_finds_relocated_rivet_yaml() {
+    let (_keep, dir, hooks_dir) = setup_with_hooks();
+
+    // Relocate rivet.yaml (and the artifacts it references) into subdir/.
+    let sub = dir.join("subdir");
+    std::fs::create_dir_all(&sub).unwrap();
+
+    // Move the complete project tree into subdir/ so paths still resolve.
+    for entry in ["rivet.yaml", "artifacts", "schemas"] {
+        let from = dir.join(entry);
+        if from.exists() {
+            let to = sub.join(entry);
+            std::fs::rename(&from, &to)
+                .unwrap_or_else(|e| panic!("moving {entry}: {e}"));
+        }
+    }
+
+    let pre_commit = hooks_dir.join("pre-commit");
+
+    // Run the hook from a nested directory inside the project. Marker
+    // discovery must walk up from $PWD and find subdir/rivet.yaml.
+    let nested = sub.join("artifacts");
+    let run_dir = if nested.exists() { nested } else { sub.clone() };
+
+    // Put the rivet binary on PATH so the hook can find it.
+    let bin = rivet_bin();
+    let bin_dir = bin.parent().expect("rivet bin parent").to_path_buf();
+    let orig_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), orig_path);
+
+    let output = Command::new("bash")
+        .arg(&pre_commit)
+        .current_dir(&run_dir)
+        .env("PATH", &new_path)
+        .output()
+        .expect("running pre-commit hook");
+
+    // Either the hook ran successfully (project has no errors) or it failed
+    // citing rivet validate errors. What it must NOT do is silently skip
+    // validation or fail with "rivet.yaml not found".
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stderr.contains("no rivet.yaml"),
+        "hook must discover the relocated rivet.yaml. stderr: {stderr}"
+    );
+    // If the hook fails, it must be because of validate errors (i.e. the
+    // discovery worked), not because it couldn't find the project.
+    if !output.status.success() {
+        assert!(
+            stdout.contains("rivet validate") || stderr.contains("rivet validate"),
+            "hook failure must come from rivet validate, not missing project.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+    }
+}

--- a/rivet-cli/tests/variant_init.rs
+++ b/rivet-cli/tests/variant_init.rs
@@ -1,0 +1,138 @@
+//! Integration tests for `rivet variant init` scaffolder (pain point #3).
+//!
+//! The scaffolder writes a starter `feature-model.yaml` and
+//! `bindings/<name>.yaml` with commented fields so users don't need to
+//! reverse-engineer the schema. See `docs/feature-model-schema.md`.
+
+use std::process::Command;
+
+fn rivet_bin() -> std::path::PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_rivet") {
+        return std::path::PathBuf::from(bin);
+    }
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest.parent().expect("workspace root");
+    workspace_root.join("target").join("debug").join("rivet")
+}
+
+#[test]
+fn variant_init_creates_starter_files() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+
+    let output = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "init",
+            "myapp",
+            "--dir",
+            dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet variant init");
+
+    assert!(
+        output.status.success(),
+        "rivet variant init must succeed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let fm = dir.join("feature-model.yaml");
+    let bind = dir.join("bindings").join("myapp.yaml");
+    assert!(fm.exists(), "feature-model.yaml not written");
+    assert!(bind.exists(), "bindings/myapp.yaml not written");
+
+    let fm_content = std::fs::read_to_string(&fm).unwrap();
+    assert!(
+        fm_content.contains("kind: feature-model"),
+        "feature-model.yaml should declare `kind: feature-model`. got:\n{fm_content}"
+    );
+    assert!(
+        fm_content.contains("group:"),
+        "feature-model.yaml should document `group:` fields"
+    );
+    assert!(
+        fm_content.contains("docs/feature-model-schema.md"),
+        "feature-model.yaml should point at the schema reference"
+    );
+
+    let bind_content = std::fs::read_to_string(&bind).unwrap();
+    assert!(
+        bind_content.contains("variant:"),
+        "bindings file should contain a `variant:` key"
+    );
+    assert!(
+        bind_content.contains("bindings:"),
+        "bindings file should contain a `bindings:` key"
+    );
+}
+
+#[test]
+fn variant_init_refuses_to_overwrite_without_force() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+
+    std::fs::write(dir.join("feature-model.yaml"), "pre-existing content")
+        .expect("seed file");
+
+    let output = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "init",
+            "myapp",
+            "--dir",
+            dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet variant init");
+
+    assert!(
+        !output.status.success(),
+        "rivet variant init must refuse to overwrite without --force"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to overwrite") || stderr.contains("--force"),
+        "stderr should mention --force. got: {stderr}"
+    );
+
+    // Original content must survive.
+    let content = std::fs::read_to_string(dir.join("feature-model.yaml")).unwrap();
+    assert_eq!(content, "pre-existing content");
+}
+
+#[test]
+fn variant_init_scaffolds_valid_feature_model() {
+    // The scaffolded feature-model.yaml must be loadable by rivet variant list
+    // without parse errors — otherwise the docs example is broken and we'd
+    // ship a starter template that fails on first use.
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+
+    let output = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "init",
+            "myapp",
+            "--dir",
+            dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet variant init");
+    assert!(output.status.success());
+
+    let list = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "list",
+            "--model",
+            dir.join("feature-model.yaml").to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet variant list");
+    assert!(
+        list.status.success(),
+        "scaffolded feature-model.yaml must parse. stderr: {}",
+        String::from_utf8_lossy(&list.stderr)
+    );
+}

--- a/rivet-cli/tests/variant_scoped_api.rs
+++ b/rivet-cli/tests/variant_scoped_api.rs
@@ -1,0 +1,285 @@
+//! Integration tests for pain point #6: variant-scoped validation API
+//! ergonomics — `--variant` optional on `rivet validate`, new
+//! `rivet variant check-all`.
+
+use std::process::Command;
+
+fn rivet_bin() -> std::path::PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_rivet") {
+        return std::path::PathBuf::from(bin);
+    }
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest.parent().expect("workspace root");
+    workspace_root.join("target").join("debug").join("rivet")
+}
+
+/// Create a fresh rivet project and write a feature model + binding into it.
+/// Returns (keep-alive tempdir, project dir, model path, binding path).
+fn setup_variant_project() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    std::path::PathBuf,
+    std::path::PathBuf,
+) {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path().to_path_buf();
+
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dir.to_str().unwrap()])
+        .output()
+        .expect("rivet init");
+    assert!(
+        init.status.success(),
+        "rivet init must succeed. stderr: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let model = dir.join("feature-model.yaml");
+    std::fs::write(
+        &model,
+        r#"kind: feature-model
+root: app
+features:
+  app:
+    group: mandatory
+    children: [auth]
+  auth:
+    group: or
+    children: [oauth, ldap]
+  oauth:
+    group: leaf
+  ldap:
+    group: leaf
+constraints: []
+"#,
+    )
+    .expect("write feature-model.yaml");
+
+    let binding = dir.join("bindings.yaml");
+    std::fs::write(
+        &binding,
+        r#"bindings:
+  oauth:
+    artifacts: []
+    source: []
+  ldap:
+    artifacts: []
+    source: []
+
+variants:
+  - name: oauth-only
+    selects: [oauth]
+  - name: ldap-only
+    selects: [ldap]
+  - name: nothing
+    selects: []
+"#,
+    )
+    .expect("write binding");
+
+    (tmp, dir, model, binding)
+}
+
+/// Before the fix: `rivet validate --model … --binding …` without `--variant`
+/// bailed with "must all be provided together". After the fix: this is a
+/// valid mode that checks model + binding consistency.
+#[test]
+fn validate_accepts_model_plus_binding_without_variant() {
+    let (_keep, dir, model, binding) = setup_variant_project();
+
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+            "--model",
+            model.to_str().unwrap(),
+            "--binding",
+            binding.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet validate");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("must all be provided together"),
+        "validate must accept --model + --binding without --variant. stderr: {stderr}"
+    );
+    // Either PASS or FAIL on artifact rules is fine; the point is the CLI
+    // didn't bail on the missing --variant.
+    assert!(
+        output.status.success() || !stderr.contains("must all"),
+        "stderr: {stderr}"
+    );
+}
+
+/// Model + binding where a binding key is not a feature must fail with a
+/// clear diagnostic (not a silent pass).
+#[test]
+fn validate_flags_unknown_features_in_binding() {
+    let (_keep, dir, model, _binding) = setup_variant_project();
+
+    let bad_binding = dir.join("bad-binding.yaml");
+    std::fs::write(
+        &bad_binding,
+        r#"bindings:
+  no-such-feature:
+    artifacts: [REQ-999]
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--model",
+            model.to_str().unwrap(),
+            "--binding",
+            bad_binding.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet validate");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown") && stderr.contains("no-such-feature"),
+        "expected an 'unknown feature' diagnostic. stderr: {stderr}"
+    );
+}
+
+/// `rivet variant check-all` iterates declared variants and exits 0 if all
+/// pass. Our fixture has three passing variants.
+#[test]
+fn check_all_passes_when_every_variant_solves() {
+    let (_keep, _dir, model, binding) = setup_variant_project();
+
+    let output = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "check-all",
+            "--model",
+            model.to_str().unwrap(),
+            "--binding",
+            binding.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet variant check-all");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // `nothing` selects [] against an `or` group, so it should FAIL. Adjust
+    // the binding so all variants PASS, then re-run.
+    // Re-use dir from the tuple: patch binding to drop the failing variant.
+    // Since setup already wrote the binding, we override here.
+    assert!(
+        stdout.contains("oauth-only") && stdout.contains("ldap-only"),
+        "stdout should list variant names.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    // `nothing` fails the `or` group constraint; check-all must exit 1.
+    assert!(
+        !output.status.success(),
+        "check-all must exit non-zero when a variant fails.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
+/// `check-all` exits 0 when every declared variant passes.
+#[test]
+fn check_all_passes_with_all_valid_variants() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path().to_path_buf();
+
+    let model = dir.join("feature-model.yaml");
+    std::fs::write(
+        &model,
+        r#"kind: feature-model
+root: app
+features:
+  app:
+    group: mandatory
+    children: [auth]
+  auth:
+    group: or
+    children: [oauth, ldap]
+  oauth:
+    group: leaf
+  ldap:
+    group: leaf
+constraints: []
+"#,
+    )
+    .unwrap();
+
+    let binding = dir.join("bindings.yaml");
+    std::fs::write(
+        &binding,
+        r#"bindings:
+  oauth:
+    artifacts: []
+  ldap:
+    artifacts: []
+
+variants:
+  - name: oauth-only
+    selects: [oauth]
+  - name: ldap-only
+    selects: [ldap]
+  - name: both
+    selects: [oauth, ldap]
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "check-all",
+            "--model",
+            model.to_str().unwrap(),
+            "--binding",
+            binding.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet variant check-all");
+
+    assert!(
+        output.status.success(),
+        "check-all should pass. stdout:{} stderr:{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("3/3 variants passed"), "stdout: {stdout}");
+}
+
+/// check-all JSON output reports per-variant result + aggregate counts.
+#[test]
+fn check_all_json_output_shape() {
+    let (_keep, _dir, model, binding) = setup_variant_project();
+
+    let output = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "check-all",
+            "--model",
+            model.to_str().unwrap(),
+            "--binding",
+            binding.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("rivet variant check-all --format json");
+
+    // Exit may be non-zero because our fixture has a deliberately failing
+    // "nothing" variant; we still expect parseable JSON on stdout.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("bad JSON: {e}: {stdout}"));
+    assert_eq!(v["total"].as_u64().unwrap(), 3);
+    assert!(v["variants"].is_array());
+}

--- a/rivet-cli/tests/variant_solve_origins.rs
+++ b/rivet-cli/tests/variant_solve_origins.rs
@@ -1,0 +1,159 @@
+//! Integration tests for pain point #8: `rivet variant solve` output
+//! must distinguish user-selected features from ones added via
+//! mandatory propagation or constraint implication. JSON output stays
+//! backwards-compatible: `effective_features` + `feature_count` are
+//! preserved, a new `origins` map is added alongside.
+
+use std::process::Command;
+
+fn rivet_bin() -> std::path::PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_rivet") {
+        return std::path::PathBuf::from(bin);
+    }
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest.parent().expect("workspace root");
+    workspace_root.join("target").join("debug").join("rivet")
+}
+
+fn write_model_and_variant() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    std::path::PathBuf,
+) {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().to_path_buf();
+
+    let model = dir.join("feature-model.yaml");
+    std::fs::write(
+        &model,
+        r#"kind: feature-model
+root: app
+features:
+  app:
+    group: mandatory
+    children: [base, auth]
+  base:
+    group: leaf
+  auth:
+    group: optional
+    children: [oauth, token-cache]
+  oauth:
+    group: leaf
+  token-cache:
+    group: leaf
+constraints:
+  - (implies oauth token-cache)
+"#,
+    )
+    .unwrap();
+
+    let variant = dir.join("variant.yaml");
+    std::fs::write(
+        &variant,
+        r#"name: oauth-variant
+selects: [auth, oauth]
+"#,
+    )
+    .unwrap();
+
+    (tmp, model, variant)
+}
+
+/// Text output must prefix each feature with `+` and label the origin
+/// so the user can distinguish selected/mandatory/implied.
+#[test]
+fn variant_solve_text_output_labels_origins() {
+    let (_keep, model, variant) = write_model_and_variant();
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "solve",
+            "--model",
+            model.to_str().unwrap(),
+            "--variant",
+            variant.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet variant solve");
+
+    assert!(
+        out.status.success(),
+        "solve must succeed. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Root + mandatory ancestor labeled as mandatory.
+    assert!(
+        stdout.contains("app") && stdout.contains("(mandatory)"),
+        "root `app` must be labeled (mandatory). stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("base") && stdout.lines().any(|l| l.contains("base") && l.contains("(mandatory)")),
+        "base is a mandatory child of app. stdout:\n{stdout}"
+    );
+    // User-named features carry (selected).
+    assert!(
+        stdout.lines().any(|l| l.contains("oauth") && l.contains("(selected)")),
+        "oauth is user-selected. stdout:\n{stdout}"
+    );
+    // Constraint-implied feature carries "implied by".
+    assert!(
+        stdout.lines().any(|l| l.contains("token-cache") && l.contains("implied by oauth")),
+        "token-cache must be labeled `implied by oauth`. stdout:\n{stdout}"
+    );
+    // Prefix `+` per the pain-point spec.
+    assert!(
+        stdout.lines().any(|l| l.trim_start().starts_with("+ ")),
+        "effective features should be prefixed with `+`. stdout:\n{stdout}"
+    );
+}
+
+/// JSON output must stay backwards-compatible: legacy fields are still
+/// present; `origins` is additive.
+#[test]
+fn variant_solve_json_output_is_backwards_compatible() {
+    let (_keep, model, variant) = write_model_and_variant();
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "variant",
+            "solve",
+            "--model",
+            model.to_str().unwrap(),
+            "--variant",
+            variant.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("rivet variant solve --format json");
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("parse JSON");
+
+    // Legacy fields preserved.
+    assert!(v["variant"].as_str().is_some());
+    assert!(v["effective_features"].is_array());
+    assert!(v["feature_count"].is_number());
+
+    // New field: origins map keyed by feature name, each with `kind`.
+    let origins = v["origins"]
+        .as_object()
+        .expect("origins must be an object");
+    assert!(!origins.is_empty());
+
+    let token_cache = origins
+        .get("token-cache")
+        .expect("token-cache must have an origin");
+    assert_eq!(token_cache["kind"], "implied");
+    assert_eq!(token_cache["by"], "oauth");
+
+    let oauth = origins.get("oauth").expect("oauth must have an origin");
+    assert_eq!(oauth["kind"], "selected");
+
+    let app = origins.get("app").expect("root must have an origin");
+    assert_eq!(app["kind"], "mandatory");
+}

--- a/rivet-core/src/feature_model.rs
+++ b/rivet-core/src/feature_model.rs
@@ -56,11 +56,44 @@ pub struct VariantConfig {
     pub selects: Vec<String>,
 }
 
+/// Origin of a feature in a resolved variant — why did the solver
+/// include it in the effective set?
+///
+/// This is reported per-feature so downstream tooling can distinguish
+/// user intent from solver-driven choices. Pain point #8: flat lists
+/// hid whether a feature was picked by the user, auto-selected via a
+/// mandatory group, or pulled in by a constraint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeatureOrigin {
+    /// User picked this feature explicitly via `selects:`.
+    UserSelected,
+    /// Forced in because an ancestor group is `mandatory`, or because
+    /// this is the root feature (root is always selected).
+    Mandatory,
+    /// A constraint (`implies X Y` and similar) propagated the
+    /// selection from the named feature.
+    ImpliedBy(String),
+    /// Present in the model and allowed but not actively chosen by the
+    /// user, group semantics, or a constraint. Surfaced for reporting
+    /// only — the solver never materialises "allowed-but-unbound"
+    /// features into `effective_features`; this variant exists so that
+    /// future reporting (e.g. showing `optional` siblings that could
+    /// still be toggled) has a slot.
+    AllowedButUnbound,
+}
+
 /// Result of solving a variant against a feature model.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedVariant {
     pub name: String,
     pub effective_features: BTreeSet<String>,
+    /// Per-feature origin for every entry in `effective_features`.
+    ///
+    /// Keys mirror `effective_features`; the map is populated for new
+    /// callers that want to distinguish user-selected, mandatory, and
+    /// constraint-implied features. Empty for manually-constructed
+    /// `ResolvedVariant` values (backwards-compatible default).
+    pub origins: BTreeMap<String, FeatureOrigin>,
 }
 
 // ── Feature-to-artifact binding ────────────────────────────────────────
@@ -359,16 +392,38 @@ pub fn solve(
     }
 
     // Start with root + user selections.
-    let mut selected: BTreeSet<String> = config.selects.iter().cloned().collect();
-    selected.insert(model.root.clone());
+    //
+    // `origins` tracks *why* each feature entered the effective set.
+    // We use `insert` with .or_insert so the first reason wins: a user
+    // selection beats a subsequent mandatory/implied discovery.
+    let mut selected: BTreeSet<String> = BTreeSet::new();
+    let mut origins: BTreeMap<String, FeatureOrigin> = BTreeMap::new();
 
-    // Also select ancestors of every selected feature (a child implies its parent).
+    // Root is always mandatory.
+    selected.insert(model.root.clone());
+    origins.insert(model.root.clone(), FeatureOrigin::Mandatory);
+
+    for name in &config.selects {
+        if selected.insert(name.clone()) {
+            origins.insert(name.clone(), FeatureOrigin::UserSelected);
+        } else {
+            origins
+                .entry(name.clone())
+                .or_insert(FeatureOrigin::UserSelected);
+        }
+    }
+
+    // Select ancestors of every selected feature. Ancestors are
+    // "mandatory" in the sense that a child cannot be selected without
+    // its parent also being selected.
     let initial: Vec<String> = selected.iter().cloned().collect();
     for name in initial {
         let mut cur = name.as_str();
         while let Some(f) = model.features.get(cur) {
             if let Some(ref p) = f.parent {
-                selected.insert(p.clone());
+                if selected.insert(p.clone()) {
+                    origins.insert(p.clone(), FeatureOrigin::Mandatory);
+                }
                 cur = p;
             } else {
                 break;
@@ -391,6 +446,7 @@ pub fn solve(
                 if f.group == GroupType::Mandatory {
                     for child in &f.children {
                         if selected.insert(child.clone()) {
+                            origins.insert(child.clone(), FeatureOrigin::Mandatory);
                             changed = true;
                         }
                     }
@@ -406,8 +462,14 @@ pub fn solve(
                     && !is_feature_selected(consequent, &selected)
                 {
                     if let Some(name) = extract_feature_name(consequent) {
-                        if model.features.contains_key(&name) && selected.insert(name) {
-                            changed = true;
+                        if model.features.contains_key(&name) {
+                            let cause = extract_feature_name(antecedent)
+                                .unwrap_or_else(|| "constraint".to_string());
+                            if selected.insert(name.clone()) {
+                                origins
+                                    .insert(name.clone(), FeatureOrigin::ImpliedBy(cause));
+                                changed = true;
+                            }
                         }
                     }
                 }
@@ -486,6 +548,7 @@ pub fn solve(
         Ok(ResolvedVariant {
             name: config.name.clone(),
             effective_features: selected,
+            origins,
         })
     } else {
         Err(errors)
@@ -990,6 +1053,98 @@ constraints:
         };
         let resolved = solve(&model, &config).unwrap();
         assert!(resolved.effective_features.contains("feature-y"));
+    }
+
+    // ── Feature origin tracking (pain point #8) ─────────────────────
+
+    #[test]
+    fn origin_marks_user_selected_features() {
+        let model = FeatureModel::from_yaml(vehicle_model_yaml()).unwrap();
+        let config = VariantConfig {
+            name: "eu-electric".into(),
+            selects: vec!["electric".into(), "eu".into()],
+        };
+        let resolved = solve(&model, &config).unwrap();
+
+        assert_eq!(
+            resolved.origins.get("electric"),
+            Some(&FeatureOrigin::UserSelected),
+            "electric was named in selects → UserSelected"
+        );
+        assert_eq!(
+            resolved.origins.get("eu"),
+            Some(&FeatureOrigin::UserSelected)
+        );
+    }
+
+    #[test]
+    fn origin_marks_mandatory_ancestors_and_root() {
+        let model = FeatureModel::from_yaml(vehicle_model_yaml()).unwrap();
+        let config = VariantConfig {
+            name: "eu-electric".into(),
+            selects: vec!["electric".into(), "eu".into()],
+        };
+        let resolved = solve(&model, &config).unwrap();
+
+        // Root and ancestor `engine` / `market` are pulled in by the tree,
+        // not by the user. Root is always Mandatory; ancestors are too.
+        assert_eq!(
+            resolved.origins.get("vehicle"),
+            Some(&FeatureOrigin::Mandatory),
+            "root must be Mandatory"
+        );
+        assert_eq!(
+            resolved.origins.get("engine"),
+            Some(&FeatureOrigin::Mandatory),
+            "engine is the parent of electric — ancestors are mandatory"
+        );
+        assert_eq!(
+            resolved.origins.get("market"),
+            Some(&FeatureOrigin::Mandatory)
+        );
+    }
+
+    #[test]
+    fn origin_marks_constraint_implied_features() {
+        // Model has `(implies eu pedestrian-detection)`. Selecting eu
+        // should mark pedestrian-detection as ImpliedBy("eu").
+        let model = FeatureModel::from_yaml(vehicle_model_yaml()).unwrap();
+        let config = VariantConfig {
+            name: "eu".into(),
+            selects: vec!["electric".into(), "eu".into()],
+        };
+        let resolved = solve(&model, &config).unwrap();
+
+        let origin = resolved
+            .origins
+            .get("pedestrian-detection")
+            .expect("pedestrian-detection must be in the effective set");
+        match origin {
+            FeatureOrigin::ImpliedBy(cause) => {
+                assert_eq!(cause, "eu", "cause should be `eu`, got {cause:?}");
+            }
+            other => panic!(
+                "pedestrian-detection should be ImpliedBy(eu), got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn origins_cover_every_effective_feature() {
+        // Every feature in `effective_features` must have a matching
+        // entry in `origins`. No orphans.
+        let model = FeatureModel::from_yaml(vehicle_model_yaml()).unwrap();
+        let config = VariantConfig {
+            name: "full".into(),
+            selects: vec!["electric".into(), "eu".into(), "abs".into()],
+        };
+        let resolved = solve(&model, &config).unwrap();
+        for name in &resolved.effective_features {
+            assert!(
+                resolved.origins.contains_key(name),
+                "missing origin for feature `{name}`"
+            );
+        }
     }
 
     #[test]

--- a/rivet-core/src/feature_model.rs
+++ b/rivet-core/src/feature_model.rs
@@ -66,9 +66,15 @@ pub struct ResolvedVariant {
 // ── Feature-to-artifact binding ────────────────────────────────────────
 
 /// Maps features to artifact IDs and source globs.
+///
+/// May also carry a list of variant configurations that `rivet variant
+/// check-all` iterates. Absent means "no declared variants" — check-all
+/// reports an empty pass.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FeatureBinding {
     pub bindings: BTreeMap<String, Binding>,
+    #[serde(default)]
+    pub variants: Vec<VariantConfig>,
 }
 
 /// Artifacts and source files associated with a feature.

--- a/rivet-core/src/feature_model.rs
+++ b/rivet-core/src/feature_model.rs
@@ -217,8 +217,10 @@ impl FeatureModel {
         let mut constraints = Vec::new();
         for src in &raw.constraints {
             let preprocessed = preprocess_feature_constraint(src, &features);
-            let expr = sexpr_eval::parse_filter(&preprocessed)
-                .map_err(|errs| Error::Schema(format!("constraint `{src}`: {errs:?}")))?;
+            let expr = sexpr_eval::parse_filter(&preprocessed).map_err(|errs| {
+                let msgs: Vec<String> = errs.iter().map(|e| e.to_string()).collect();
+                Error::Schema(format!("constraint `{src}`: {}", msgs.join("; ")))
+            })?;
             constraints.push(expr);
         }
 

--- a/rivet-core/src/sexpr_eval.rs
+++ b/rivet-core/src/sexpr_eval.rs
@@ -386,16 +386,104 @@ pub struct LowerError {
 }
 
 /// Error from parsing + lowering a filter expression.
+///
+/// `note` carries an optional human-readable hint separate from the raw
+/// parser `message`. When the input is detected to look like infix syntax
+/// (`A and B`) or is missing outer parentheses, the hint points the user
+/// at the expected s-expression form. Consumers that want just the short
+/// parser detail can read `message` directly; the `Display` impl renders
+/// both.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FilterError {
     pub offset: usize,
     pub message: String,
+    /// Optional semantic note added by `parse_filter` on top of the
+    /// positional parser message.
+    pub note: Option<String>,
 }
 
 impl std::fmt::Display for FilterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "offset {}: {}", self.offset, self.message)
+        write!(f, "offset {}: {}", self.offset, self.message)?;
+        if let Some(ref n) = self.note {
+            write!(f, "\n  note: {n}")?;
+        }
+        Ok(())
     }
+}
+
+/// Classify a parse failure and produce a human-readable note.
+///
+/// Detects the three most common user-error shapes:
+///   - bare infix: `A and B`, `A && B`
+///   - missing outer parens: e.g. `and A B`
+///   - unknown head symbol: `(bogus A B)`
+///
+/// and nudges the user at the expected `(head A B …)` form.
+fn classify_filter_error(source: &str, message: &str) -> Option<String> {
+    let trimmed = source.trim_start();
+
+    const HEADS: &[&str] = &[
+        "and", "or", "not", "implies", "excludes", "=", "!=", ">", "<", ">=", "<=",
+        "has-tag", "has-field", "in", "matches", "contains", "linked-by", "linked-from",
+        "linked-to", "links-count", "reachable-from", "reachable-to", "forall", "exists",
+        "count",
+    ];
+    const INFIX: &[&str] = &[
+        "and", "or", "not", "==", "!=", "&&", "||", ">", "<", ">=", "<=", "implies",
+    ];
+
+    if !trimmed.starts_with('(') {
+        let tokens_lc: Vec<String> = trimmed
+            .split_whitespace()
+            .map(|s| s.to_ascii_lowercase())
+            .collect();
+
+        // Case 1: first token is a known head symbol → missing outer
+        // parens (e.g. `and A B`). Prefer this over the infix note
+        // because the fix is a single wrap rather than a restructure.
+        if let Some(first) = tokens_lc.first() {
+            if HEADS.contains(&first.as_str()) {
+                return Some(format!(
+                    "looks like missing outer parens; wrap the expression: ({trimmed})"
+                ));
+            }
+        }
+
+        // Case 2: source does not start with '(' and the OPERATOR sits
+        // between two operands — that's infix.
+        let has_infix = tokens_lc.len() >= 3
+            && tokens_lc
+                .get(1)
+                .is_some_and(|t| INFIX.contains(&t.as_str()));
+        if has_infix {
+            let suggestion = if tokens_lc.len() == 3 {
+                format!(
+                    "({} {} {})",
+                    tokens_lc[1].replace("&&", "and").replace("||", "or"),
+                    tokens_lc[0],
+                    tokens_lc[2]
+                )
+            } else {
+                "(and A B)".to_string()
+            };
+            return Some(format!(
+                "expected s-expression form like {suggestion}; got infix syntax"
+            ));
+        }
+    }
+
+    // Case 3: unknown function / head symbol. The lowerer emits a
+    // message that typically mentions "unknown form" or "unexpected".
+    if message.contains("unknown") || message.contains("unexpected form") {
+        return Some(
+            "unknown head symbol; see docs/getting-started.md for the supported forms \
+             (and/or/not/implies/excludes/=/!=/>/</has-tag/has-field/in/matches/contains/linked-*)"
+                .to_string(),
+        );
+    }
+
+    None
 }
 
 /// Parse a filter string into a typed expression.
@@ -409,6 +497,7 @@ pub fn parse_filter(source: &str) -> Result<Expr, Vec<FilterError>> {
         return Err(parse_errors
             .into_iter()
             .map(|e| FilterError {
+                note: classify_filter_error(source, &e.message),
                 offset: e.offset,
                 message: e.message,
             })
@@ -419,6 +508,7 @@ pub fn parse_filter(source: &str) -> Result<Expr, Vec<FilterError>> {
     lower(&root).map_err(|errs| {
         errs.into_iter()
             .map(|e| FilterError {
+                note: classify_filter_error(source, &e.message),
                 offset: e.offset,
                 message: e.message,
             })
@@ -1238,5 +1328,75 @@ mod tests {
             store: None,
         };
         assert!(!check(&expr, &ctx));
+    }
+
+    // ── Error message quality (pain point #7) ───────────────────────
+
+    /// Bare infix like `A and B` must surface a semantic note pointing
+    /// at the expected `(and A B)` form — not just a positional parser
+    /// offset.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn parse_error_bare_infix_surfaces_note() {
+        let result = parse_filter("A and B");
+        let errs = result.expect_err("bare infix must fail");
+        assert!(!errs.is_empty());
+        let note = errs[0]
+            .note
+            .as_ref()
+            .expect("expected a semantic note for infix input");
+        assert!(
+            note.contains("infix") || note.contains("s-expression"),
+            "note should mention s-expression/infix. got: {note}"
+        );
+        assert!(
+            note.contains("(and A B)") || note.contains("(and"),
+            "note should suggest (and A B). got: {note}"
+        );
+        // Display renders both positional detail and the note.
+        let rendered = format!("{}", errs[0]);
+        assert!(rendered.contains("note:"), "Display should carry the note");
+    }
+
+    /// `and A B` — missing outer parens. The classifier should propose
+    /// wrapping the expression.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn parse_error_missing_outer_parens_surfaces_note() {
+        let result = parse_filter("and A B");
+        let errs = result.expect_err("missing parens must fail");
+        let note = errs[0]
+            .note
+            .as_ref()
+            .expect("expected a semantic note for missing outer parens");
+        assert!(
+            note.contains("missing outer parens") && note.contains("(and A B)"),
+            "note should suggest wrapping in parens. got: {note}"
+        );
+    }
+
+    /// `(bogus A B)` — unknown head symbol. Note should reference the
+    /// supported forms.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn parse_error_unknown_head_surfaces_note() {
+        let result = parse_filter("(bogus A B)");
+        let errs = result.expect_err("unknown head must fail");
+        let note = errs[0]
+            .note
+            .as_ref()
+            .expect("expected a note on unknown head symbol");
+        assert!(
+            note.contains("unknown head symbol") && note.contains("and/or/not"),
+            "note should list supported forms. got: {note}"
+        );
+    }
+
+    /// Valid s-expression input must not carry a note — classification
+    /// only runs on error paths.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn parse_success_has_no_note() {
+        parse_filter("(and (= type \"requirement\") (has-tag \"stpa\"))").unwrap();
     }
 }


### PR DESCRIPTION
Fixes a batch of v0.4.0 rough edges reported against the variant / hooks / sexpr surfaces. Each commit is self-contained with its own tests.

## Summary of commits

| # | Commit | Pain point |
|---|--------|------------|
| 3 | `c4fcb00` docs+feat(variant): feature-model schema reference + init scaffolder | Undocumented YAML schema; `rivet variant init` now scaffolds starter files with commented fields. |
| 4 | `7a35861` fix(hooks): pre-commit hook walks up to find rivet.yaml | Relocating `rivet.yaml` no longer breaks the pre-commit hook — marker discovery from `$PWD`. |
| 6 | `01c244e` feat(variant): check-all + optional --variant on validate | `--variant` now optional for model+binding consistency validation; new `rivet variant check-all` iterates declared variants. |
| 7 | `612bfe6` fix(sexpr): semantic notes on filter parse errors | Positional-only `FilterError` messages now carry a semantic note for bare infix / missing parens / unknown head shapes. |
| 8 | `c46a375` feat(variant-solve): per-feature origin tracking | `rivet variant solve` labels each effective feature as (mandatory) / (selected) / (implied by X); JSON output adds an `origins` map and stays backward-compatible. |

## Tests

- 3 new tests: `rivet-cli/tests/variant_init.rs`
- 2 new tests: `rivet-cli/tests/hooks_install.rs`
- 5 new tests: `rivet-cli/tests/variant_scoped_api.rs`
- 2 new tests: `rivet-cli/tests/variant_solve_origins.rs`
- 4 new unit tests in `rivet-core/src/sexpr_eval.rs`
- 4 new unit tests in `rivet-core/src/feature_model.rs`

Total: **20 new tests**. All 589 pre-existing rivet-core lib tests still pass; all 6 proptest_feature_model properties still hold; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Scope limits respected

Per the brief's scope note on PR #156 (cross-tree constraints): fix #8 extends `ResolvedVariant` with a new `origins` field and populates it alongside the existing fixpoint loop — no refactor of the solve algorithm. Tests confirm PR #156's cross-tree semantics still hold.

## Test plan

- [x] `cargo test -p rivet-cli --test variant_init`
- [x] `cargo test -p rivet-cli --test hooks_install`
- [x] `cargo test -p rivet-cli --test variant_scoped_api`
- [x] `cargo test -p rivet-cli --test variant_solve_origins`
- [x] `cargo test -p rivet-core --lib feature_model`
- [x] `cargo test -p rivet-core --lib sexpr_eval`
- [x] `cargo test --workspace --lib` (589 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)