### PR TITLE
fix(tests/playwright): batch stale-test cleanups (5 of 10)

### DIFF
--- a/tests/playwright/artifacts.spec.ts
+++ b/tests/playwright/artifacts.spec.ts
@@ -57,9 +57,6 @@ test.describe("Artifacts", () => {
     const mermaidPre = page.locator("pre.mermaid");
     await expect(mermaidPre).toHaveCount(1);
 
-    // The source content must be there before mermaid.js runs.
-    await expect(mermaidPre).toContainText("flowchart LR");
-
     // mermaid.js replaces the block's contents with an <svg> on success.
     // Give it a moment to run — it's triggered by DOMContentLoaded and
     // htmx:afterSwap.  If rendering fails the pre block keeps its source.

--- a/tests/playwright/documents.spec.ts
+++ b/tests/playwright/documents.spec.ts
@@ -161,7 +161,7 @@ test.describe("Documents", () => {
     await page.goto(docLinks[0]);
     await waitForHtmx(page);
     const headings = await page
-      .locator("article h2, article h3, article h4, main h2, main h3, main h4")
+      .locator(".doc-body h2, .doc-body h3, .doc-body h4")
       .evaluateAll((els) =>
         els.map((el) => ({
           tag: el.tagName.toLowerCase(),

--- a/tests/playwright/rivet-delta.spec.ts
+++ b/tests/playwright/rivet-delta.spec.ts
@@ -65,6 +65,12 @@ function mdToHtml(md: string): string {
   html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
   // Bold.
   html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  // Images (must come before links — `![alt](url)` would otherwise be
+  // partly consumed by the link regex as `[alt](url)`).
+  html = html.replace(
+    /!\[([^\]]+)\]\(([^)]+)\)/g,
+    '<img alt="$1" src="$2">',
+  );
   // Links.
   html = html.replace(
     /\[([^\]]+)\]\(([^)]+)\)/g,
@@ -184,7 +190,11 @@ test.describe("rivet-delta PR-comment output", () => {
     await expect(
       page.locator("h2", { hasText: "Rivet artifact delta" }),
     ).toBeVisible();
-    await expect(page.locator("code", { hasText: "REQ-NEW-1" })).toBeVisible();
+    await expect(
+      page
+        .locator("code:not(.language-mermaid)", { hasText: "REQ-NEW-1" })
+        .first(),
+    ).toBeVisible();
     await expect(
       page.locator("details summary", { hasText: "Modified" }),
     ).toBeVisible();
@@ -283,6 +293,9 @@ test.describe("rivet-delta PR-comment output", () => {
 
     // Use the project's bundled mermaid (served by `rivet serve` at
     // /assets/mermaid.js) so the parser version matches production.
+    // Navigate first so <script src="/assets/mermaid.js"> resolves
+    // against the dev server instead of about:blank.
+    await page.goto("/");
     await page.setContent(`
       <!doctype html><html><body>
         <pre class="mermaid">${mermaidSrc


### PR DESCRIPTION
## Summary

Five Playwright tests had stale assertions that diverged from the rendered output. None require a code change in `rivet-cli` or `rivet-core` — these are pure test-code fixes.

- **`artifacts.spec.ts:49` — mermaid race.** The test asserted `toContainText("flowchart LR")` on `<pre class=\"mermaid\">` after mermaid.js had already replaced the source with rendered SVG. Drop the source-text assertion; keep only the SVG-presence check.
- **`documents.spec.ts:145` — heading IDs selector too broad.** `article h2, article h3, article h4, main h2, main h3, main h4` matched the page-chrome `<h2>{title}</h2>` (rendered by `rivet-cli/src/render/documents.rs:122` with no id by design). Tighten to `.doc-body h2-h4` so only body headings (which correctly emit `id=\"{slug}\"` via `rivet-core/src/document.rs:541`) are checked.
- **`rivet-delta.spec.ts:136` — strict-mode locator violation.** `page.locator(\"code\", { hasText: \"REQ-NEW-1\" })` matched both `<code class=\"language-mermaid\">` (mermaid source contains `REQ_NEW_1`) and the standalone `<code>REQ-NEW-1</code>` row. Tighten to `code:not(.language-mermaid)` plus `.first()`.
- **`rivet-delta.spec.ts:258` — `setContent` has no base URL.** `<script src=\"/assets/mermaid.js\">` resolved to `about:blank/...` and never loaded → `window.mermaid` undefined → 30s timeout. `page.goto(\"/\")` before `setContent` so the script resolves against the dev server.
- **`rivet-delta.spec.ts:367` — missing image regex in `mdToHtml` helper.** The local `mdToHtml` only had a `[link](url)` regex, which matched the inner `[alt](url)` of `![alt](url)` and produced `!<a href=\"url\">…</a>` instead of `<img>`. Add a `![alt](url)` regex BEFORE the link regex.

The other 5 Playwright failures (`artifacts.spec.ts:73`, `filter-sort.spec.ts:225/253`, `serve-variant.spec.ts:25/67`) are addressed in separate PRs (serve middleware fix, decision-pending, `js.rs` reload restoration).

## Test plan

- [ ] CI Playwright job: the five tests at `artifacts.spec.ts:49`, `documents.spec.ts:145`, `rivet-delta.spec.ts:136`, `rivet-delta.spec.ts:258`, `rivet-delta.spec.ts:367` pass.
- [ ] No file outside `tests/playwright/` is touched (verify via `git diff --stat`).
- [ ] The other 5 known-failing tests still fail (out of scope for this PR; tracked elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)