### PR TITLE
fix(playwright): close out remaining 8 dashboard test failures

### DIFF
--- a/rivet-cli/src/render/artifacts.rs
+++ b/rivet-cli/src/render/artifacts.rs
@@ -101,44 +101,6 @@ fn wrap_markdown_mermaid_in_svg_viewer(html: &str) -> String {
     out
 }
 
-#[cfg(test)]
-mod mermaid_wrap_tests {
-    use super::*;
-
-    // rivet: verifies REQ-007 (artifact diagram viewer parity)
-    #[test]
-    fn wraps_single_mermaid_block_in_svg_viewer() {
-        let html = "<p>intro</p><pre class=\"mermaid\">graph LR\nA-->B</pre><p>outro</p>";
-        let wrapped = wrap_markdown_mermaid_in_svg_viewer(html);
-        assert!(wrapped.contains("<div class=\"svg-viewer\">"));
-        assert!(wrapped.contains("svg-viewer-toolbar"));
-        assert!(wrapped.contains("title=\"Fullscreen\""));
-        // Pre block still in place.
-        assert!(wrapped.contains("<pre class=\"mermaid\">graph LR"));
-        // Surrounding paragraphs preserved.
-        assert!(wrapped.contains("<p>intro</p>"));
-        assert!(wrapped.contains("<p>outro</p>"));
-    }
-
-    // rivet: verifies REQ-007
-    #[test]
-    fn no_mermaid_means_no_change() {
-        let html = "<p>plain description with <code>foo</code></p>";
-        assert_eq!(wrap_markdown_mermaid_in_svg_viewer(html), html);
-    }
-
-    // rivet: verifies REQ-007
-    #[test]
-    fn wraps_multiple_mermaid_blocks() {
-        let html =
-            "<pre class=\"mermaid\">A</pre> mid <pre class=\"mermaid\">B</pre>";
-        let wrapped = wrap_markdown_mermaid_in_svg_viewer(html);
-        // Two viewer wrappers present.
-        assert_eq!(wrapped.matches("<div class=\"svg-viewer\">").count(), 2);
-        assert_eq!(wrapped.matches("svg-viewer-toolbar").count(), 2);
-    }
-}
-
 // ── Artifacts list ────────────────────────────────────────────────────────
 
 pub(crate) fn render_artifacts_list(ctx: &RenderContext, params: &ViewParams) -> String {
@@ -904,4 +866,43 @@ fn find_source_ref(s: &str) -> Option<SourceRefMatch> {
         i += 1;
     }
     None
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // rivet: verifies REQ-007 (artifact diagram viewer parity)
+    #[test]
+    fn wraps_single_mermaid_block_in_svg_viewer() {
+        let html = "<p>intro</p><pre class=\"mermaid\">graph LR\nA-->B</pre><p>outro</p>";
+        let wrapped = wrap_markdown_mermaid_in_svg_viewer(html);
+        assert!(wrapped.contains("<div class=\"svg-viewer\">"));
+        assert!(wrapped.contains("svg-viewer-toolbar"));
+        assert!(wrapped.contains("title=\"Fullscreen\""));
+        // Pre block still in place.
+        assert!(wrapped.contains("<pre class=\"mermaid\">graph LR"));
+        // Surrounding paragraphs preserved.
+        assert!(wrapped.contains("<p>intro</p>"));
+        assert!(wrapped.contains("<p>outro</p>"));
+    }
+
+    // rivet: verifies REQ-007
+    #[test]
+    fn no_mermaid_means_no_change() {
+        let html = "<p>plain description with <code>foo</code></p>";
+        assert_eq!(wrap_markdown_mermaid_in_svg_viewer(html), html);
+    }
+
+    // rivet: verifies REQ-007
+    #[test]
+    fn wraps_multiple_mermaid_blocks() {
+        let html = "<pre class=\"mermaid\">A</pre> mid <pre class=\"mermaid\">B</pre>";
+        let wrapped = wrap_markdown_mermaid_in_svg_viewer(html);
+        // Two viewer wrappers present.
+        assert_eq!(wrapped.matches("<div class=\"svg-viewer\">").count(), 2);
+        assert_eq!(wrapped.matches("svg-viewer-toolbar").count(), 2);
+    }
 }

--- a/rivet-cli/src/render/artifacts.rs
+++ b/rivet-cli/src/render/artifacts.rs
@@ -44,6 +44,101 @@ use super::RenderResult;
 use super::helpers::badge_for_type;
 use crate::serve::components::ViewParams;
 
+/// Wrap any `<pre class="mermaid">…</pre>` block inside an HTML fragment
+/// (typically the output of `render_markdown` on an artifact description)
+/// in the shared `.svg-viewer` shell with the standard zoom-fit /
+/// fullscreen / popout toolbar.
+///
+/// The dashboard renders mermaid diagrams from two surfaces:
+///
+/// * The structured `diagram:` field — already wrapped in `.svg-viewer`
+///   by `render_artifact_detail` below.
+/// * Fenced ```mermaid blocks inside the artifact's `description` —
+///   emitted by `rivet_core::markdown::render_markdown` as bare
+///   `<pre class="mermaid">`.
+///
+/// Without this wrapping the description-based diagrams missed the
+/// toolbar, breaking the cross-view diagram-viewer parity contract
+/// pinned by `tests/playwright/artifacts.spec.ts:70`.
+///
+/// The transform is a textual scan rather than a DOM rewrite to keep
+/// the render path dependency-free; pulldown-cmark always emits the
+/// open tag verbatim as `<pre class="mermaid">` (see the
+/// `MERMAID_OPEN` sentinel in `rivet_core::markdown`), so a literal
+/// substring match is reliable.
+fn wrap_markdown_mermaid_in_svg_viewer(html: &str) -> String {
+    const NEEDLE: &str = "<pre class=\"mermaid\">";
+    if !html.contains(NEEDLE) {
+        return html.to_string();
+    }
+    const TOOLBAR: &str = "<div class=\"svg-viewer\">\
+         <div class=\"svg-viewer-toolbar\">\
+           <button onclick=\"svgZoomFit(this)\" title=\"Zoom to fit\">\u{229e}</button>\
+           <button onclick=\"svgFullscreen(this)\" title=\"Fullscreen\">\u{26f6}</button>\
+           <button onclick=\"svgPopout(this)\" title=\"Open in new window\">\u{2197}</button>\
+         </div>";
+    let mut out = String::with_capacity(html.len() + 256);
+    let mut cursor = 0;
+    while let Some(start) = html[cursor..].find(NEEDLE) {
+        let abs_start = cursor + start;
+        out.push_str(&html[cursor..abs_start]);
+        // Find the matching `</pre>` close.  No nested `<pre>` is
+        // possible inside a fenced code block, so the first `</pre>`
+        // after the open is the right one.
+        if let Some(close_rel) = html[abs_start..].find("</pre>") {
+            let close_end = abs_start + close_rel + "</pre>".len();
+            out.push_str(TOOLBAR);
+            out.push_str(&html[abs_start..close_end]);
+            out.push_str("</div>"); // .svg-viewer
+            cursor = close_end;
+        } else {
+            // Unterminated — emit the rest as-is and stop.
+            out.push_str(&html[abs_start..]);
+            return out;
+        }
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+#[cfg(test)]
+mod mermaid_wrap_tests {
+    use super::*;
+
+    // rivet: verifies REQ-007 (artifact diagram viewer parity)
+    #[test]
+    fn wraps_single_mermaid_block_in_svg_viewer() {
+        let html = "<p>intro</p><pre class=\"mermaid\">graph LR\nA-->B</pre><p>outro</p>";
+        let wrapped = wrap_markdown_mermaid_in_svg_viewer(html);
+        assert!(wrapped.contains("<div class=\"svg-viewer\">"));
+        assert!(wrapped.contains("svg-viewer-toolbar"));
+        assert!(wrapped.contains("title=\"Fullscreen\""));
+        // Pre block still in place.
+        assert!(wrapped.contains("<pre class=\"mermaid\">graph LR"));
+        // Surrounding paragraphs preserved.
+        assert!(wrapped.contains("<p>intro</p>"));
+        assert!(wrapped.contains("<p>outro</p>"));
+    }
+
+    // rivet: verifies REQ-007
+    #[test]
+    fn no_mermaid_means_no_change() {
+        let html = "<p>plain description with <code>foo</code></p>";
+        assert_eq!(wrap_markdown_mermaid_in_svg_viewer(html), html);
+    }
+
+    // rivet: verifies REQ-007
+    #[test]
+    fn wraps_multiple_mermaid_blocks() {
+        let html =
+            "<pre class=\"mermaid\">A</pre> mid <pre class=\"mermaid\">B</pre>";
+        let wrapped = wrap_markdown_mermaid_in_svg_viewer(html);
+        // Two viewer wrappers present.
+        assert_eq!(wrapped.matches("<div class=\"svg-viewer\">").count(), 2);
+        assert_eq!(wrapped.matches("svg-viewer-toolbar").count(), 2);
+    }
+}
+
 // ── Artifacts list ────────────────────────────────────────────────────────
 
 pub(crate) fn render_artifacts_list(ctx: &RenderContext, params: &ViewParams) -> String {
@@ -451,9 +546,15 @@ pub(crate) fn render_artifact_detail(ctx: &RenderContext, id: &str) -> RenderRes
         html_escape(&artifact.title)
     ));
     if let Some(desc) = &artifact.description {
+        // Render markdown, then wrap any `<pre class="mermaid">` blocks in
+        // the same `.svg-viewer` toolbar shell used by the dedicated
+        // `diagram:` field below — so a mermaid diagram embedded in a
+        // description gets the same zoom-fit / fullscreen / popout
+        // controls as one supplied via the structured field. Pins the
+        // diagram-viewer parity contract (tests/playwright/artifacts.spec.ts:70).
+        let rendered = wrap_markdown_mermaid_in_svg_viewer(&render_markdown(desc));
         html.push_str(&format!(
-            "<dt>Description</dt><dd class=\"artifact-desc\">{}</dd>",
-            render_markdown(desc)
+            "<dt>Description</dt><dd class=\"artifact-desc artifact-diagram\">{rendered}</dd>"
         ));
     }
     if let Some(status) = &artifact.status {

--- a/rivet-cli/src/serve/layout.rs
+++ b/rivet-cli/src/serve/layout.rs
@@ -200,13 +200,18 @@ pub(crate) fn page_layout_with_variant(
         s
     };
     // Variant selector: only rendered when the project has a feature model.
+    //
+    // The change handler is wired up in the variant-sync script (below)
+    // via `addEventListener('change', …)` instead of an inline `onchange`
+    // attribute. Inline handlers are blocked by some headless Chromium
+    // configs (e.g. Playwright's default page CSP) and can be silently
+    // skipped when the selectOption action mutates the DOM via the
+    // accessibility tree. The addEventListener route runs in every
+    // env we care about.
     let variant_selector_html = if state.variants.has_model() {
         let mut s = String::from(
             "<span class=\"ctx-sep\">/</span>\
              <select id=\"variant-selector\" name=\"variant\" \
-             onchange=\"(function(sel){var u=new URL(window.location.href);\
-             if(sel.value){u.searchParams.set('variant',sel.value)}else{u.searchParams.delete('variant')}\
-             window.location.href=u.toString()})(this)\" \
              style=\"padding:.2rem .5rem;font-size:.72rem;font-family:var(--mono);\
              background:var(--surface);color:var(--text);border:1px solid var(--border);\
              border-radius:4px;max-width:220px\" \
@@ -323,6 +328,23 @@ document.addEventListener('DOMContentLoaded',renderMermaid);
   }}
   document.addEventListener('htmx:afterSettle',sync);
   document.addEventListener('htmx:pushedIntoHistory',sync);
+
+  // Variant dropdown navigation: setting `?variant=...` (or clearing it)
+  // and reloading. Implemented via `change` event listener instead of an
+  // inline onchange so that:
+  //   1. CSP profiles that block inline event handlers still work.
+  //   2. Playwright's selectOption() reliably triggers the navigation
+  //      (Chromium fires `change` after selectOption; an inline onchange
+  //      attribute was occasionally skipped, leaving `tests/playwright/
+  //      serve-variant.spec.ts:25` stuck on the original URL).
+  document.addEventListener('change', function(e){{
+    var sel = e.target;
+    if(!sel || sel.id !== 'variant-selector') return;
+    var u = new URL(window.location.href);
+    if(sel.value){{ u.searchParams.set('variant', sel.value); }}
+    else {{ u.searchParams.delete('variant'); }}
+    window.location.href = u.toString();
+  }});
 }})();
 </script>
 </head>

--- a/rivet-cli/src/serve/mod.rs
+++ b/rivet-cli/src/serve/mod.rs
@@ -864,33 +864,64 @@ pub async fn run(app_state: AppState, bind: String, watch: bool) -> Result<()> {
             mcp_config,
         );
 
+    // Build the dashboard view routes once, then mount them at both
+    // `/` (the regular dashboard) and `/embed` (sidebar-free for
+    // iframe / VS Code WebView embedding).
+    //
+    // Mounting via `Router::nest` is the supported axum 0.8 way to
+    // handle prefix-stripping — the inner router sees `/artifacts/{id}`
+    // for both `/artifacts/REQ-001` and `/embed/artifacts/REQ-001`. An
+    // earlier version of `wrap_full_page` tried to strip `/embed` by
+    // mutating the request URI in middleware, but axum 0.8's router
+    // ignores URI mutation done in `from_fn_with_state` middleware
+    // (the matcher uses internal path state set up beforehand). The
+    // result was a wrapped 404 — see `tests/serve_integration.rs ::
+    // embed_artifact_returns_200_with_embed_layout` for the regression
+    // guard.
+    let view_routes = || -> Router<SharedState> {
+        Router::new()
+            .route("/", get(views::index))
+            .route("/artifacts", get(views::artifacts_list))
+            .route("/artifacts/{id}", get(views::artifact_detail))
+            .route("/artifacts/{id}/preview", get(views::artifact_preview))
+            .route("/artifacts/{id}/graph", get(views::artifact_graph))
+            .route("/validate", get(views::validate_view))
+            .route("/matrix", get(views::matrix_view))
+            .route("/matrix/cell", get(views::matrix_cell_detail))
+            .route("/graph", get(views::graph_view))
+            .route("/stats", get(views::stats_view))
+            .route("/coverage", get(views::coverage_view))
+            .route("/documents", get(views::documents_list))
+            .route("/documents/{id}", get(views::document_detail))
+            .route("/search", get(views::search_view))
+            .route("/verification", get(views::verification_view))
+            .route("/stpa", get(views::stpa_view))
+            .route("/eu-ai-act", get(views::eu_ai_act_view))
+            .route("/results", get(views::results_view))
+            .route("/results/{run_id}", get(views::result_detail))
+            .route("/source", get(views::source_tree_view))
+            .route("/source/{*path}", get(views::source_file_view))
+            .route("/diff", get(views::diff_view))
+            .route("/doc-linkage", get(views::doc_linkage_view))
+            .route("/traceability", get(views::traceability_view))
+            .route("/traceability/history", get(views::traceability_history))
+            .route("/help", get(views::help_view))
+            .route("/help/docs", get(views::help_docs_list))
+            .route("/help/docs/{*slug}", get(views::help_docs_topic))
+            .route("/help/schema", get(views::help_schema_list))
+            .route("/help/schema/{name}", get(views::help_schema_show))
+            .route("/help/links", get(views::help_links_view))
+            .route("/help/rules", get(views::help_rules_view))
+            .route("/externals", get(views::externals_list))
+            .route("/externals/{prefix}", get(views::external_detail))
+            .route("/variants", get(views::variants_list))
+    };
+
     let app = Router::new()
-        .route("/", get(views::index))
-        .route("/artifacts", get(views::artifacts_list))
-        .route("/artifacts/{id}", get(views::artifact_detail))
-        .route("/artifacts/{id}/preview", get(views::artifact_preview))
-        .route("/artifacts/{id}/graph", get(views::artifact_graph))
-        .route("/validate", get(views::validate_view))
-        .route("/matrix", get(views::matrix_view))
-        .route("/matrix/cell", get(views::matrix_cell_detail))
-        .route("/graph", get(views::graph_view))
-        .route("/stats", get(views::stats_view))
-        .route("/coverage", get(views::coverage_view))
-        .route("/documents", get(views::documents_list))
-        .route("/documents/{id}", get(views::document_detail))
-        .route("/search", get(views::search_view))
-        .route("/verification", get(views::verification_view))
-        .route("/stpa", get(views::stpa_view))
-        .route("/eu-ai-act", get(views::eu_ai_act_view))
-        .route("/results", get(views::results_view))
-        .route("/results/{run_id}", get(views::result_detail))
-        .route("/source", get(views::source_tree_view))
-        .route("/source/{*path}", get(views::source_file_view))
+        .merge(view_routes())
+        .nest("/embed", view_routes())
+        // Routes that exist only at the root (assets, APIs, hooks).
         .route("/source-raw/{*path}", get(source_raw))
-        .route("/diff", get(views::diff_view))
-        .route("/doc-linkage", get(views::doc_linkage_view))
-        .route("/traceability", get(views::traceability_view))
-        .route("/traceability/history", get(views::traceability_history))
         .route("/api/links/{id}", get(api_artifact_links))
         .route("/oembed", get(api::oembed))
         .nest(
@@ -905,16 +936,6 @@ pub async fn run(app_state: AppState, bind: String, watch: bool) -> Result<()> {
                 .with_state(state.clone()),
         )
         .route("/wasm/{*path}", get(wasm_asset))
-        .route("/help", get(views::help_view))
-        .route("/help/docs", get(views::help_docs_list))
-        .route("/help/docs/{*slug}", get(views::help_docs_topic))
-        .route("/help/schema", get(views::help_schema_list))
-        .route("/help/schema/{name}", get(views::help_schema_show))
-        .route("/help/links", get(views::help_links_view))
-        .route("/help/rules", get(views::help_rules_view))
-        .route("/externals", get(views::externals_list))
-        .route("/externals/{prefix}", get(views::external_detail))
-        .route("/variants", get(views::variants_list))
         .route("/docs-asset/{*path}", get(docs_asset))
         .route("/assets/htmx.js", get(htmx_asset))
         .route("/assets/mermaid.js", get(mermaid_asset))
@@ -979,37 +1000,18 @@ async fn wrap_full_page(
         || original_path == "/embed";
     let method = req.method().clone();
 
-    // Strip /embed prefix so existing route handlers match.
+    // The /embed/* routes are registered separately via
+    // `Router::nest("/embed", …)` (see `run` above) so we do NOT mutate
+    // the request URI here.  An earlier version of this middleware
+    // tried to strip /embed in-place via `head.uri = rewritten`, but
+    // axum 0.8's router consults internal path state set up before
+    // top-level `from_fn_with_state` middleware runs and ignores the
+    // URI mutation — confirmed by `tests/serve_integration.rs ::
+    // embed_artifact_returns_200_with_embed_layout`, which kept seeing
+    // a wrapped 404 with the in-place rewrite.
     //
-    // axum 0.8 routing uses `req.uri().path()` at request-time to
-    // dispatch, so rewriting the URI in a top-level middleware is
-    // sufficient to redirect /embed/foo → /foo without registering
-    // duplicate routes.  Two subtleties:
-    //
-    //   1. `Uri::from_parts(parts).unwrap()` can panic if the URI loses
-    //      its scheme/authority and we keep them set; build the new URI
-    //      directly from path+query so the result is a relative-form URI
-    //      (which is what hyper hands axum for incoming requests anyway).
-    //   2. The matcher in axum 0.8 also caches `OriginalUri` in
-    //      extensions; we don't strip that, so callers that inspect the
-    //      original /embed/... path can still do so.
-    let req = if is_embed && original_path.starts_with("/embed") {
-        let new_path = original_path.strip_prefix("/embed").unwrap_or("/");
-        let new_path = if new_path.is_empty() { "/" } else { new_path };
-        let new_pq = if query.is_empty() {
-            new_path.to_string()
-        } else {
-            format!("{new_path}?{query}")
-        };
-        let new_uri: axum::http::Uri = new_pq
-            .parse()
-            .expect("rewritten /embed path is a valid relative URI");
-        let (mut head, body) = req.into_parts();
-        head.uri = new_uri;
-        axum::extract::Request::from_parts(head, body)
-    } else {
-        req
-    };
+    // What we still need from `is_embed` here: pick the right layout
+    // when wrapping the inner handler's HTML body below.
     let path = if is_embed && original_path.starts_with("/embed") {
         original_path
             .strip_prefix("/embed")

--- a/rivet-cli/src/serve/mod.rs
+++ b/rivet-cli/src/serve/mod.rs
@@ -979,18 +979,31 @@ async fn wrap_full_page(
         || original_path == "/embed";
     let method = req.method().clone();
 
-    // Strip /embed prefix so existing route handlers match
+    // Strip /embed prefix so existing route handlers match.
+    //
+    // axum 0.8 routing uses `req.uri().path()` at request-time to
+    // dispatch, so rewriting the URI in a top-level middleware is
+    // sufficient to redirect /embed/foo → /foo without registering
+    // duplicate routes.  Two subtleties:
+    //
+    //   1. `Uri::from_parts(parts).unwrap()` can panic if the URI loses
+    //      its scheme/authority and we keep them set; build the new URI
+    //      directly from path+query so the result is a relative-form URI
+    //      (which is what hyper hands axum for incoming requests anyway).
+    //   2. The matcher in axum 0.8 also caches `OriginalUri` in
+    //      extensions; we don't strip that, so callers that inspect the
+    //      original /embed/... path can still do so.
     let req = if is_embed && original_path.starts_with("/embed") {
         let new_path = original_path.strip_prefix("/embed").unwrap_or("/");
         let new_path = if new_path.is_empty() { "/" } else { new_path };
-        let mut parts = req.uri().clone().into_parts();
         let new_pq = if query.is_empty() {
             new_path.to_string()
         } else {
             format!("{new_path}?{query}")
         };
-        parts.path_and_query = Some(new_pq.parse().unwrap());
-        let new_uri = axum::http::Uri::from_parts(parts).unwrap();
+        let new_uri: axum::http::Uri = new_pq
+            .parse()
+            .expect("rewritten /embed path is a valid relative URI");
         let (mut head, body) = req.into_parts();
         head.uri = new_uri;
         axum::extract::Request::from_parts(head, body)
@@ -1010,12 +1023,20 @@ async fn wrap_full_page(
 
     // Only wrap GET requests to view routes (not assets or APIs)
     // For "/" without print/embed, the index handler already renders the full page.
+    //
+    // /search is a fragment-only endpoint — the Cmd+K JS fetches it via
+    // `fetch()` (no `HX-Request` header) and dumps the body into
+    // `#cmd-k-results`. If we wrap it in the full layout, a second
+    // `<input id="cmd-k-input">` ends up nested inside `#cmd-k-results`,
+    // tripping Playwright's strict-mode locator and confusing keyboard
+    // navigation. Treat /search like the other API endpoints.
     if method == axum::http::Method::GET
         && !is_htmx
         && (path != "/" || is_print || is_embed)
         && !path.starts_with("/api/")
         && !path.starts_with("/mcp")
         && !path.starts_with("/oembed")
+        && !path.starts_with("/search")
         && !path.starts_with("/assets/")
         && !path.starts_with("/wasm/")
         && !path.starts_with("/source-raw/")

--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -1106,3 +1106,64 @@ fn stats_page_shows_variant_banner_when_scoped() {
     child.kill().ok();
     child.wait().ok();
 }
+
+// ── /embed/* path rewriting (REQ-007 + tests/playwright/api.spec.ts:291) ──
+
+#[test]
+fn embed_artifact_returns_200_with_embed_layout() {
+    // Regression: the wrap_full_page middleware strips /embed and routes
+    // to /artifacts/{id} so the dashboard can iframe-embed an artifact
+    // without registering duplicate routes.  A previous URI-rewriting
+    // bug (round-tripping `Uri::into_parts` / `from_parts`) left the
+    // inner router with an empty matched path, returning a wrapped 404
+    // — exactly the symptom Playwright's api.spec.ts:291 catches.
+    let (mut child, port) = start_server();
+    let (status, body, _) = fetch(port, "/embed/artifacts/REQ-001", false);
+    assert_eq!(
+        status, 200,
+        "/embed/artifacts/REQ-001 must route through to artifact_detail"
+    );
+    // embed_layout (no nav, no .shell) — distinct from page_layout.
+    assert!(
+        !body.contains("class=\"shell\""),
+        "/embed/* must not render the sidebar shell"
+    );
+    assert!(
+        !body.contains("Main navigation"),
+        "/embed/* must not render the main nav"
+    );
+    // Artifact body still renders (REQ-001 always exists in the test fixture).
+    assert!(
+        body.contains("REQ-001"),
+        "embed body must contain the artifact ID, got body of length {}",
+        body.len()
+    );
+    // htmx is loaded so the embedded view stays interactive.
+    assert!(
+        body.contains("htmx"),
+        "embed body must include htmx (script tag)"
+    );
+    child.kill().ok();
+    child.wait().ok();
+}
+
+#[test]
+fn embed_unknown_artifact_returns_200_with_not_found_body() {
+    // Unknown artifact under /embed should still go through the embed
+    // layout — render_artifact_detail returns a 200 with a "Not Found"
+    // body, which the embed wrap preserves. Exercises the same
+    // middleware-strip path as the happy case.
+    let (mut child, port) = start_server();
+    let (status, body, _) = fetch(port, "/embed/artifacts/DOES-NOT-EXIST", false);
+    assert_eq!(status, 200);
+    assert!(
+        body.contains("Not Found"),
+        "embed body for unknown artifact should include 'Not Found'"
+    );
+    assert!(
+        !body.contains("Main navigation"),
+        "/embed/* must not render the main nav even for not-found"
+    );
+    child.kill().ok();
+    child.wait().ok();
+}

--- a/tests/playwright/diagram-viewer.spec.ts
+++ b/tests/playwright/diagram-viewer.spec.ts
@@ -19,8 +19,11 @@ const VIEWER_PAGES = [
   { name: "graph", url: "/graph?limit=2000" },
   // Doc linkage view.
   { name: "doc-linkage", url: "/doc-linkage" },
-  // Help / schema page renders the schema-linkage mermaid diagram.
-  { name: "schema-linkage", url: "/help/schema" },
+  // /help renders the schema-linkage mermaid diagram (a Schema Linkage
+  // card showing artifact-type relationships in the dashboard's design
+  // language). The diagram lives on the help index, not /help/schema —
+  // /help/schema is the type-list table.
+  { name: "schema-linkage", url: "/help" },
 ];
 
 for (const page of VIEWER_PAGES) {

--- a/tests/playwright/filter-sort.spec.ts
+++ b/tests/playwright/filter-sort.spec.ts
@@ -236,8 +236,14 @@ test.describe("Artifacts Filter/Sort/Pagination", () => {
     // Verify the input is wired for URL push-on-type.
     await expect(searchInput).toHaveAttribute("hx-push-url", "true");
 
-    // Type a query — HTMX fires a debounced hx-get and pushes the URL.
-    await searchInput.fill("OSLC");
+    // Type a query — HTMX fires a debounced hx-get on `keyup changed`
+    // (see rivet-cli/src/serve/components.rs ~line 216), so we need to
+    // generate real keypress events. Playwright's `fill()` sets the
+    // value via JS and only fires `input`, not `keyup`, so HTMX would
+    // never see the trigger. `pressSequentially` types one char at a
+    // time, dispatching keydown/keypress/keyup for each.
+    await searchInput.click();
+    await searchInput.pressSequentially("OSLC");
     await waitForHtmx(page);
 
     // URL must now carry ?q=OSLC.

--- a/tests/playwright/rivet-delta.spec.ts
+++ b/tests/playwright/rivet-delta.spec.ts
@@ -190,6 +190,11 @@ test.describe("rivet-delta PR-comment output", () => {
     await expect(
       page.locator("h2", { hasText: "Rivet artifact delta" }),
     ).toBeVisible();
+    // REQ-NEW-1 lives inside the collapsed <details><summary>Added</summary>
+    // block (rendered by scripts/diff-to-markdown.mjs:181-188), so it is
+    // attached to the DOM but not "visible" until that <details> is
+    // expanded. Open it before checking visibility.
+    await page.locator("details summary", { hasText: "Added" }).click();
     await expect(
       page
         .locator("code:not(.language-mermaid)", { hasText: "REQ-NEW-1" })


### PR DESCRIPTION
## Summary

CI on `main` has been failing Playwright for ~25 consecutive runs. After
PR #214 bumped the per-test timeout to 60s the cascading timeout failures
(graph viewer, variant nav) cleared, leaving **eight real failures** in
the latest run on 58801b6. This PR fixes all eight, split between tests,
render, and serve.

| # | Test | Class | Fix |
|---|------|-------|-----|
| 1 | `artifacts.spec.ts:70` artifact mermaid → svg-viewer | render | wrap `<pre class=\"mermaid\">` from description in `.svg-viewer` |
| 2 | `diagram-viewer.spec.ts:27` schema-linkage toolbar | test | URL was `/help/schema` (type-list); diagram lives on `/help` |
| 3 | `diagram-viewer.spec.ts:46` schema-linkage fullscreen | test | same URL fix |
| 4 | `filter-sort.spec.ts:225` `?q=` push-url | test | `fill()` doesn't fire `keyup`; switch to `pressSequentially()` |
| 5 | `filter-sort.spec.ts:253` Cmd+K reload | serve | bypass `/search` in `wrap_full_page` middleware (was duplicating `#cmd-k-input` into `#cmd-k-results`) |
| 6 | `rivet-delta.spec.ts:142` shipping summary | test | `REQ-NEW-1` lives inside collapsed `<details>Added`; expand before asserting visibility |
| 7 | `serve-variant.spec.ts:25` variant nav | serve | inline `onchange` was occasionally skipped under selectOption; switch to delegated `change` listener |
| 8 | `api.spec.ts:291` /embed/* returns 404 | serve | mount dashboard view routes under `/embed` via `Router::nest` (axum 0.8 ignores middleware-driven URI rewrites — see commit ef3d00b) |

## Why these are the right fixes

### artifacts.spec.ts:70 — render fix

`ARCH-CORE-001` has a fenced ` ```mermaid ` block in its
**description**, not in the structured `diagram:` field. The dedicated
field already wraps in `.svg-viewer`; the description path emitted a
bare `<pre class=\"mermaid\">` from `render_markdown`. New helper
`wrap_markdown_mermaid_in_svg_viewer` post-processes the rendered
description and wraps each mermaid block in the same toolbar shell
(zoom-fit / fullscreen / popout). Three unit tests pin the wrapping
behaviour.

### serve middleware — `/search` bypass

The Cmd+K JS does `fetch('/search?q=...')` (no HX-Request header) and
dumps the response into `#cmd-k-results`. Without bypass, the
`wrap_full_page` middleware wraps `/search` in the full layout — that
layout contains another `<input id=\"cmd-k-input\">`, and after the
fetch resolves you have two `#cmd-k-input` nodes in the DOM. Playwright's
strict-mode locator was failing on the duplicate after reload.

### serve routing — `/embed/*` via Router::nest

The previous wrap_full_page middleware tried to strip /embed by
mutating the request URI in-place:

```rust
let (mut head, body) = req.into_parts();
head.uri = rewritten;          // axum 0.8 ignores this
next.run(Request::from_parts(head, body)).await
```

axum 0.8 routes against internal path state set up before
`from_fn_with_state` middleware runs, so the URI mutation is silently
ignored — the inner router still sees `/embed/...` and returns 404. New
integration test `embed_artifact_returns_200_with_embed_layout`
reproduces this exact 404 and pins the desired behaviour.

The fix is to use the axum-supported `Router::nest(\"/embed\", view_routes())`
pattern: extract the dashboard view routes into a builder closure and
mount them at both `/` and `/embed`. axum's `nest` strips the prefix
when delegating to the inner router, so `/embed/artifacts/REQ-001`
reaches the same `artifact_detail` handler as `/artifacts/REQ-001`.
The middleware still picks the embed layout when wrapping the response
body, but no longer touches the URI.

### Variant onchange — inline → addEventListener

Inline `onchange=\"...\"` attributes are flaky under headless Chromium
when the change event is fired by Playwright's `selectOption()` — the
attribute parses fine but is occasionally not invoked (visible in the
trace: option shows `[selected]`, URL unchanged). Delegating to a
single `addEventListener('change', ...)` in the variant-sync script
fires reliably across all environments and is also more CSP-friendly.

### Test-code fixes

- `pressSequentially` instead of `fill` because the HTMX trigger is
  `keyup changed delay:300ms`; `fill()` only fires `input`.
- `<details>Added</details>` must be expanded before asserting
  visibility on its content — REQ-NEW-1 lives inside.
- `/help` is where the schema-linkage mermaid renders;
  `/help/schema` is the type-list table.

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo clippy --release -p rivet-cli --all-targets -- -D warnings` — clean
- [x] `cargo test --release --bin rivet -- mermaid_wrap` — 3/3 pass
- [x] `cargo test --release --test serve_integration -- embed` — 10/10 pass
       (including new `embed_artifact_returns_200_with_embed_layout`,
       `embed_unknown_artifact_returns_200_with_not_found_body`)
- [x] `cargo test --release --test serve_integration -- oembed` — 6/6 pass
- [ ] CI Playwright job — all 384 tests pass (or the failure is one of
      the pre-existing flakes outside this PR's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)