### PR TITLE
fix(aspice): seed validates clean after init

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1980,6 +1980,18 @@ artifacts:
 
 const ASPICE_SAMPLE: &str = "\
 artifacts:
+  - id: STKHR-001
+    type: stakeholder-req
+    title: Operators need full sensor history for fleet diagnostics
+    status: draft
+    description: >
+      Fleet operators need access to a complete time-series record of
+      every sensor reading so anomalies discovered post-trip can be
+      diagnosed against ground-truth data.
+    fields:
+      priority: must
+      source: fleet-operations-stakeholder-doc-v1
+
   - id: SYSREQ-001
     type: system-req
     title: System shall provide data logging
@@ -1991,6 +2003,9 @@ artifacts:
       priority: must
       verification-criteria: >
         Verify that sensor data is recorded at 100Hz under nominal load.
+    links:
+      - type: derives-from
+        target: STKHR-001
 
   - id: SWREQ-001
     type: sw-req

--- a/schemas/aspice.yaml
+++ b/schemas/aspice.yaml
@@ -419,6 +419,19 @@ link-types:
     source-types: [verification-verdict]
     target-types: [verification-execution]
 
+  # `allocated-from` is the forward direction used by ASPICE
+  # `sw-arch-component` to point at its allocating sw-req. The common
+  # schema declares the inverse-named pair (`allocated-to` with
+  # `inverse: allocated-from`) but only registers the forward token
+  # `allocated-to`. ASPICE swaps the canonical direction for SWE.2,
+  # so we declare `allocated-from` here as a forward link-type to
+  # avoid the gotcha-G.3 footgun in the seed.
+  - name: allocated-from
+    inverse: allocated-to
+    description: SW arch component is allocated from a SW requirement (SWE.2)
+    source-types: [sw-arch-component]
+    target-types: [sw-req, system-arch-component]
+
 # ──────────────────────────────────────────────────────────────────────────
 # ASPICE traceability rules
 #


### PR DESCRIPTION
## Summary

Round-3 fresh-user dogfood discovered that `rivet init --preset aspice && rivet validate` ships a seed that fails validation with 2 errors:

\`\`\`
ERROR: [SYSREQ-001] link 'derives-from' requires at least 1 target, found 0
ERROR: [SWARCH-001] link type 'allocated-from' is not defined in the schema
Result: FAIL (2 errors)
\`\`\`

This PR fixes both — `rivet init --preset aspice && rivet validate` now returns PASS with 0 errors and 0 warnings.

## Two bugs, two fixes

### 1. Undeclared `allocated-from` link-type

The `common` schema registers only the forward token `allocated-to` (with `inverse: allocated-from`). ASPICE's SWE.2 rule (`swe2-allocated-from-swe1`) uses `allocated-from` as the **forward** direction (sw-arch-component → sw-req), and so does the seed's SWARCH-001. The validator correctly rejects it because no schema declares `allocated-from` as a forward link-type.

This is exactly the gotcha-G.3 footgun the quickstart documents. **Fix**: declare `allocated-from` as a forward link-type in `schemas/aspice.yaml` link-types block, with `inverse: allocated-to`, restricted to `source-types: [sw-arch-component]` / `target-types: [sw-req, system-arch-component]`.

### 2. Missing stakeholder-req parent

ASPICE's `sys2-derives-from-sys1` rule requires every `system-req` to derive from a `stakeholder-req`. The seed's SYSREQ-001 had no `derives-from`. **Fix**: add a STKHR-001 stakeholder-req as the V-model root and wire SYSREQ-001's `derives-from` to it.

## V-model chain after fix

\`\`\`
STKHR-001 (stakeholder-req)
  ← derives-from
SYSREQ-001 (system-req)
  ← derives-from
SWREQ-001 (sw-req)
  ← allocated-from
SWARCH-001 (sw-arch-component)
\`\`\`

This satisfies all three left-V ASPICE rules: `sys2-derives-from-sys1`, `swe1-derives-from-sys`, `swe2-allocated-from-swe1`.

## Verification

\`\`\`
$ rivet init --preset aspice && rivet validate
Result: PASS (0 warnings)
\`\`\`

Two INFOs remain (lifecycle-coverage hints suggesting verification artifacts) — they're advisory, not errors.

## Test plan

- [ ] CI green
- [ ] `rivet init --preset aspice && rivet validate` returns PASS in CI integration test
- [ ] No regression in `rivet init --preset stpa` / `dev` / other presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)