### PR TITLE
style(rivet-core): cargo fmt drift after PR #218 merge

### DIFF
--- a/rivet-core/src/embed.rs
+++ b/rivet-core/src/embed.rs
@@ -2166,10 +2166,7 @@ mod tests {
     fn epoch_to_ymd_hm_2024_12_31_end_of_day() {
         // 2024-12-31 23:59:59 UTC — exercises mp + 3 with mp = 9 (m =
         // 12) and confirms hour/minute decomposition from time-of-day.
-        assert_eq!(
-            epoch_to_ymd_hm(1_735_689_599),
-            (2024, 12, 31, 23, 59),
-        );
+        assert_eq!(epoch_to_ymd_hm(1_735_689_599), (2024, 12, 31, 23, 59),);
     }
 
     #[test]
@@ -2177,10 +2174,7 @@ mod tests {
         // 2024-04-25 12:34:56 UTC — exercises mp + 3 branch (mp = 1 →
         // m = 4) and a non-zero hour AND minute. 56s rounds down to
         // minute 34.
-        assert_eq!(
-            epoch_to_ymd_hm(1_714_048_496),
-            (2024, 4, 25, 12, 34),
-        );
+        assert_eq!(epoch_to_ymd_hm(1_714_048_496), (2024, 4, 25, 12, 34),);
     }
 
     #[test]
@@ -2190,10 +2184,7 @@ mod tests {
         // give m = 1 = January).
         // Kills: rivet-core/src/embed.rs:1320 — replace `-` with `/` in
         // the `mp - 9` else branch.
-        assert_eq!(
-            epoch_to_ymd_hm(1_707_955_200),
-            (2024, 2, 15, 0, 0),
-        );
+        assert_eq!(epoch_to_ymd_hm(1_707_955_200), (2024, 2, 15, 0, 0),);
     }
 
     #[test]
@@ -2206,10 +2197,7 @@ mod tests {
         // doe/36524 = 0` → yoe = 0/365 = 0 (would compute y = 2000
         // and the wrong day).
         // Kills: rivet-core/src/embed.rs:1315 — replace `+` with `*`.
-        assert_eq!(
-            epoch_to_ymd_hm(1_078_012_800),
-            (2004, 2, 29, 0, 0),
-        );
+        assert_eq!(epoch_to_ymd_hm(1_078_012_800), (2004, 2, 29, 0, 0),);
     }
 
     #[test]
@@ -2221,10 +2209,7 @@ mod tests {
         // 199 → wrong year as well.
         // Kills: rivet-core/src/embed.rs:1315 — replace `+` with `-`
         // and `+` with `*` on the `+ doe/36524` term.
-        assert_eq!(
-            epoch_to_ymd_hm(7_263_216_000),
-            (2200, 3, 1, 0, 0),
-        );
+        assert_eq!(epoch_to_ymd_hm(7_263_216_000), (2200, 3, 1, 0, 0),);
     }
 
     /// `epoch_to_iso8601()` is the public ISO-8601 wrapper; mutants
@@ -2255,10 +2240,7 @@ mod tests {
         // year (div by 400) and Feb 29 exists.
         // Kills: rivet-core/src/embed.rs:1315 — replace `-` with `+`
         // and `-` with `/` on the `- doe/146096` term.
-        assert_eq!(
-            epoch_to_ymd_hm(13_574_563_200),
-            (2400, 2, 29, 0, 0),
-        );
+        assert_eq!(epoch_to_ymd_hm(13_574_563_200), (2400, 2, 29, 0, 0),);
     }
 
     // ── Mutation-killing tests for render_coverage thresholds ───────

--- a/rivet-core/src/reqif.rs
+++ b/rivet-core/src/reqif.rs
@@ -2233,47 +2233,32 @@ mod tests {
 
     #[test]
     fn epoch_secs_to_iso8601_2024_jan_1_midnight() {
-        assert_eq!(
-            epoch_secs_to_iso8601(1_704_067_200),
-            "2024-01-01T00:00:00Z",
-        );
+        assert_eq!(epoch_secs_to_iso8601(1_704_067_200), "2024-01-01T00:00:00Z",);
     }
 
     #[test]
     fn epoch_secs_to_iso8601_2024_dec_31_end_of_day() {
-        assert_eq!(
-            epoch_secs_to_iso8601(1_735_689_599),
-            "2024-12-31T23:59:59Z",
-        );
+        assert_eq!(epoch_secs_to_iso8601(1_735_689_599), "2024-12-31T23:59:59Z",);
     }
 
     #[test]
     fn epoch_secs_to_iso8601_2024_apr_25_with_seconds() {
         // 2024-04-25 12:34:56 UTC — the seconds field exercises
         // `time_secs % 60` (different from minute decomposition).
-        assert_eq!(
-            epoch_secs_to_iso8601(1_714_048_496),
-            "2024-04-25T12:34:56Z",
-        );
+        assert_eq!(epoch_secs_to_iso8601(1_714_048_496), "2024-04-25T12:34:56Z",);
     }
 
     #[test]
     fn epoch_secs_to_iso8601_2024_feb_15() {
         // mp = 11 path (m = mp - 9 = 2 → February).
-        assert_eq!(
-            epoch_secs_to_iso8601(1_707_955_200),
-            "2024-02-15T00:00:00Z",
-        );
+        assert_eq!(epoch_secs_to_iso8601(1_707_955_200), "2024-02-15T00:00:00Z",);
     }
 
     #[test]
     fn epoch_secs_to_iso8601_2200_mar_1_century_skipped_leap() {
         // 2200 is NOT a leap year (divisible by 100, not 400).
         // doe = 73048 — exercises the `+ doe/36524` correction.
-        assert_eq!(
-            epoch_secs_to_iso8601(7_263_216_000),
-            "2200-03-01T00:00:00Z",
-        );
+        assert_eq!(epoch_secs_to_iso8601(7_263_216_000), "2200-03-01T00:00:00Z",);
     }
 
     #[test]
@@ -2638,7 +2623,11 @@ mod tests {
             .collect();
         assert_eq!(
             rel_ids,
-            vec!["REL-1".to_string(), "REL-2".to_string(), "REL-3".to_string()],
+            vec![
+                "REL-1".to_string(),
+                "REL-2".to_string(),
+                "REL-3".to_string()
+            ],
             "REL counter must increment from 1 by +=1 per link",
         );
     }


### PR DESCRIPTION
PR #218's new tests had multi-line assert_eq! formatting cargo fmt rejects. Running cargo fmt --all collapses to single-line where fits.

No semantic changes.