### PR TITLE
feat(vscode): HTML-view source link jumps to artifact definition + new context menu

### DIFF
--- a/rivet-cli/src/render/artifacts.rs
+++ b/rivet-cli/src/render/artifacts.rs
@@ -389,17 +389,38 @@ pub(crate) fn render_artifact_detail(ctx: &RenderContext, id: &str) -> RenderRes
         .as_ref()
         .map(|p| p.display().to_string());
 
+    // Resolve the line number of `id: <this>` within the source file so
+    // VS Code's Open Source lands on the artifact definition, not the
+    // top of the file. Uses a simple scan (mirrors lsp_find_artifact_line)
+    // so no rowan CST dependency is pulled into the render path.
+    let source_line: Option<u32> = source_file
+        .as_deref()
+        .and_then(|sf| std::fs::read_to_string(sf).ok())
+        .and_then(|content| {
+            content.lines().enumerate().find_map(|(i, line)| {
+                let t = line.trim();
+                (t == format!("id: {id}") || t == format!("- id: {id}"))
+                    .then_some(u32::try_from(i).unwrap_or(0))
+            })
+        });
+
     // Source file link (shown at top for quick access)
-    // Uses data-source-file attribute — the VS Code nav shim picks this up
+    // Uses data-source-file + data-source-line attributes — the VS Code
+    // nav shim in shell.ts picks these up and opens the file at the
+    // exact line of the artifact definition.
     let source_link = if let Some(ref sf) = source_file {
         let filename = std::path::Path::new(sf)
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or(sf);
+        let line_attr = source_line
+            .map(|l| format!(" data-source-line=\"{l}\""))
+            .unwrap_or_default();
         format!(
             " <span class=\"meta\" style=\"float:right;font-size:.85rem\">\
-             <a href=\"#\" data-source-file=\"{}\" title=\"Open source file\">&#128196; {}</a></span>",
+             <a href=\"#\" data-source-file=\"{}\"{} title=\"Open source file\">&#128196; {}</a></span>",
             html_escape(sf),
+            line_attr,
             html_escape(filename),
         )
     } else {
@@ -630,7 +651,7 @@ pub(crate) fn render_artifact_detail(ctx: &RenderContext, id: &str) -> RenderRes
         html,
         title: format!("{} — {}", artifact.id, artifact.title),
         source_file,
-        source_line: None,
+        source_line,
     }
 }
 

--- a/vscode-rivet/package-lock.json
+++ b/vscode-rivet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rivet-sdlc",
-  "version": "0.3.0",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rivet-sdlc",
-      "version": "0.3.0",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -78,8 +78,32 @@
         "command": "rivet.searchArtifact",
         "title": "Search Artifacts",
         "category": "Rivet"
+      },
+      {
+        "command": "rivet.openArtifactInView",
+        "title": "Rivet: Open Artifact in Dashboard",
+        "category": "Rivet"
+      },
+      {
+        "command": "rivet.openArtifactInGraph",
+        "title": "Rivet: Show Artifact in Graph",
+        "category": "Rivet"
       }
     ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "rivet.openArtifactInView",
+          "group": "rivet@1",
+          "when": "editorLangId == yaml"
+        },
+        {
+          "command": "rivet.openArtifactInGraph",
+          "group": "rivet@2",
+          "when": "editorLangId == yaml"
+        }
+      ]
+    },
     "keybindings": [
       {
         "command": "rivet.searchArtifact",

--- a/vscode-rivet/src/extension.ts
+++ b/vscode-rivet/src/extension.ts
@@ -67,6 +67,22 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('rivet.validate', () => runValidate()),
     vscode.commands.registerCommand('rivet.addArtifact', () => addArtifact()),
     vscode.commands.registerCommand('rivet.navigateTo', (urlPath: string) => showDashboard(context, urlPath)),
+    vscode.commands.registerCommand('rivet.openArtifactInView', () => {
+      const id = artifactIdAtCursor();
+      if (!id) {
+        vscode.window.showInformationMessage('Place the cursor on an artifact ID (e.g. REQ-001) first.');
+        return;
+      }
+      vscode.commands.executeCommand('rivet.navigateTo', `/artifact/${encodeURIComponent(id)}`);
+    }),
+    vscode.commands.registerCommand('rivet.openArtifactInGraph', () => {
+      const id = artifactIdAtCursor();
+      if (!id) {
+        vscode.window.showInformationMessage('Place the cursor on an artifact ID (e.g. REQ-001) first.');
+        return;
+      }
+      vscode.commands.executeCommand('rivet.navigateTo', `/graph?focus=${encodeURIComponent(id)}`);
+    }),
     vscode.commands.registerCommand('rivet.showSource', async () => {
       if (!currentSourceFile) {
         vscode.window.showInformationMessage('No source file for current view');
@@ -204,6 +220,33 @@ export function deactivate() {
   return client?.stop().catch(() => {});
 }
 
+// --- Artifact ID detection ---
+
+// Returns the artifact-ID-shaped token at the cursor in the active YAML
+// editor, or undefined if no editor is active or the cursor is not on
+// such a token. Pattern matches canonical rivet IDs: an uppercase prefix
+// of 2+ letters, an optional colon-namespaced external prefix, and a
+// numeric suffix separated by dashes. Examples: REQ-001, FEAT-128,
+// spar:SPAR-SYS-001, DD-059.
+function artifactIdAtCursor(): string | undefined {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return undefined;
+  const doc = editor.document;
+  const pos = editor.selection.active;
+  // Word-boundary regex; colon-inclusive for external-ref prefixes.
+  const wordRange = doc.getWordRangeAtPosition(
+    pos,
+    /[A-Za-z][A-Za-z0-9:_-]*/,
+  );
+  if (!wordRange) return undefined;
+  const word = doc.getText(wordRange);
+  // Accept bare `REQ-001`, prefixed `stpa:REQ-001`, and any uppercase
+  // alpha+dash+digit shape. Reject plain words and YAML keys like `title`.
+  return /^([a-z][a-z0-9-]*:)?[A-Z][A-Z0-9]*-[A-Z0-9-]+$/.test(word)
+    ? word
+    : undefined;
+}
+
 // --- Binary discovery ---
 
 function findRivetBinary(context: vscode.ExtensionContext): string | undefined {
@@ -275,7 +318,18 @@ async function showDashboard(context: vscode.ExtensionContext, urlPath: string =
             ? msg.file
             : path.join(rivetProjectRoot, msg.file);
           const uri = vscode.Uri.file(filePath);
-          await vscode.window.showTextDocument(uri, { viewColumn: vscode.ViewColumn.One });
+          // `msg.line` is the 0-based line where the artifact is defined,
+          // as computed by render_artifact_detail. Position the cursor
+          // and reveal that line on open so the user lands on the
+          // artifact's `id:` row, not the top of the file.
+          const options: vscode.TextDocumentShowOptions = {
+            viewColumn: vscode.ViewColumn.One,
+          };
+          if (typeof msg.line === 'number' && Number.isFinite(msg.line) && msg.line >= 0) {
+            const pos = new vscode.Position(msg.line, 0);
+            options.selection = new vscode.Range(pos, pos);
+          }
+          await vscode.window.showTextDocument(uri, options);
         }
       }
     });

--- a/vscode-rivet/src/shell.ts
+++ b/vscode-rivet/src/shell.ts
@@ -48,11 +48,13 @@ export function getShellHtml(
     document.addEventListener('click', (e) => {
       const a = e.target.closest('a');
       if (!a) return;
-      // Source file links — open in editor
+      // Source file links — open in editor at the artifact's definition line
       const sourceFile = a.getAttribute('data-source-file');
       if (sourceFile) {
         e.preventDefault();
-        vscode.postMessage({ type: 'openSource', file: sourceFile });
+        const lineAttr = a.getAttribute('data-source-line');
+        const line = lineAttr !== null ? parseInt(lineAttr, 10) : undefined;
+        vscode.postMessage({ type: 'openSource', file: sourceFile, line });
         return;
       }
       // Internal navigation links


### PR DESCRIPTION
## Bug fix
The 📄 source-file link on an artifact's HTML view (in the VS Code webview) posted `{ file }` but no line number, so the editor opened the YAML at the **top of the file** instead of the artifact's own `id:` line. For a file with 200+ artifacts, that's a long scroll.

Fix spans the render → webview → extension path:
- \`render/artifacts.rs\`: scan the source YAML for `id: <this>` / `- id: <this>`, emit `data-source-line="<0-based>"` on the anchor alongside `data-source-file`. Mirrors `lsp_find_artifact_line` so go-to-def and the webview nav produce identical positions.
- \`shell.ts\`: parse `data-source-line` as integer, forward as `msg.line` in `openSource`.
- \`extension.ts\`: use `msg.line` to construct a `vscode.Range` and pass as `options.selection` in `showTextDocument`. Cursor lands on the artifact's `id:` row, editor reveals the line.

## New: YAML editor context menu
Two new commands registered in `editor/context` for `yaml` files:
- **Rivet: Open Artifact in Dashboard** → navigates webview to `/artifact/<id>` for the ID under the cursor
- **Rivet: Show Artifact in Graph** → navigates webview to `/graph?focus=<id>`

Both use a shared `artifactIdAtCursor()` helper that extracts a rivet-shaped ID (uppercase-prefix + dash + digits, optionally namespaced with `prefix:` for external refs). Rejects plain YAML keys like `title` so menu items no-op gracefully when the cursor isn't on an ID.

## Test plan
- [x] rivet-cli builds clean (`cargo build -p rivet-cli`)
- [x] Extension compiles clean (`tsc -b` in vscode-rivet)
- [x] Existing integration tests still pass (serve_integration: 37 pass)

Refs: FEAT-010, FEAT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)