### PR TITLE
fix(playwright): bump per-test timeout 30s -> 60s for graph render

### DIFF
--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -3,7 +3,11 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: ".",
   testMatch: "*.spec.ts",
-  timeout: 30_000,
+  // 60s per-test timeout: /graph with the dogfood dataset (742 nodes, 1477
+  // edges) takes ~25-30s for synchronous layout + SVG generation in
+  // render_graph_view, leaving <5s for the .toBeVisible() assertion under
+  // the previous 30s budget. CI runner load makes this tighter still.
+  timeout: 60_000,
   retries: process.env.CI ? 1 : 0,
   workers: 1, // serial — single server instance
   use: {


### PR DESCRIPTION
## Why

Latest CI on main showed the `diagram-viewer.spec.ts:graph` tests failing despite the `?limit=2000` fix in cc8403e. Page snapshot from the failed retry shows the graph **did** render ("742 nodes, 1477 edges"), but layout + SVG generation took ~25-30s synchronously in `render_graph_view`, leaving <5s for the `.toBeVisible()` assertion before the 30s test timeout fired.

## Fix

Bump the global per-test timeout from 30s to 60s in `playwright.config.ts`. Most tests complete in <2s so the bump is inert; it specifically unblocks the SVG-heavy diagram-viewer assertions.

## Future work (separate PR)

The real fix is moving graph layout/SVG out of the synchronous response (lazy-load via HTMX). Tracked as a follow-up; this timeout bump unblocks CI now.

## Test plan

- [x] Local edit applied
- [ ] CI runs Playwright with new timeout
- [ ] All 4 diagram-viewer tests (graph + schema-linkage × toolbar + fullscreen) pass