### PR TITLE
chore(release): bump vscode-rivet/package.json to 0.4.3

### DIFF
--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Missed in the v0.4.3 release bump (#200). Docs-check \`VersionConsistency\` invariant fails CI on the v0.4.3 tag because the VS Code extension package stayed at 0.4.2 while workspace moved to 0.4.3.

Platform packages stay at 0.4.1 intentionally — \`release-npm.yml\` overwrites them at publish time via jq.

## Next step after merge
The v0.4.3 tag already points at the previous commit (which lacks this fix). Suggested recovery: after merge, move the v0.4.3 tag to the new main HEAD so the Release workflow re-runs against the fixed tree.

## Test plan
- [x] \`rivet docs check\` passes locally (0 violations)

Trace: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)