### PR TITLE
fix(ci): remove dead build-vsix reference that killed ci.yml at parse time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,10 +446,14 @@ jobs:
       - run: cargo check --all
 
   # ── Attach test results + attestation to releases ───────────────────
+  #
+  # VSIX packaging moved to release.yml so the extension ships together
+  # with the platform binaries on tag push. This job now only attaches
+  # the JUnit, coverage lcov, and attested rivet binary for the tag.
   release-results:
     name: Publish Test Results on Release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test, coverage, miri, proptest, playwright, build-vsix]
+    needs: [test, coverage, miri, proptest, playwright]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -473,11 +477,6 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: target/release/rivet
-      - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: vsix
-          path: vsix
       - name: Package results
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
@@ -496,4 +495,3 @@ jobs:
           files: |
             release-results-*.tar.gz
             target/release/rivet
-            vsix/*.vsix


### PR DESCRIPTION
## Summary
`release-results.needs:` referenced a `build-vsix` job that no longer exists — VSIX packaging was moved to `release.yml` so the extension attaches to the GitHub Release alongside the platform binaries. GitHub Actions rejects the whole workflow at validation time when `needs:` names a non-existent job, which is why every push to `main` and every PR has been showing **"ci.yml failed in 0s, 0 jobs"** since the move.

## Impact (silent regression)
The main CI test gate has been **silently absent** on every commit since the VSIX move. PRs have been merging only on Benchmarks + Rivet Delta checks. Fix restores these as live gating checks: `fmt` / `clippy` / `test` / `playwright` / `miri` / `proptest` / `coverage` / `audit` / `deny` / `kani` / `verus` / `rocq` / `msrv` / `docs-check`.

## Changes
- Drop `build-vsix` from `release-results.needs:` list.
- Drop the now-obsolete "Download VSIX artifact" step.
- Drop `vsix/*.vsix` from the `release-results` upload list.

release.yml already handles VSIX on tag push (both GitHub Release attachment and Marketplace publish).

## Test plan
- [x] `actionlint 1.7.12` clean across every workflow file
- [ ] CI actually runs on this PR (and every job starts — the regression is exit=0 at 0s, no jobs scheduled)

Trace: skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)