### PR TITLE
fix(serve): preserve response status through wrap_full_page middleware

### DIFF
--- a/rivet-cli/src/serve/mod.rs
+++ b/rivet-cli/src/serve/mod.rs
@@ -1021,20 +1021,27 @@ async fn wrap_full_page(
         && !path.starts_with("/source-raw/")
         && !path.starts_with("/docs-asset/")
     {
+        // Capture status before consuming the body so we can re-apply it after
+        // wrapping; otherwise .into_response() defaults to 200 and silently
+        // turns explicit error statuses (e.g. 400 from variant_error_response)
+        // into successful responses.
+        let status = response.status();
         let bytes = axum::body::to_bytes(response.into_body(), 16 * 1024 * 1024)
             .await
             .unwrap_or_default();
         let content = String::from_utf8_lossy(&bytes);
         let app = state.read().await;
-        if is_print {
-            return layout::print_layout(&content, &app).into_response();
-        }
-        if is_embed {
-            return layout::embed_layout(&content, &app).into_response();
-        }
-        let active_variant = extract_variant_from_query(&query);
-        return layout::page_layout_with_variant(&content, &app, active_variant.as_deref())
-            .into_response();
+        let mut wrapped = if is_print {
+            layout::print_layout(&content, &app).into_response()
+        } else if is_embed {
+            layout::embed_layout(&content, &app).into_response()
+        } else {
+            let active_variant = extract_variant_from_query(&query);
+            layout::page_layout_with_variant(&content, &app, active_variant.as_deref())
+                .into_response()
+        };
+        *wrapped.status_mut() = status;
+        return wrapped;
     }
 
     response


### PR DESCRIPTION
## Summary

Fix `wrap_full_page` middleware in `rivet-cli/src/serve/mod.rs` so it preserves the inner handler's HTTP status when re-wrapping the response body in the page layout.

The middleware consumed the response body and rebuilt the response via `layout::page_layout_with_variant(...).into_response()`, which defaults to 200. As a result, every non-200 status (notably the 400 from `views::variant_error_response`) silently became a 200 with an error-looking page — wrong HTTP semantics for callers, broken error-handling assertions in tests.

Patch is minimal: capture `response.status()` before draining the body, then re-apply via `*wrapped.status_mut() = status` after building the wrapped response.

## Likely cascade-fixes (Playwright triage)

- `serve-variant.spec.ts:67` (#9 — unknown-variant 400-style error page)
- `serve-variant.spec.ts:25` (#4 — variant selection navigation)
- `filter-sort.spec.ts:225` (#10 — `?q=` push-url; the middleware was also potentially clobbering response headers, verify post-fix)

## Test plan

- [x] `cargo build --release -p rivet-cli` — clean
- [x] `cargo clippy -p rivet-cli` — clean
- [x] `cargo test --release -p rivet-cli --test serve_integration` — 37/37 pass
- [ ] Local curl smoke (run by reviewer or CI):
  - `cargo run --release -- serve --port 3099 &`
  - `curl -i 'http://localhost:3099/artifacts?variant=does-not-exist' | head -3` → expect `HTTP/1.1 400` (was 200)
  - `curl -i 'http://localhost:3099/artifacts' | head -3` → still `HTTP/1.1 200`
- [ ] CI — Playwright `serve-variant.spec.ts` cases :25 and :67 expected green post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)