### PR TITLE
fix(serve): variant banner link missing hx-push-url (v0.4.1 release hotfix)

### DIFF
--- a/rivet-cli/src/serve/views.rs
+++ b/rivet-cli/src/serve/views.rs
@@ -18,8 +18,7 @@ fn variant_error_response(msg: &str) -> Response {
         "<div class=\"card\" style=\"margin:2rem\">\
          <h2 style=\"margin-top:0;color:#b91c1c\">Invalid variant scope</h2>\
          <p>{}</p>\
-         <p><a href=\"/variants\" hx-get=\"/variants\" hx-target=\"#content\" \
-         hx-push-url=\"true\">See all declared variants</a> \
+         <p><a href=\"/variants\" hx-get=\"/variants\" hx-push-url=\"true\" hx-target=\"#content\">See all declared variants</a> \
          or <a href=\"?\">clear the filter</a>.</p>\
          </div>",
         rivet_core::document::html_escape(msg),


### PR DESCRIPTION
v0.4.1 release's test-evidence job failed on `serve_lint::all_content_links_push_url`: the "Invalid variant scope" error banner link in views.rs:21 had its `hx-push-url` attribute on the next source line from `hx-get` + `hx-target="#content"`, so the per-line lint flagged it.

Collapsing onto one line. Test passes locally.

Once merged, I'll re-tag v0.4.1 on the fix commit.