### PR TITLE
feat(validate): warn when prose names an artifact id without a typed link (#207)

### DIFF
--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -40,6 +40,15 @@ use crate::document::DocumentStore;
 use crate::links::LinkGraph;
 use crate::schema::{Cardinality, Schema, Severity};
 use crate::store::Store;
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex matching an artifact-id-shaped token in prose: leading
+/// uppercase letter, optional uppercase / digit chars, a `-`, and a
+/// numeric suffix. `\b` boundaries avoid substrings of larger
+/// identifiers. Matches `H-3`, `REQ-028`, `SYSREQ-001`, `CC-12`, etc.
+static ID_MENTION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b[A-Z][A-Z0-9]*-[0-9]+\b").unwrap());
 
 /// A single validation diagnostic.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -509,6 +518,71 @@ pub fn validate_structural(store: &Store, schema: &Schema, graph: &LinkGraph) ->
                         ),
                     });
                 }
+            }
+        }
+    }
+
+    // 10. Prose-mention without typed link.
+    //
+    // When an artifact's `description` (or a string-typed value in
+    // `fields`) names another artifact id (e.g. "satisfies REQ-028"),
+    // that mention should be matched by a typed link to keep the prose
+    // and the typed graph coherent. Severity is Warning, not Error:
+    // authors sometimes mention an id casually ("similar to DD-001") and
+    // the warning is the discipline nudge — not a hard rule. Use
+    // `--fail-on warning` for projects that want hard enforcement.
+    //
+    // Suppress when:
+    //   * the mention is the artifact's own id (self-reference),
+    //   * the mentioned id does not resolve in the corpus (broken refs
+    //     are a separate concern; see broken-link / doc-broken-ref),
+    //   * the artifact already has any typed link to that id.
+    //
+    // Dedupe per (artifact, mentioned-id) so that prose mentioning
+    // REQ-028 three times yields one warning, matching the
+    // unknown-link-type pass's per-(artifact, link-type) policy.
+    // (BTreeSet is already imported at the top of pass 8 above.)
+    for artifact in store.iter() {
+        let linked_targets: BTreeSet<&str> =
+            artifact.links.iter().map(|l| l.target.as_str()).collect();
+        let mut warned: BTreeSet<String> = BTreeSet::new();
+
+        let mut scan = |text: &str| {
+            for m in ID_MENTION_RE.find_iter(text) {
+                let mentioned = m.as_str();
+                if mentioned == artifact.id {
+                    continue;
+                }
+                if !store.contains(mentioned) {
+                    continue;
+                }
+                if linked_targets.contains(mentioned) {
+                    continue;
+                }
+                if !warned.insert(mentioned.to_string()) {
+                    continue;
+                }
+                diagnostics.push(Diagnostic {
+                    source_file: None,
+                    line: None,
+                    column: None,
+                    severity: Severity::Warning,
+                    artifact_id: Some(artifact.id.clone()),
+                    rule: "prose-mention-without-typed-link".to_string(),
+                    message: format!(
+                        "prose mentions '{mentioned}' but no typed link to it; \
+                         add a link in `links:` or remove the mention"
+                    ),
+                });
+            }
+        };
+
+        if let Some(desc) = &artifact.description {
+            scan(desc);
+        }
+        for value in artifact.fields.values() {
+            if let Some(s) = value.as_str() {
+                scan(s);
             }
         }
     }
@@ -2056,5 +2130,124 @@ then:
              reference to a missing artifact",
         );
         assert_eq!(diags[0].rule, "doc-broken-ref");
+    }
+
+    // --- prose-mention-without-typed-link (issue #207) ---
+    //
+    // Helper: build a two-artifact store where `description_of_a` is
+    // arbitrary prose attached to A-1, and B-1 is a target that may or
+    // may not be referenced by a typed link. Returns just the prose-
+    // mention diagnostics filtered out of a full validation pass.
+    fn prose_mention_diags(
+        description_of_a: Option<&str>,
+        a_fields: Vec<(&str, &str)>,
+        a_links: Vec<Link>,
+    ) -> Vec<Diagnostic> {
+        use crate::store::Store;
+
+        let schema_file = minimal_schema("test");
+        let schema = Schema::merge(&[schema_file]);
+
+        let a = make_artifact("A-1", "test", None, description_of_a, a_fields, a_links);
+        let b = make_artifact("B-1", "test", None, None, vec![], vec![]);
+
+        let mut store = Store::new();
+        store.insert(a).unwrap();
+        store.insert(b).unwrap();
+        let graph = LinkGraph::build(&store, &schema);
+
+        crate::validate::validate(&store, &schema, &graph)
+            .into_iter()
+            .filter(|d| d.rule == "prose-mention-without-typed-link")
+            .collect()
+    }
+
+    // rivet: verifies REQ-004
+    #[test]
+    fn prose_mention_warns_when_no_typed_link() {
+        let diags = prose_mention_diags(Some("This artifact relates to B-1."), vec![], vec![]);
+        assert_eq!(diags.len(), 1, "expected one warning, got {diags:?}");
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].artifact_id.as_deref(), Some("A-1"));
+        assert!(
+            diags[0].message.contains("B-1"),
+            "message should name the mentioned id: {}",
+            diags[0].message
+        );
+    }
+
+    // rivet: verifies REQ-004
+    #[test]
+    fn prose_mention_suppressed_when_typed_link_present() {
+        let diags = prose_mention_diags(
+            Some("This artifact relates to B-1."),
+            vec![],
+            vec![Link {
+                link_type: "satisfies".to_string(),
+                target: "B-1".to_string(),
+            }],
+        );
+        assert!(
+            diags.is_empty(),
+            "typed link to B-1 must suppress prose-mention warning, got {diags:?}"
+        );
+    }
+
+    // rivet: verifies REQ-004
+    #[test]
+    fn prose_mention_suppressed_when_self_reference() {
+        let diags = prose_mention_diags(
+            Some("This artifact, A-1, is the canonical example."),
+            vec![],
+            vec![],
+        );
+        assert!(
+            diags.is_empty(),
+            "self-id mention must not warn, got {diags:?}"
+        );
+    }
+
+    // rivet: verifies REQ-004
+    #[test]
+    fn prose_mention_suppressed_when_id_does_not_resolve() {
+        // GHOST-999 is not in the store; broken-ref handling is a
+        // separate concern, not this rule's job.
+        let diags = prose_mention_diags(Some("Unlike GHOST-999, this works."), vec![], vec![]);
+        assert!(
+            diags.is_empty(),
+            "unresolved id must not warn, got {diags:?}"
+        );
+    }
+
+    // rivet: verifies REQ-004
+    #[test]
+    fn prose_mention_scans_string_field_values() {
+        // The mention is in a string-typed `fields` value, not in
+        // `description`. Should still warn.
+        let diags = prose_mention_diags(
+            None,
+            vec![("rationale", "Decided like B-1 was decided.")],
+            vec![],
+        );
+        assert_eq!(diags.len(), 1, "expected one warning, got {diags:?}");
+        assert!(diags[0].message.contains("B-1"));
+    }
+
+    // rivet: verifies REQ-004
+    #[test]
+    fn prose_mention_dedupes_per_id_per_artifact() {
+        // Three mentions of B-1 in the same description must yield
+        // exactly one warning, matching the unknown-link-type pass's
+        // per-(artifact, link-type) dedup policy.
+        let diags = prose_mention_diags(
+            Some("B-1 here. B-1 again. And once more: B-1."),
+            vec![],
+            vec![],
+        );
+        assert_eq!(
+            diags.len(),
+            1,
+            "repeated mentions of one id must dedupe, got {diags:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #207.

## Summary

`rivet validate` now scans each artifact's `description` (and every string-typed value in its `fields` map) for tokens matching `\b[A-Z][A-Z0-9]*-[0-9]+\b`. When such a mention resolves to an artifact in the corpus and the mentioning artifact has no typed link to it, validate emits a `Warning` diagnostic (`prose-mention-without-typed-link`).

This is the discipline analogue of Karpathy's `[[wikilinks]]` for the typed-graph world — see the issue body's link to the [companion blog post](https://pulseengine.eu/blog/rivet-zettelkasten-with-mechanical-guarantees/).

## Acceptance-criteria mapping (from #207)

The issue body's "Implementation sketch" enumerates testable bullets; mapped 1:1 here:

| Sketch bullet | Where it landed |
|---|---|
| New diagnostic kind in `rivet-core/src/validate.rs` | `prose-mention-without-typed-link`, severity `Warning`, emitted from a new pass-10 in `validate_structural` |
| Pre-compile a regex `\b[A-Z][A-Z0-9]*-[0-9]+\b` (cached statically) | `static ID_MENTION_RE: LazyLock<Regex>` at module scope, mirroring the pattern in `rivet-core/src/markdown.rs` |
| Apply to `description` + every value in `fields` that is a string | `if let Some(desc) = &artifact.description { scan(desc); }` plus iteration over `artifact.fields.values()` filtering `value.as_str()` |
| Skip if it is the artifact's own id | `if mentioned == artifact.id { continue; }` |
| Check if `Store::get(mentioned_id)` resolves; if yes and the artifact has no typed link to it, emit | `store.contains(mentioned)` AND `!linked_targets.contains(mentioned)` (BTreeSet of all link targets, regardless of link type) |
| Tests: warning fires; typed link present → no warning; same-artifact-ID match suppressed | All three covered, plus three more (unresolved id suppresses; string `fields` value is scanned; repeated mentions dedupe to one warning) |

## On `--strict`

The issue mentions a hypothetical `rivet validate --strict` to escalate this warning to an error. rivet already exposes `rivet validate --fail-on warning` (parsed in `rivet-cli/src/main.rs::parse_fail_on`), which fails the run on any warning; that subsumes the hypothetical flag without adding a new CLI surface. A literal severity-changing `--strict` is left for a follow-up if a separate warning-stays-warn-but-rule-becomes-error semantic is wanted.

## Verification

- `cargo test -p rivet-core --lib` — **822 passed, 0 failed** (6 new tests for this rule, all green).
- `cargo test -p rivet-core --tests` — all integration test binaries pass.
- `cargo clippy -p rivet-core --all-targets -- -D warnings` — no new warnings (only the pre-existing MSRV-config mismatch warning).
- `rustfmt --check rivet-core/src/validate.rs` — clean.
- `./target/release/rivet validate` on this repo:
  - Pristine `main`: `FAIL (6 errors, 10 warnings, 0 broken cross-refs)`
  - With this change: `FAIL (6 errors, 68 warnings, 0 broken cross-refs)`
  - **Delta: +58 new prose-mention warnings on rivet's own artifacts** — these are the real authoring-discipline gaps the rule is designed to surface (e.g. `[TEST-027] prose mentions 'FEAT-061' but no typed link to it`). They are not regressions; default `--fail-on error` is unaffected, so CI/release/compliance/pre-commit flows that rely on the default exit-code threshold see no behaviour change. A follow-up clean-up PR can decide which mentions deserve typed links and which should be reworded.

## Tests added (all under `rivet-core/src/validate.rs::tests`, annotated `// rivet: verifies REQ-004`)

- `prose_mention_warns_when_no_typed_link` — positive case: warn fires.
- `prose_mention_suppressed_when_typed_link_present` — typed link to mentioned id suppresses.
- `prose_mention_suppressed_when_self_reference` — self-id mention suppressed.
- `prose_mention_suppressed_when_id_does_not_resolve` — unresolved id suppressed (broken-ref handling is a separate rule).
- `prose_mention_scans_string_field_values` — string-typed `fields` values are scanned, not only `description`.
- `prose_mention_dedupes_per_id_per_artifact` — three mentions of one id yield one warning.

## Test plan

- [x] `cargo fmt --check` on the changed file is clean
- [x] `cargo test -p rivet-core` green (lib + integration)
- [x] `cargo clippy -p rivet-core --all-targets -- -D warnings` clean
- [x] `rivet validate` exit code unchanged on default `--fail-on error`
- [ ] CI green
- [ ] Maintainer confirms the pass-10 placement (after unknown-fields, before conditional rules) is the intended spot
- [ ] Maintainer decides whether the 58 surfaced warnings warrant a follow-up clean-up PR or a temporary `# rivet: ignore prose-mention` mechanism

## Trailers

Per `CLAUDE.md`:
```
Implements: REQ-004
```

Validation change → `REQ-004`.

---

_Generated by [Claude Code](https://claude.com/claude-code) — issue-triage agent run 2026-04-28._

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9L8nhj4vNWvhKnmLQ1tVE)_