### PR TITLE
feat(validate): cited-source typed field + sha256 stamp Phase 1 — kind: file backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,6 +2717,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "tokio",
  "tower-http",

--- a/rivet-cli/Cargo.toml
+++ b/rivet-cli/Cargo.toml
@@ -40,6 +40,7 @@ rmcp = { version = "1.3.0", features = ["server", "transport-io", "macros", "tra
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = "3"
+sha2 = { workspace = true }
 rmcp = { version = "1.3.0", features = ["client", "transport-child-process"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/rivet-cli/src/check/mod.rs
+++ b/rivet-cli/src/check/mod.rs
@@ -23,3 +23,4 @@
 pub mod bidirectional;
 pub mod gaps_json;
 pub mod review_signoff;
+pub mod sources;

--- a/rivet-cli/src/check/sources.rs
+++ b/rivet-cli/src/check/sources.rs
@@ -1,0 +1,333 @@
+//! `rivet check sources` — list / update cited-source stamps.
+//!
+//! Phase 1: only handles `kind: file`. Remote kinds (`url`, `github`,
+//! `oslc`, `reqif`, `polarion`) are listed but skipped with an Info
+//! message that points at `--check-remote-sources` (Phase 2).
+//!
+//! Modes:
+//!
+//! * default — list every artifact carrying a `cited-source`, with
+//!   per-source status: `MATCH`, `DRIFT`, `MISSING-HASH`, `READ-ERROR`,
+//!   `SKIPPED-REMOTE`.
+//! * `--update` — interactive: prompt `[y/N]` per drifted / missing
+//!   stamp, refresh the artifact YAML in place when accepted.
+//! * `--update --apply` — non-interactive batch update.
+//!
+//! JSON contract on `--format json`:
+//! ```json
+//! {
+//!   "oracle": "sources",
+//!   "entries": [
+//!     {
+//!       "artifact_id": "REQ-001",
+//!       "uri": "./doc.md",
+//!       "kind": "file",
+//!       "status": "DRIFT",
+//!       "stamped_sha256": "0000…",
+//!       "computed_sha256": "ba78…",
+//!       "last_checked": "2026-01-01T00:00:00Z"
+//!     }
+//!   ],
+//!   "total": 1,
+//!   "by_status": { "match": 0, "drift": 1, "missing_hash": 0, "read_error": 0, "skipped_remote": 0 }
+//! }
+//! ```
+
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use rivet_core::cited_source::{
+    self, CheckOutcome, CitedSource, check_cited_source, parse_cited_source,
+};
+use rivet_core::model::Artifact;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntryStatus {
+    Match,
+    Drift,
+    MissingHash,
+    ReadError,
+    SkippedRemote,
+    ShapeError,
+}
+
+impl EntryStatus {
+    fn label(self) -> &'static str {
+        match self {
+            EntryStatus::Match => "MATCH",
+            EntryStatus::Drift => "DRIFT",
+            EntryStatus::MissingHash => "MISSING-HASH",
+            EntryStatus::ReadError => "READ-ERROR",
+            EntryStatus::SkippedRemote => "SKIPPED-REMOTE",
+            EntryStatus::ShapeError => "SHAPE-ERROR",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Entry {
+    pub artifact_id: String,
+    pub uri: String,
+    pub kind: String,
+    pub status: EntryStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stamped_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub computed_sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_checked: Option<String>,
+    /// File path on disk for `kind: file` entries (for `--update`).
+    #[serde(skip)]
+    pub source_file: Option<PathBuf>,
+    /// Free-form detail (e.g. read-error reason or shape-error message).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct StatusCounts {
+    pub r#match: usize,
+    pub drift: usize,
+    pub missing_hash: usize,
+    pub read_error: usize,
+    pub skipped_remote: usize,
+    pub shape_error: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Report {
+    pub oracle: &'static str,
+    pub entries: Vec<Entry>,
+    pub total: usize,
+    pub by_status: StatusCounts,
+}
+
+/// Compute the listing report from a slice of artifacts.
+///
+/// `project_root` is used to resolve relative `kind: file` URIs.
+pub fn compute<'a>(
+    artifacts: impl IntoIterator<Item = &'a Artifact>,
+    project_root: &Path,
+) -> Report {
+    let mut entries = Vec::new();
+    let mut by_status = StatusCounts::default();
+
+    for artifact in artifacts {
+        let Some(raw) = artifact.fields.get("cited-source") else {
+            continue;
+        };
+
+        let parsed: CitedSource = match parse_cited_source(raw) {
+            Ok(p) => p,
+            Err(e) => {
+                by_status.shape_error += 1;
+                entries.push(Entry {
+                    artifact_id: artifact.id.clone(),
+                    uri: String::new(),
+                    kind: String::new(),
+                    status: EntryStatus::ShapeError,
+                    stamped_sha256: None,
+                    computed_sha256: None,
+                    last_checked: None,
+                    source_file: artifact.source_file.clone(),
+                    detail: Some(e.to_string()),
+                });
+                continue;
+            }
+        };
+
+        let outcome = check_cited_source(&parsed, project_root, false);
+        let (status, computed, detail) = match &outcome {
+            CheckOutcome::Match => (EntryStatus::Match, None, None),
+            CheckOutcome::Drift { computed } => (EntryStatus::Drift, Some(computed.clone()), None),
+            CheckOutcome::MissingHash { computed } => {
+                (EntryStatus::MissingHash, Some(computed.clone()), None)
+            }
+            CheckOutcome::FileError { reason } => {
+                (EntryStatus::ReadError, None, Some(reason.clone()))
+            }
+            CheckOutcome::SkippedRemote => (EntryStatus::SkippedRemote, None, None),
+        };
+
+        match status {
+            EntryStatus::Match => by_status.r#match += 1,
+            EntryStatus::Drift => by_status.drift += 1,
+            EntryStatus::MissingHash => by_status.missing_hash += 1,
+            EntryStatus::ReadError => by_status.read_error += 1,
+            EntryStatus::SkippedRemote => by_status.skipped_remote += 1,
+            EntryStatus::ShapeError => by_status.shape_error += 1,
+        }
+
+        entries.push(Entry {
+            artifact_id: artifact.id.clone(),
+            uri: parsed.uri.clone(),
+            kind: parsed.kind.as_str().to_string(),
+            status,
+            stamped_sha256: parsed.sha256.clone(),
+            computed_sha256: computed,
+            last_checked: parsed.last_checked.clone(),
+            source_file: artifact.source_file.clone(),
+            detail,
+        });
+    }
+
+    let total = entries.len();
+    Report {
+        oracle: "sources",
+        entries,
+        total,
+        by_status,
+    }
+}
+
+/// Render the report as human text.
+pub fn render_text(report: &Report) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    if report.entries.is_empty() {
+        out.push_str("No artifacts have a cited-source field.\n");
+        return out;
+    }
+    let _ = writeln!(out, "{:<14} {:<14} {:<8} URI", "ARTIFACT", "STATUS", "KIND",);
+    for e in &report.entries {
+        let _ = writeln!(
+            out,
+            "{:<14} {:<14} {:<8} {}",
+            e.artifact_id,
+            e.status.label(),
+            e.kind,
+            e.uri
+        );
+        if let Some(detail) = &e.detail {
+            let _ = writeln!(out, "    detail: {detail}");
+        }
+        if let (Some(stamped), Some(computed)) = (&e.stamped_sha256, &e.computed_sha256) {
+            if e.status == EntryStatus::Drift {
+                let _ = writeln!(out, "    stamped : {stamped}");
+                let _ = writeln!(out, "    computed: {computed}");
+            }
+        }
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Total: {} (match: {}, drift: {}, missing-hash: {}, read-error: {}, skipped-remote: {}, shape-error: {})",
+        report.total,
+        report.by_status.r#match,
+        report.by_status.drift,
+        report.by_status.missing_hash,
+        report.by_status.read_error,
+        report.by_status.skipped_remote,
+        report.by_status.shape_error,
+    );
+    if report.by_status.skipped_remote > 0 {
+        let _ = writeln!(
+            out,
+            "note: {} remote-kind source(s) skipped — Phase 2 will add `--check-remote-sources` backends",
+            report.by_status.skipped_remote,
+        );
+    }
+    out
+}
+
+/// Apply updates to drifted / missing-hash entries.
+///
+/// `interactive` triggers a per-entry y/N prompt on stdin. With
+/// `interactive=false` the function applies every drift / missing-hash
+/// fix without asking (the `--apply` mode).
+///
+/// Returns the number of entries updated.
+pub fn apply_updates(report: &Report, interactive: bool) -> Result<usize> {
+    let now = current_iso8601_utc();
+    let mut applied = 0;
+    let stdin = io::stdin();
+    let mut stdin_lock = stdin.lock();
+
+    for e in &report.entries {
+        let needs_update = matches!(e.status, EntryStatus::Drift | EntryStatus::MissingHash);
+        if !needs_update {
+            if e.status == EntryStatus::SkippedRemote {
+                eprintln!(
+                    "  skipping {}: kind={} — use --check-remote-sources for remote kinds (Phase 2)",
+                    e.artifact_id, e.kind
+                );
+            }
+            continue;
+        }
+        let Some(computed) = e.computed_sha256.as_deref() else {
+            continue;
+        };
+        let Some(file) = e.source_file.as_deref() else {
+            eprintln!("  skipping {}: artifact source file unknown", e.artifact_id);
+            continue;
+        };
+
+        if interactive {
+            print!("Update {} sha256 to {}? [y/N] ", e.artifact_id, computed);
+            io::stdout().flush().ok();
+            let mut buf = String::new();
+            stdin_lock.read_line(&mut buf)?;
+            let answer = buf.trim().to_ascii_lowercase();
+            if !(answer == "y" || answer == "yes") {
+                continue;
+            }
+        }
+
+        cited_source::update_cited_source_in_file(file, &e.artifact_id, computed, &now)
+            .with_context(|| format!("updating cited-source for {}", e.artifact_id))?;
+        applied += 1;
+    }
+
+    Ok(applied)
+}
+
+/// Best-effort ISO-8601 UTC timestamp without pulling chrono in.
+fn current_iso8601_utc() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+
+    // Convert epoch seconds into Y/M/D/H/M/S using a fixed-point algorithm.
+    // Days since 1970-01-01:
+    let days = now.div_euclid(86_400);
+    let secs_of_day = now.rem_euclid(86_400);
+    let h = secs_of_day / 3600;
+    let m = (secs_of_day % 3600) / 60;
+    let s = secs_of_day % 60;
+
+    // Date math: Howard Hinnant's "civil_from_days".
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m_civil = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m_civil <= 2 { y + 1 } else { y };
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y, m_civil, d, h, m, s
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_iso8601_format_is_well_formed() {
+        let s = current_iso8601_utc();
+        // Expect "YYYY-MM-DDTHH:MM:SSZ"
+        assert_eq!(s.len(), 20);
+        assert!(s.ends_with('Z'));
+        assert!(s.contains('T'));
+    }
+}

--- a/rivet-cli/src/docs.rs
+++ b/rivet-cli/src/docs.rs
@@ -122,6 +122,12 @@ const TOPICS: &[DocTopic] = &[
         content: CONDITIONAL_RULES_DOC,
     },
     DocTopic {
+        slug: "schema-cited-sources",
+        title: "Cited-source typed field — sha256-stamped external references",
+        category: "Reference",
+        content: SCHEMA_CITED_SOURCES_DOC,
+    },
+    DocTopic {
         slug: "impact",
         title: "Change impact analysis",
         category: "Reference",
@@ -429,6 +435,22 @@ Exposes rivet tools to AI agents via the Model Context Protocol.
 The server uses stdio transport and only binds to the local process.
 See `rivet docs mcp` for the wire format, the 15-tool catalog, and the
 3-message handshake.
+
+## Oracle Subcommands (`rivet check`)
+
+```
+rivet check bidirectional           Verify every link with an inverse has it on the target
+rivet check review-signoff ID       Verify a released artifact has a reviewer
+rivet check gaps-json               Validation gaps as canonical JSON
+rivet check sources                 List artifacts with cited-source + hash status
+rivet check sources --update        Interactive y/N stamp refresh per drift
+rivet check sources --update --apply  Batch refresh, non-interactive
+```
+
+`rivet check sources` and `rivet validate --strict-cited-sources` together
+implement the deterministic external-source faithfulness check (issue
+#237). Phase 1 only handles `kind: file`; remote backends ship in
+Phase 2. See `rivet docs schema-cited-sources`.
 
 ## Schema Commands
 
@@ -1848,6 +1870,122 @@ each other. If two rules with the same condition impose conflicting
 requirements, the schema is rejected with a diagnostic.
 
 Related: [[REQ-023]], [[DD-018]], [[FEAT-040]]
+"#;
+
+const SCHEMA_CITED_SOURCES_DOC: &str = r#"# Cited-source typed field
+
+The `cited-source` field is a first-class typed schema construct that
+stamps an artifact with a hash-verifiable reference to an external
+source. Run `rivet validate` to detect drift; run `rivet check sources
+--update` to refresh the stamps.
+
+Phase 1 (current) implements the `kind: file` backend only. Remote kinds
+(`url`, `github`, `oslc`, `reqif`, `polarion`) are recognised by the
+schema and round-trip cleanly, but their backends ship in Phase 2.
+
+## Field shape
+
+```yaml
+- id: REQ-001
+  type: requirement
+  fields:
+    cited-source:
+      uri: ./testdata/source.txt           # required
+      kind: file                           # required: file | url | github | oslc | reqif | polarion
+      sha256: ba78…                        # optional but warned-on if missing
+      last-checked: 2026-04-27T00:00:00Z   # optional ISO-8601 UTC
+```
+
+## Per-kind backend behaviour
+
+| kind     | Phase 1 behaviour                                        | Phase 2 (planned)                       |
+|----------|----------------------------------------------------------|-----------------------------------------|
+| file     | re-read file on disk, recompute sha256, compare          | unchanged                               |
+| url      | accepted by schema, skipped at validate                  | HTTP fetch with `--check-remote-sources`|
+| github   | accepted by schema, skipped at validate                  | GitHub API with `GITHUB_TOKEN`          |
+| oslc     | accepted by schema, skipped at validate                  | gated by `oslc` feature flag            |
+| reqif    | accepted by schema, skipped at validate                  | gated by `reqif` feature flag           |
+| polarion | accepted by schema, skipped at validate                  | gated by `polarion` feature flag        |
+
+## URI resolution (kind: file)
+
+- Bare relative paths (`./doc.md`, `testdata/x.txt`) are resolved
+  against the project root (the directory containing `rivet.yaml`).
+- Absolute paths (`/etc/hosts`) are used as-is.
+- The `file://` scheme is honoured: `file:///abs/path` is absolute,
+  `file://relative/path` is joined to the project root.
+
+## Diagnostics
+
+Rule names emitted by `rivet validate`:
+
+- `cited-source-shape` (Error) — the field is malformed (missing uri /
+  kind, unknown kind, scheme outside the allowlist).
+- `cited-source-drift` (Warning by default; Error with
+  `--strict-cited-sources`) — sha256 stamp does not match the file on
+  disk, or the stamp is missing entirely.
+- `cited-source-stale` (Info) — `last-checked` is missing.
+- `cited-source-skipped` (Info, only with `--check-remote-sources`) —
+  remote kind acknowledged but not yet verified (Phase 1).
+
+## Security model — URI scheme allowlist
+
+The cited-source field rejects any URI scheme outside this allowlist at
+validate time:
+
+    file, http, https, github, oslc, reqif, polarion
+
+Bare relative paths (no scheme) are accepted only for `kind: file`.
+Arbitrary schemes (`javascript:`, `ftp:`, custom protocols) are blocked
+before any backend touches them — defence against exfiltration / SSRF
+from untrusted YAML.
+
+Network-touching backends (`url`, `github`, `oslc`, `reqif`, `polarion`)
+remain opt-in via `--check-remote-sources` (Phase 2 work).
+
+## CLI surface
+
+```bash
+# Default validate — checks kind: file only, no network.
+rivet validate
+
+# Treat cited-source-drift as a hard failure (CI gate).
+rivet validate --strict-cited-sources
+
+# Phase 2 — flag accepted by Phase 1, no-op for now.
+rivet validate --check-remote-sources
+
+# Audit & refresh workflow.
+rivet check sources                       # list every cited-source + status
+rivet check sources --update              # interactive y/N per drift
+rivet check sources --update --apply      # batch refresh
+```
+
+## last-checked semantics
+
+`last-checked` is a stamp, not a verification gate. Phase 1 emits an
+`Info`-severity `cited-source-stale` diagnostic when the field is
+absent; future phases may add a per-schema staleness threshold (`>30
+days for fast-moving sources`) if real-world demand justifies it.
+
+The `rivet check sources --update --apply` flow always rewrites
+`last-checked` to the current UTC time when it touches an artifact.
+
+## Migration note (Phase 1 caveat)
+
+Existing schemas declaring `upstream-ref: string` (currently `dev`'s
+`requirement` plus references in `aadl` and `supply-chain`) are NOT
+migrated by Phase 1. The migration recipe needs the `rivet schema
+migrate` machinery from issue #236. Phase 1 simply adds `cited-source`
+as an additional optional field next to `upstream-ref` — projects can
+opt in incrementally.
+
+## Related
+
+- Issue #237 — feature design and rollout phases.
+- Issue #236 — `rivet schema migrate` (required for the upstream-ref
+  migration recipe).
+- `rivet docs cli` for the full flag reference.
 "#;
 
 const IMPACT_DOC: &str = r#"# Change Impact Analysis

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -304,6 +304,19 @@ enum Command {
         /// warning (or error) fails the run.
         #[arg(long, default_value = "error")]
         fail_on: String,
+
+        /// Promote `cited-source-drift` warnings to errors. See
+        /// `rivet docs schema-cited-sources` for the field shape.
+        #[arg(long = "strict-cited-sources")]
+        strict_cited_sources: bool,
+
+        /// Reserved for Phase 2 — flag is accepted but the remote
+        /// backends (`url`, `github`, `oslc`, `reqif`, `polarion`) are
+        /// not yet implemented. Phase 1 only verifies `kind: file`. When
+        /// set, remote-kind sources emit an Info diagnostic noting they
+        /// were skipped.
+        #[arg(long = "check-remote-sources")]
+        check_remote_sources: bool,
     },
 
     /// Show a single artifact by ID
@@ -1409,6 +1422,27 @@ enum CheckAction {
         #[arg(short, long, default_value = "json")]
         format: String,
     },
+
+    /// List artifacts with `cited-source` and the current hash status
+    /// (match / drift / missing-hash / read-error / skipped-remote).
+    /// Phase 1 only handles `kind: file` — see
+    /// `rivet docs schema-cited-sources`.
+    Sources {
+        /// Refresh sha256 + last-checked stamps. By default prompts
+        /// per-artifact; pair with `--apply` for non-interactive batch
+        /// updates.
+        #[arg(long)]
+        update: bool,
+
+        /// Skip the prompt and apply every refresh non-interactively.
+        /// Requires `--update`.
+        #[arg(long, requires = "update")]
+        apply: bool,
+
+        /// Output format: "text" (default) or "json".
+        #[arg(short, long, default_value = "text")]
+        format: String,
+    },
 }
 
 fn main() -> ExitCode {
@@ -1519,6 +1553,8 @@ fn run(cli: Cli) -> Result<bool> {
             variant,
             binding,
             fail_on,
+            strict_cited_sources,
+            check_remote_sources,
         } => cmd_validate(
             &cli,
             format,
@@ -1530,6 +1566,8 @@ fn run(cli: Cli) -> Result<bool> {
             variant.as_deref(),
             binding.as_deref(),
             fail_on,
+            *strict_cited_sources,
+            *check_remote_sources,
         ),
         Command::List {
             r#type,
@@ -1813,6 +1851,11 @@ fn run(cli: Cli) -> Result<bool> {
             CheckAction::GapsJson { baseline, format } => {
                 cmd_check_gaps_json(&cli, baseline.as_deref(), format)
             }
+            CheckAction::Sources {
+                update,
+                apply,
+                format,
+            } => cmd_check_sources(&cli, *update, *apply, format),
         },
         #[cfg(feature = "wasm")]
         Command::Import {
@@ -4148,6 +4191,8 @@ fn cmd_validate(
     variant_path: Option<&std::path::Path>,
     binding_path: Option<&std::path::Path>,
     fail_on: &str,
+    strict_cited_sources: bool,
+    check_remote_sources: bool,
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let fail_on_threshold = parse_fail_on(fail_on)?;
@@ -4313,6 +4358,20 @@ fn cmd_validate(
         }
     };
     diagnostics.extend(validate::validate_documents(&doc_store, &store));
+
+    // Cited-source validation (Phase 1: kind: file backend).
+    //
+    // The store iterator yields references; clone artifacts to feed the
+    // owning `IntoIterator<Item = Artifact>` validator. Drift / missing-hash
+    // diagnostics default to Severity::Warning; `--strict-cited-sources`
+    // promotes them to Error.
+    let cited_source_diags = rivet_core::cited_source::validate_cited_sources(
+        store.iter().cloned(),
+        &cli.project,
+        strict_cited_sources,
+        check_remote_sources,
+    );
+    diagnostics.extend(cited_source_diags);
 
     // Cross-repo link validation (skipped with --skip-external-validation)
     let mut cross_repo_broken: Vec<rivet_core::externals::BrokenRef> = Vec::new();
@@ -6326,6 +6385,8 @@ fn cmd_diff(
                         variant: None,
                         binding: None,
                         fail_on: "error".to_string(),
+                        strict_cited_sources: false,
+                        check_remote_sources: false,
                     },
                 };
                 let head_cli = Cli {
@@ -6342,6 +6403,8 @@ fn cmd_diff(
                         variant: None,
                         binding: None,
                         fail_on: "error".to_string(),
+                        strict_cited_sources: false,
+                        check_remote_sources: false,
                     },
                 };
                 let bc = ProjectContext::load(&base_cli)?;
@@ -9604,6 +9667,42 @@ fn cmd_check_gaps_json(cli: &Cli, baseline_name: Option<&str>, format: &str) -> 
         return Ok(false);
     }
     Ok(true)
+}
+
+/// `rivet check sources [--update [--apply]]` — list artifacts with
+/// `cited-source`, optionally refreshing their sha256 / last-checked
+/// stamps. Phase 1 only handles `kind: file`.
+fn cmd_check_sources(cli: &Cli, update: bool, apply: bool, format: &str) -> Result<bool> {
+    validate_format(format, &["text", "json"])?;
+    let ctx = ProjectContext::load(cli)?;
+
+    let report = check::sources::compute(ctx.store.iter(), &cli.project);
+
+    if format == "json" {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", check::sources::render_text(&report));
+    }
+
+    if update {
+        let interactive = !apply;
+        let applied = check::sources::apply_updates(&report, interactive)?;
+        if format != "json" {
+            println!();
+            println!("Updated {applied} artifact(s).");
+        }
+    }
+
+    // The oracle's exit-code semantics: pass when no drift / read-error /
+    // missing-hash / shape-error remains. After --apply, drift and
+    // missing-hash will have been written back, but we report on the
+    // pre-update state so that the caller can see what happened. For
+    // pipelines that want post-update assurance, re-run validate.
+    let firing = report.by_status.drift
+        + report.by_status.missing_hash
+        + report.by_status.read_error
+        + report.by_status.shape_error;
+    Ok(firing == 0)
 }
 
 struct ProjectContext {

--- a/rivet-cli/tests/cited_source_integration.rs
+++ b/rivet-cli/tests/cited_source_integration.rs
@@ -1,0 +1,285 @@
+// SAFETY-REVIEW (SCRC Phase 1, DD-058): Integration test code. Allows
+// the same restriction lints as other integration tests in this crate.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::wildcard_enum_match_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::print_stderr
+)]
+
+//! Integration test for the Phase 1 `cited-source` flow.
+//!
+//! Covers issue #237 acceptance criteria:
+//! - Schema accepts the typed `cited-source` field.
+//! - `rivet validate` PASSes when the stamp matches the file.
+//! - Edit the file → `rivet validate` emits a `cited-source-drift` diagnostic.
+//! - `rivet validate --strict-cited-sources` exits 1 on drift.
+//! - `rivet check sources --update --apply` refreshes the stamp.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use sha2::{Digest, Sha256};
+
+fn rivet_bin() -> PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_rivet") {
+        return PathBuf::from(bin);
+    }
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest.parent().expect("workspace root");
+    workspace_root.join("target").join("debug").join("rivet")
+}
+
+const SCHEMA: &str = r#"schema:
+  name: cs-test
+  version: "0.1.0"
+  description: Minimal test schema with cited-source.
+
+artifact-types:
+  - name: requirement
+    description: A requirement
+    fields:
+      - name: cited-source
+        type: cited-source
+        required: false
+        description: cited-source field
+
+link-types: []
+"#;
+
+const RIVET_YAML: &str = r#"project:
+  name: cs-test
+  version: "0.1.0"
+  schemas:
+    - cs-test
+sources:
+  - path: artifacts
+    format: generic-yaml
+"#;
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let digest = h.finalize();
+    let mut s = String::with_capacity(64);
+    for byte in digest.iter() {
+        use std::fmt::Write;
+        let _ = write!(&mut s, "{byte:02x}");
+    }
+    s
+}
+
+fn seed(dir: &Path) -> PathBuf {
+    std::fs::create_dir_all(dir.join("schemas")).unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    std::fs::create_dir_all(dir.join("testdata")).unwrap();
+    std::fs::write(dir.join("rivet.yaml"), RIVET_YAML).unwrap();
+    std::fs::write(dir.join("schemas").join("cs-test.yaml"), SCHEMA).unwrap();
+    let source = dir.join("testdata").join("source.txt");
+    std::fs::write(&source, "v1\n").unwrap();
+    source
+}
+
+fn write_artifact(dir: &Path, sha: &str) {
+    let yaml = format!(
+        r#"artifacts:
+  - id: REQ-001
+    type: requirement
+    title: A test requirement
+    status: draft
+    fields:
+      cited-source:
+        uri: ./testdata/source.txt
+        kind: file
+        sha256: {sha}
+        last-checked: 2026-04-27T00:00:00Z
+"#
+    );
+    std::fs::write(dir.join("artifacts").join("req.yaml"), yaml).unwrap();
+}
+
+fn run_rivet(dir: &Path, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(rivet_bin());
+    cmd.arg("--project")
+        .arg(dir)
+        .arg("--schemas")
+        .arg(dir.join("schemas"));
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.output().expect("spawn rivet")
+}
+
+#[test]
+fn validate_passes_when_hash_matches() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    seed(dir);
+    let original = sha256_hex(b"v1\n");
+    write_artifact(dir, &original);
+
+    let out = run_rivet(dir, &["validate", "--direct"]);
+    assert!(
+        out.status.success(),
+        "validate should pass when hash matches\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("PASS"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("cited-source-drift"),
+        "no drift expected: {stdout}"
+    );
+}
+
+#[test]
+fn validate_emits_drift_warning_after_file_edit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let source = seed(dir);
+    let original = sha256_hex(b"v1\n");
+    write_artifact(dir, &original);
+
+    // Edit the cited file
+    std::fs::write(&source, "v2\n").unwrap();
+
+    let out = run_rivet(dir, &["validate", "--direct"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // Default fail-on=error: a Warning-level drift does not fail the gate.
+    assert!(
+        out.status.success(),
+        "validate should still PASS at default --fail-on=error.\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    // The diagnostic message text contains "sha256 mismatch" — the rule
+    // name `cited-source-drift` is not in the rendered text.
+    assert!(
+        stdout.contains("sha256 mismatch") || stderr.contains("sha256 mismatch"),
+        "expected drift diagnostic.\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}
+
+#[test]
+fn validate_strict_cited_sources_fails_on_drift() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let source = seed(dir);
+    let original = sha256_hex(b"v1\n");
+    write_artifact(dir, &original);
+
+    std::fs::write(&source, "v2\n").unwrap();
+
+    let out = run_rivet(dir, &["validate", "--direct", "--strict-cited-sources"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "validate --strict-cited-sources should fail on drift.\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        stdout.contains("sha256 mismatch") || stderr.contains("sha256 mismatch"),
+        "drift diag missing: stdout={stdout} stderr={stderr}"
+    );
+}
+
+#[test]
+fn check_sources_update_apply_refreshes_stamp() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let source = seed(dir);
+    let original = sha256_hex(b"v1\n");
+    write_artifact(dir, &original);
+
+    // Drift the source file.
+    std::fs::write(&source, "v2\n").unwrap();
+    let new_hash = sha256_hex(b"v2\n");
+
+    // Run the audit-update flow.
+    let out = run_rivet(dir, &["check", "sources", "--update", "--apply"]);
+    assert!(
+        out.status.code() != Some(2),
+        "command crashed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Inspect the rewritten artifact.
+    let updated_yaml = std::fs::read_to_string(dir.join("artifacts").join("req.yaml")).unwrap();
+    assert!(
+        updated_yaml.contains(&format!("sha256: {new_hash}")),
+        "sha256 was not updated: {updated_yaml}"
+    );
+
+    // After update, validate should pass cleanly.
+    let v = run_rivet(dir, &["validate", "--direct"]);
+    let stdout = String::from_utf8_lossy(&v.stdout);
+    assert!(v.status.success(), "validate after update: {stdout}");
+    assert!(
+        !stdout.contains("cited-source-drift"),
+        "drift should be resolved: {stdout}"
+    );
+}
+
+#[test]
+fn check_sources_lists_entries_in_text_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    seed(dir);
+    let original = sha256_hex(b"v1\n");
+    write_artifact(dir, &original);
+
+    let out = run_rivet(dir, &["check", "sources"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(stdout.contains("REQ-001"), "stdout: {stdout}");
+    assert!(stdout.contains("MATCH"), "stdout: {stdout}");
+    assert!(stdout.contains("file"), "stdout: {stdout}");
+}
+
+#[test]
+fn validate_rejects_arbitrary_uri_scheme() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    seed(dir);
+
+    // Write an artifact with an arbitrary URI scheme — must not pass validate.
+    let yaml = r#"artifacts:
+  - id: REQ-001
+    type: requirement
+    title: A test requirement
+    status: draft
+    fields:
+      cited-source:
+        uri: 'ftp://evil.example.com/exfil'
+        kind: url
+        sha256: 0000000000000000000000000000000000000000000000000000000000000000
+"#;
+    std::fs::write(dir.join("artifacts").join("req.yaml"), yaml).unwrap();
+
+    let out = run_rivet(dir, &["validate", "--direct"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "validate should fail on unknown URI scheme.\nstdout: {stdout}\nstderr: {stderr}",
+    );
+    assert!(
+        stdout.contains("not in the allowlist") || stderr.contains("not in the allowlist"),
+        "expected scheme allowlist error.\nstdout: {stdout}\nstderr: {stderr}",
+    );
+}

--- a/rivet-core/src/cited_source.rs
+++ b/rivet-core/src/cited_source.rs
@@ -1,0 +1,999 @@
+// SAFETY-REVIEW (SCRC Phase 1, DD-058): File-scope blanket allow for
+// the v0.4.3 clippy restriction-lint escalation. These lints are enabled
+// at workspace scope at `warn` so new violations surface in CI; existing
+// call sites here are grandfathered in via this file-level allow until
+// Phase 2 (per-site #[allow(...)] + rewrite). Rationale per lint class:
+// see other rivet-core modules.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::wildcard_enum_match_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::print_stderr
+)]
+
+//! Typed `cited-source` field — sha256-stamped reference to an external source.
+//!
+//! See `rivet docs schema-cited-sources` for the user-facing reference.
+//!
+//! Phase 1 scope (issue #237):
+//! - First-class typed schema field with shape `{ uri, kind, sha256, last-checked }`.
+//! - URI scheme allowlist, enforced at validation time.
+//! - `kind: file` backend — re-read the file on disk, recompute sha256,
+//!   compare to the stamped value.
+//! - Remote kinds (`url`, `github`, `oslc`, `reqif`, `polarion`) are
+//!   recognised by the schema but Phase 1 does NOT implement their
+//!   backends. They round-trip through the validator unchanged with an
+//!   Info diagnostic when `--check-remote-sources` is requested.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::model::Artifact;
+use crate::schema::Severity;
+use crate::validate::Diagnostic;
+
+/// Allowed `cited-source.kind` values.
+///
+/// Phase 1 only implements `File`. The other kinds round-trip but are
+/// skipped at validate time unless `--check-remote-sources` is set
+/// (which becomes a real backend in Phase 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CitedSourceKind {
+    File,
+    Url,
+    Github,
+    Oslc,
+    Reqif,
+    Polarion,
+}
+
+impl CitedSourceKind {
+    /// Human-readable label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CitedSourceKind::File => "file",
+            CitedSourceKind::Url => "url",
+            CitedSourceKind::Github => "github",
+            CitedSourceKind::Oslc => "oslc",
+            CitedSourceKind::Reqif => "reqif",
+            CitedSourceKind::Polarion => "polarion",
+        }
+    }
+
+    /// True for kinds whose backend is implemented in Phase 1.
+    pub fn is_local(self) -> bool {
+        matches!(self, CitedSourceKind::File)
+    }
+}
+
+/// Parsed and validated `cited-source` field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CitedSource {
+    pub uri: String,
+    pub kind: CitedSourceKind,
+    pub sha256: Option<String>,
+    pub last_checked: Option<String>,
+}
+
+/// URI schemes the cited-source field accepts. Schemes outside this
+/// allowlist are rejected at validate time — defence against arbitrary
+/// schemes from untrusted YAML (exfiltration / SSRF surface).
+pub const ALLOWED_URI_SCHEMES: &[&str] = &[
+    "file", "http", "https", "github", "oslc", "reqif", "polarion",
+];
+
+/// Extract the scheme component of a URI, lowercased.
+///
+/// Recognises both the canonical `scheme://rest` form and the bare
+/// `scheme:rest` form (e.g. `javascript:alert(1)`, `mailto:x@y`). The
+/// scheme component must satisfy the RFC 3986 grammar
+/// (`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`); other prefixes (like
+/// drive letters `C:\…` or naked windows paths) return `None` so the
+/// caller can treat them as relative.
+pub fn uri_scheme(uri: &str) -> Option<String> {
+    // Find the first `:` and verify everything before it is a valid scheme.
+    let colon = uri.find(':')?;
+    let head = &uri[..colon];
+    if head.is_empty() {
+        return None;
+    }
+    let mut chars = head.chars();
+    let first = chars.next()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
+        return None;
+    }
+    // Reject single-letter schemes (the "C:" drive-letter case on Windows).
+    if head.len() == 1 {
+        return None;
+    }
+    Some(head.to_ascii_lowercase())
+}
+
+/// Compute the hex-encoded sha256 of a byte slice.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut s = String::with_capacity(64);
+    for byte in digest.iter() {
+        use std::fmt::Write;
+        let _ = write!(&mut s, "{byte:02x}");
+    }
+    s
+}
+
+/// Compute the sha256 of a file's contents.
+pub fn sha256_file(path: &Path) -> std::io::Result<String> {
+    let bytes = std::fs::read(path)?;
+    Ok(sha256_hex(&bytes))
+}
+
+/// Errors encountered when interpreting a raw `cited-source` field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CitedSourceParseError {
+    /// The field is not a YAML mapping.
+    NotAMapping,
+    /// Required `uri` is missing or not a string.
+    MissingUri,
+    /// Required `kind` is missing or not a string.
+    MissingKind,
+    /// `kind` is not one of the allowed values.
+    UnknownKind(String),
+    /// URI uses an unrecognised scheme.
+    UnknownScheme(String),
+}
+
+impl std::fmt::Display for CitedSourceParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CitedSourceParseError::NotAMapping => {
+                write!(f, "cited-source must be a mapping with uri/kind keys")
+            }
+            CitedSourceParseError::MissingUri => {
+                write!(f, "cited-source missing required 'uri' (string)")
+            }
+            CitedSourceParseError::MissingKind => {
+                write!(f, "cited-source missing required 'kind' (string)")
+            }
+            CitedSourceParseError::UnknownKind(k) => write!(
+                f,
+                "cited-source.kind = '{k}' is not one of file|url|github|oslc|reqif|polarion"
+            ),
+            CitedSourceParseError::UnknownScheme(s) => write!(
+                f,
+                "cited-source.uri uses scheme '{s}' which is not in the allowlist {ALLOWED_URI_SCHEMES:?}"
+            ),
+        }
+    }
+}
+
+/// Parse a `serde_yaml::Value` into a typed `CitedSource`.
+///
+/// Validates that:
+/// - the value is a mapping
+/// - `uri` and `kind` are present and stringy
+/// - `kind` is one of the allowed enum values
+/// - the URI scheme (when one is present) is in `ALLOWED_URI_SCHEMES`
+///   (relative paths and bare filenames are accepted for `kind: file`)
+pub fn parse_cited_source(value: &serde_yaml::Value) -> Result<CitedSource, CitedSourceParseError> {
+    let map = value
+        .as_mapping()
+        .ok_or(CitedSourceParseError::NotAMapping)?;
+
+    let uri = map
+        .get(serde_yaml::Value::String("uri".into()))
+        .and_then(|v| v.as_str())
+        .ok_or(CitedSourceParseError::MissingUri)?
+        .to_string();
+
+    let kind_raw = map
+        .get(serde_yaml::Value::String("kind".into()))
+        .and_then(|v| v.as_str())
+        .ok_or(CitedSourceParseError::MissingKind)?;
+
+    let kind = match kind_raw {
+        "file" => CitedSourceKind::File,
+        "url" => CitedSourceKind::Url,
+        "github" => CitedSourceKind::Github,
+        "oslc" => CitedSourceKind::Oslc,
+        "reqif" => CitedSourceKind::Reqif,
+        "polarion" => CitedSourceKind::Polarion,
+        other => return Err(CitedSourceParseError::UnknownKind(other.to_string())),
+    };
+
+    // Scheme allowlist enforcement. Relative paths (no `://`) are
+    // accepted only for kind: file — otherwise the URI must declare a
+    // scheme. file paths without a scheme are interpreted relative to
+    // the project root in `validate_cited_source`.
+    if let Some(scheme) = uri_scheme(&uri) {
+        if !ALLOWED_URI_SCHEMES.contains(&scheme.as_str()) {
+            return Err(CitedSourceParseError::UnknownScheme(scheme));
+        }
+    }
+
+    let sha256 = map
+        .get(serde_yaml::Value::String("sha256".into()))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let last_checked = map
+        .get(serde_yaml::Value::String("last-checked".into()))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Ok(CitedSource {
+        uri,
+        kind,
+        sha256,
+        last_checked,
+    })
+}
+
+/// Resolve a `kind: file` URI to an absolute filesystem path.
+///
+/// Accepts:
+/// - bare relative paths (e.g. `./testdata/source.txt`) — joined to `project_root`
+/// - bare absolute paths (e.g. `/etc/hosts`) — used as-is
+/// - `file://` URIs — the path component is extracted
+pub fn resolve_file_uri(uri: &str, project_root: &Path) -> PathBuf {
+    if let Some(rest) = uri.strip_prefix("file://") {
+        let p = Path::new(rest);
+        if p.is_absolute() {
+            return p.to_path_buf();
+        }
+        return project_root.join(p);
+    }
+
+    let p = Path::new(uri);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        project_root.join(p)
+    }
+}
+
+/// Outcome of checking a single `cited-source` field against its source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckOutcome {
+    /// sha256 matches — no drift.
+    Match,
+    /// sha256 differs from the file on disk. Carries the freshly computed hash.
+    Drift { computed: String },
+    /// `sha256` field was missing from the artifact YAML; carries computed.
+    MissingHash { computed: String },
+    /// The file referenced by the URI could not be read.
+    FileError { reason: String },
+    /// Phase 1 does not implement this kind's backend; skipped.
+    SkippedRemote,
+}
+
+/// Check one `cited-source` field for drift.
+///
+/// `project_root` is the directory used to resolve relative `kind: file`
+/// URIs. `check_remote` is the user's `--check-remote-sources` flag — in
+/// Phase 1 this only affects whether remote kinds emit
+/// `SkippedRemote` (they always skip the actual hash check).
+pub fn check_cited_source(
+    src: &CitedSource,
+    project_root: &Path,
+    _check_remote: bool,
+) -> CheckOutcome {
+    if !src.kind.is_local() {
+        // Phase 2 wires the http/github/oslc/reqif/polarion backends.
+        return CheckOutcome::SkippedRemote;
+    }
+
+    let path = resolve_file_uri(&src.uri, project_root);
+    let computed = match sha256_file(&path) {
+        Ok(h) => h,
+        Err(e) => {
+            return CheckOutcome::FileError {
+                reason: format!("{}: {e}", path.display()),
+            };
+        }
+    };
+
+    match &src.sha256 {
+        None => CheckOutcome::MissingHash { computed },
+        Some(stamped) if stamped.eq_ignore_ascii_case(&computed) => CheckOutcome::Match,
+        Some(_) => CheckOutcome::Drift { computed },
+    }
+}
+
+/// Validate every artifact's `cited-source` field and return the
+/// resulting diagnostics.
+///
+/// `project_root` is used to resolve relative `kind: file` URIs. The
+/// `strict` flag promotes drift / missing-hash diagnostics from
+/// `Severity::Warning` to `Severity::Error` (the
+/// `--strict-cited-sources` CLI flag).
+pub fn validate_cited_sources(
+    artifacts: impl IntoIterator<Item = Artifact>,
+    project_root: &Path,
+    strict: bool,
+    check_remote: bool,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let drift_severity = if strict {
+        Severity::Error
+    } else {
+        Severity::Warning
+    };
+
+    for artifact in artifacts {
+        let Some(raw) = artifact.fields.get("cited-source") else {
+            continue;
+        };
+        let parsed = match parse_cited_source(raw) {
+            Ok(p) => p,
+            Err(e) => {
+                diagnostics.push(Diagnostic::new(
+                    Severity::Error,
+                    Some(artifact.id.clone()),
+                    "cited-source-shape",
+                    e.to_string(),
+                ));
+                continue;
+            }
+        };
+
+        let outcome = check_cited_source(&parsed, project_root, check_remote);
+        match outcome {
+            CheckOutcome::Match => {}
+            CheckOutcome::Drift { computed } => {
+                diagnostics.push(Diagnostic::new(
+                    drift_severity,
+                    Some(artifact.id.clone()),
+                    "cited-source-drift",
+                    format!(
+                        "cited-source '{}' (kind: {}) sha256 mismatch — stamped {} but file hashes to {}",
+                        parsed.uri,
+                        parsed.kind.as_str(),
+                        parsed.sha256.as_deref().unwrap_or("(unknown)"),
+                        computed,
+                    ),
+                ));
+            }
+            CheckOutcome::MissingHash { computed } => {
+                diagnostics.push(Diagnostic::new(
+                    drift_severity,
+                    Some(artifact.id.clone()),
+                    "cited-source-drift",
+                    format!(
+                        "cited-source '{}' (kind: {}) is missing the sha256 stamp; current file hashes to {} — run `rivet check sources --update --apply` to set",
+                        parsed.uri,
+                        parsed.kind.as_str(),
+                        computed,
+                    ),
+                ));
+            }
+            CheckOutcome::FileError { reason } => {
+                diagnostics.push(Diagnostic::new(
+                    Severity::Error,
+                    Some(artifact.id.clone()),
+                    "cited-source-drift",
+                    format!(
+                        "cited-source '{}' (kind: file) could not be read: {reason}",
+                        parsed.uri,
+                    ),
+                ));
+            }
+            CheckOutcome::SkippedRemote => {
+                if check_remote {
+                    diagnostics.push(Diagnostic::new(
+                        Severity::Info,
+                        Some(artifact.id.clone()),
+                        "cited-source-skipped",
+                        format!(
+                            "cited-source '{}' (kind: {}) — remote backend not yet implemented (Phase 2)",
+                            parsed.uri,
+                            parsed.kind.as_str(),
+                        ),
+                    ));
+                }
+            }
+        }
+
+        if parsed.last_checked.is_none() && parsed.kind.is_local() {
+            diagnostics.push(Diagnostic::new(
+                Severity::Info,
+                Some(artifact.id.clone()),
+                "cited-source-stale",
+                format!(
+                    "cited-source '{}' has no 'last-checked' timestamp; consider running `rivet check sources --update`",
+                    parsed.uri,
+                ),
+            ));
+        }
+    }
+
+    diagnostics
+}
+
+/// Update an artifact's `cited-source.sha256` and `last-checked` fields
+/// in place by re-writing the YAML file at `file_path`. Returns `Ok(true)`
+/// if the file was modified, `Ok(false)` if no change was needed.
+///
+/// Uses a line-oriented edit to preserve comments and ordering. The
+/// strategy is:
+///
+/// 1. Find the artifact block by `- id: <id>`.
+/// 2. Within that block, find `cited-source:` (under `fields:`).
+/// 3. Walk the nested mapping until we find `sha256:` and `last-checked:`,
+///    replacing or inserting them.
+///
+/// Limitations:
+/// - The `cited-source:` block must already be a YAML mapping (not a flow
+///   `{}` form). Phase 1 ships only the canonical block form.
+/// - Comments inside the cited-source block are preserved verbatim.
+pub fn update_cited_source_in_file(
+    file_path: &Path,
+    artifact_id: &str,
+    new_sha256: &str,
+    new_last_checked: &str,
+) -> Result<bool, std::io::Error> {
+    let content = std::fs::read_to_string(file_path)?;
+    let lines: Vec<String> = content.lines().map(str::to_string).collect();
+
+    // Locate the artifact block
+    let id_marker_a = format!("- id: {artifact_id}");
+    let id_marker_b = format!("- id: \"{artifact_id}\"");
+    let id_marker_c = format!("- id: '{artifact_id}'");
+    let block_start = lines.iter().position(|l| {
+        let t = l.trim_start();
+        t.starts_with(&id_marker_a) || t.starts_with(&id_marker_b) || t.starts_with(&id_marker_c)
+    });
+
+    let Some(block_start) = block_start else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!(
+                "artifact '{artifact_id}' not found in {}",
+                file_path.display()
+            ),
+        ));
+    };
+
+    // Determine the indent of fields in this block (the `id:` line indent)
+    let field_indent = lines[block_start].find('-').map(|d| d + 2).unwrap_or(2);
+
+    // Find next `- id:` (or EOF) — that's the block end
+    let block_end = lines
+        .iter()
+        .enumerate()
+        .skip(block_start + 1)
+        .find(|(_, l)| {
+            let t = l.trim_start();
+            t.starts_with("- id:") || t.starts_with("- id ")
+        })
+        .map(|(i, _)| i)
+        .unwrap_or(lines.len());
+
+    // Locate `fields:` line within the block
+    let fields_line = (block_start + 1..block_end).find(|&i| {
+        let line = &lines[i];
+        let trimmed = line.trim();
+        let indent = line.len() - line.trim_start().len();
+        indent == field_indent && trimmed.starts_with("fields:")
+    });
+
+    let Some(fields_line) = fields_line else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("artifact '{artifact_id}' has no `fields:` section to host cited-source"),
+        ));
+    };
+
+    let sub_indent = field_indent + 2;
+
+    // Locate the `cited-source:` line under `fields:`
+    let cited_source_line = (fields_line + 1..block_end).find(|&i| {
+        let line = &lines[i];
+        let trimmed = line.trim();
+        let indent = line.len() - line.trim_start().len();
+        indent == sub_indent && trimmed.starts_with("cited-source:")
+    });
+
+    let Some(cited_source_line) = cited_source_line else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("artifact '{artifact_id}' has no cited-source: under fields:"),
+        ));
+    };
+
+    // The cited-source block's interior fields should be at indent +2 from cited-source
+    let inner_indent = sub_indent + 2;
+
+    // Find the end of the cited-source block — first line at indent <= sub_indent
+    let cs_block_end = (cited_source_line + 1..block_end)
+        .find(|&i| {
+            let line = &lines[i];
+            if line.trim().is_empty() {
+                return false;
+            }
+            let indent = line.len() - line.trim_start().len();
+            indent <= sub_indent
+        })
+        .unwrap_or(block_end);
+
+    // Find existing sha256 / last-checked lines.
+    let mut sha256_line: Option<usize> = None;
+    let mut last_checked_line: Option<usize> = None;
+    for (i, line) in lines
+        .iter()
+        .enumerate()
+        .take(cs_block_end)
+        .skip(cited_source_line + 1)
+    {
+        let trimmed = line.trim();
+        let indent = line.len() - line.trim_start().len();
+        if indent != inner_indent {
+            continue;
+        }
+        if trimmed.starts_with("sha256:") {
+            sha256_line = Some(i);
+        } else if trimmed.starts_with("last-checked:") {
+            last_checked_line = Some(i);
+        }
+    }
+
+    let mut new_lines = lines.clone();
+    let pad = " ".repeat(inner_indent);
+
+    let new_sha_line = format!("{pad}sha256: {new_sha256}");
+    let new_lc_line = format!("{pad}last-checked: {new_last_checked}");
+
+    let mut changed = false;
+
+    match sha256_line {
+        Some(i) => {
+            if new_lines[i] != new_sha_line {
+                new_lines[i] = new_sha_line;
+                changed = true;
+            }
+        }
+        None => {
+            new_lines.insert(cs_block_end, new_sha_line);
+            changed = true;
+        }
+    }
+
+    // Recompute end after possible insertion above
+    let cs_block_end_after_sha = if sha256_line.is_none() {
+        cs_block_end + 1
+    } else {
+        cs_block_end
+    };
+
+    let last_checked_line = if sha256_line.is_none() {
+        last_checked_line.map(|i| if i >= cs_block_end { i + 1 } else { i })
+    } else {
+        last_checked_line
+    };
+
+    match last_checked_line {
+        Some(i) => {
+            if new_lines[i] != new_lc_line {
+                new_lines[i] = new_lc_line;
+                changed = true;
+            }
+        }
+        None => {
+            new_lines.insert(cs_block_end_after_sha, new_lc_line);
+            changed = true;
+        }
+    }
+
+    if changed {
+        let mut out = new_lines.join("\n");
+        if content.ends_with('\n') && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        std::fs::write(file_path, out)?;
+    }
+
+    Ok(changed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::io::Write;
+
+    fn yaml_value(s: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(s).expect("valid YAML")
+    }
+
+    #[test]
+    fn sha256_hex_matches_known_vector() {
+        // sha256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn sha256_hex_empty_input() {
+        // sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sha256_file_round_trip() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(b"hello world").unwrap();
+        let h = sha256_file(f.path()).unwrap();
+        assert_eq!(h, sha256_hex(b"hello world"));
+    }
+
+    #[test]
+    fn uri_scheme_extraction() {
+        assert_eq!(uri_scheme("file:///tmp/x"), Some("file".into()));
+        assert_eq!(uri_scheme("https://example.com"), Some("https".into()));
+        assert_eq!(uri_scheme("HTTPS://x"), Some("https".into()));
+        assert_eq!(uri_scheme("./local"), None);
+        assert_eq!(uri_scheme("plain.txt"), None);
+    }
+
+    #[test]
+    fn parse_minimal_cited_source() {
+        let v = yaml_value("uri: ./x.md\nkind: file");
+        let cs = parse_cited_source(&v).unwrap();
+        assert_eq!(cs.uri, "./x.md");
+        assert_eq!(cs.kind, CitedSourceKind::File);
+        assert_eq!(cs.sha256, None);
+    }
+
+    #[test]
+    fn parse_full_cited_source() {
+        let v = yaml_value(
+            r#"
+uri: file:///tmp/source.txt
+kind: file
+sha256: ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+last-checked: 2026-04-28T14:30:00Z
+"#,
+        );
+        let cs = parse_cited_source(&v).unwrap();
+        assert_eq!(cs.kind, CitedSourceKind::File);
+        assert!(cs.sha256.is_some());
+        assert!(cs.last_checked.is_some());
+    }
+
+    #[test]
+    fn parse_rejects_unknown_kind() {
+        let v = yaml_value("uri: x\nkind: bogus");
+        let err = parse_cited_source(&v).unwrap_err();
+        assert!(matches!(err, CitedSourceParseError::UnknownKind(_)));
+    }
+
+    #[test]
+    fn parse_rejects_unknown_scheme() {
+        let v = yaml_value("uri: ftp://evil.example.com/exfil\nkind: url");
+        let err = parse_cited_source(&v).unwrap_err();
+        assert!(matches!(err, CitedSourceParseError::UnknownScheme(_)));
+    }
+
+    #[test]
+    fn parse_rejects_javascript_uri() {
+        // SSRF / exfiltration mitigation: arbitrary schemes from untrusted
+        // YAML must be rejected before any backend touches them.
+        let v = yaml_value("uri: 'javascript:alert(1)'\nkind: url");
+        let err = parse_cited_source(&v).unwrap_err();
+        assert!(matches!(err, CitedSourceParseError::UnknownScheme(_)));
+    }
+
+    #[test]
+    fn parse_accepts_relative_path_for_file_kind() {
+        let v = yaml_value("uri: ./testdata/source.txt\nkind: file");
+        assert!(parse_cited_source(&v).is_ok());
+    }
+
+    #[test]
+    fn parse_rejects_missing_uri() {
+        let v = yaml_value("kind: file");
+        assert!(matches!(
+            parse_cited_source(&v).unwrap_err(),
+            CitedSourceParseError::MissingUri
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_missing_kind() {
+        let v = yaml_value("uri: x");
+        assert!(matches!(
+            parse_cited_source(&v).unwrap_err(),
+            CitedSourceParseError::MissingKind
+        ));
+    }
+
+    #[test]
+    fn check_file_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("doc.md");
+        std::fs::write(&p, "hello").unwrap();
+        let stamped = sha256_hex(b"hello");
+
+        let cs = CitedSource {
+            uri: "doc.md".into(),
+            kind: CitedSourceKind::File,
+            sha256: Some(stamped),
+            last_checked: Some("2026-04-27T00:00:00Z".into()),
+        };
+        let outcome = check_cited_source(&cs, dir.path(), false);
+        assert_eq!(outcome, CheckOutcome::Match);
+    }
+
+    #[test]
+    fn check_file_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("doc.md");
+        std::fs::write(&p, "hello").unwrap();
+
+        let cs = CitedSource {
+            uri: "doc.md".into(),
+            kind: CitedSourceKind::File,
+            sha256: Some("0".repeat(64)),
+            last_checked: None,
+        };
+        match check_cited_source(&cs, dir.path(), false) {
+            CheckOutcome::Drift { computed } => {
+                assert_eq!(computed, sha256_hex(b"hello"));
+            }
+            other => panic!("expected Drift, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_file_missing_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("doc.md");
+        std::fs::write(&p, "hello").unwrap();
+
+        let cs = CitedSource {
+            uri: "doc.md".into(),
+            kind: CitedSourceKind::File,
+            sha256: None,
+            last_checked: None,
+        };
+        match check_cited_source(&cs, dir.path(), false) {
+            CheckOutcome::MissingHash { .. } => {}
+            other => panic!("expected MissingHash, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_remote_kind_skipped() {
+        let cs = CitedSource {
+            uri: "https://example.com".into(),
+            kind: CitedSourceKind::Url,
+            sha256: None,
+            last_checked: None,
+        };
+        let outcome = check_cited_source(&cs, Path::new("."), false);
+        assert_eq!(outcome, CheckOutcome::SkippedRemote);
+    }
+
+    #[test]
+    fn validate_cited_sources_emits_drift_diagnostic() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("doc.md");
+        std::fs::write(&p, "v1").unwrap();
+        let original_hash = sha256_hex(b"v1");
+
+        // mutate the file
+        std::fs::write(&p, "v2").unwrap();
+
+        let mut artifact = Artifact {
+            id: "REQ-1".into(),
+            artifact_type: "requirement".into(),
+            title: "t".into(),
+            description: None,
+            status: None,
+            tags: vec![],
+            links: vec![],
+            fields: BTreeMap::new(),
+            provenance: None,
+            source_file: None,
+        };
+        let mut cs_map = serde_yaml::Mapping::new();
+        cs_map.insert("uri".into(), "doc.md".into());
+        cs_map.insert("kind".into(), "file".into());
+        cs_map.insert("sha256".into(), original_hash.into());
+        artifact
+            .fields
+            .insert("cited-source".into(), serde_yaml::Value::Mapping(cs_map));
+
+        let diags = validate_cited_sources(vec![artifact], dir.path(), false, false);
+        assert!(diags.iter().any(|d| d.rule == "cited-source-drift"));
+    }
+
+    #[test]
+    fn validate_cited_sources_strict_promotes_to_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("doc.md");
+        std::fs::write(&p, "v1").unwrap();
+        let original_hash = sha256_hex(b"v1");
+        std::fs::write(&p, "v2").unwrap();
+
+        let mut artifact = Artifact {
+            id: "REQ-1".into(),
+            artifact_type: "requirement".into(),
+            title: "t".into(),
+            description: None,
+            status: None,
+            tags: vec![],
+            links: vec![],
+            fields: BTreeMap::new(),
+            provenance: None,
+            source_file: None,
+        };
+        let mut cs_map = serde_yaml::Mapping::new();
+        cs_map.insert("uri".into(), "doc.md".into());
+        cs_map.insert("kind".into(), "file".into());
+        cs_map.insert("sha256".into(), original_hash.into());
+        artifact
+            .fields
+            .insert("cited-source".into(), serde_yaml::Value::Mapping(cs_map));
+
+        let diags = validate_cited_sources(vec![artifact], dir.path(), true, false);
+        let drift = diags
+            .iter()
+            .find(|d| d.rule == "cited-source-drift")
+            .expect("drift diag");
+        assert_eq!(drift.severity, Severity::Error);
+    }
+
+    #[test]
+    fn validate_cited_sources_no_field_no_diag() {
+        let artifact = Artifact {
+            id: "REQ-1".into(),
+            artifact_type: "requirement".into(),
+            title: "t".into(),
+            description: None,
+            status: None,
+            tags: vec![],
+            links: vec![],
+            fields: BTreeMap::new(),
+            provenance: None,
+            source_file: None,
+        };
+        let diags = validate_cited_sources(vec![artifact], Path::new("."), false, false);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn resolve_file_uri_relative() {
+        let root = Path::new("/proj");
+        assert_eq!(
+            resolve_file_uri("./x.md", root),
+            PathBuf::from("/proj/./x.md")
+        );
+    }
+
+    #[test]
+    fn resolve_file_uri_absolute() {
+        let root = Path::new("/proj");
+        assert_eq!(
+            resolve_file_uri("/etc/hosts", root),
+            PathBuf::from("/etc/hosts")
+        );
+    }
+
+    #[test]
+    fn resolve_file_uri_with_scheme() {
+        let root = Path::new("/proj");
+        assert_eq!(
+            resolve_file_uri("file:///etc/hosts", root),
+            PathBuf::from("/etc/hosts")
+        );
+        assert_eq!(
+            resolve_file_uri("file://relative/path", root),
+            PathBuf::from("/proj/relative/path")
+        );
+    }
+
+    #[test]
+    fn update_cited_source_replaces_existing_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml_path = dir.path().join("a.yaml");
+        let original = "\
+artifacts:
+  - id: REQ-001
+    type: requirement
+    title: Test
+    fields:
+      cited-source:
+        uri: ./doc.md
+        kind: file
+        sha256: 0000000000000000000000000000000000000000000000000000000000000000
+        last-checked: 2026-01-01T00:00:00Z
+";
+        std::fs::write(&yaml_path, original).unwrap();
+
+        let changed =
+            update_cited_source_in_file(&yaml_path, "REQ-001", "abc123", "2026-04-27T12:00:00Z")
+                .unwrap();
+        assert!(changed);
+
+        let updated = std::fs::read_to_string(&yaml_path).unwrap();
+        assert!(updated.contains("sha256: abc123"));
+        assert!(updated.contains("last-checked: 2026-04-27T12:00:00Z"));
+        // No duplicate sha256 lines
+        assert_eq!(updated.matches("sha256:").count(), 1);
+        assert_eq!(updated.matches("last-checked:").count(), 1);
+    }
+
+    #[test]
+    fn update_cited_source_inserts_missing_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml_path = dir.path().join("a.yaml");
+        // Note: cited-source block exists but lacks sha256 / last-checked
+        let original = "\
+artifacts:
+  - id: REQ-001
+    type: requirement
+    title: Test
+    fields:
+      cited-source:
+        uri: ./doc.md
+        kind: file
+";
+        std::fs::write(&yaml_path, original).unwrap();
+
+        let changed =
+            update_cited_source_in_file(&yaml_path, "REQ-001", "deadbeef", "2026-04-27T12:00:00Z")
+                .unwrap();
+        assert!(changed);
+
+        let updated = std::fs::read_to_string(&yaml_path).unwrap();
+        assert!(updated.contains("sha256: deadbeef"));
+        assert!(updated.contains("last-checked: 2026-04-27T12:00:00Z"));
+    }
+
+    #[test]
+    fn update_cited_source_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml_path = dir.path().join("a.yaml");
+        let original = "\
+artifacts:
+  - id: REQ-001
+    type: requirement
+    title: Test
+    fields:
+      cited-source:
+        uri: ./doc.md
+        kind: file
+        sha256: deadbeef
+        last-checked: 2026-04-27T12:00:00Z
+";
+        std::fs::write(&yaml_path, original).unwrap();
+
+        let changed =
+            update_cited_source_in_file(&yaml_path, "REQ-001", "deadbeef", "2026-04-27T12:00:00Z")
+                .unwrap();
+        assert!(!changed);
+    }
+}

--- a/rivet-core/src/lib.rs
+++ b/rivet-core/src/lib.rs
@@ -40,6 +40,7 @@
 pub mod adapter;
 pub mod agent_pipelines;
 pub mod bazel;
+pub mod cited_source;
 pub mod commits;
 pub mod compliance;
 pub mod convergence;

--- a/schemas/dev.yaml
+++ b/schemas/dev.yaml
@@ -31,6 +31,15 @@ artifact-types:
         type: string
         required: false
         description: Reference to an upstream issue or external tracking item
+      - name: cited-source
+        type: cited-source
+        required: false
+        description: >
+          Typed cited-source field — sha256-stamped reference to an
+          external source. Shape: { uri, kind, sha256, last-checked },
+          where kind is one of file | url | github | oslc | reqif |
+          polarion. Phase 1 only verifies kind: file. See
+          `rivet docs schema-cited-sources` for the full reference.
     link-fields:
       - name: satisfies
         link-type: satisfies


### PR DESCRIPTION
## Summary

Phase 1 MVP of issue #237 — typed `cited-source` field with sha256
stamp, deterministic faithfulness check at `rivet validate` time.

- `cited-source: { uri, kind, sha256, last-checked }` is now a
  first-class typed schema field. Per-kind enum validation
  (`file | url | github | oslc | reqif | polarion`) and URI scheme
  allowlist enforcement reject arbitrary schemes from untrusted YAML.
- `kind: file` backend re-reads the file, recomputes sha256, compares
  to the stamped value. New `cited-source-drift` diagnostic
  (Severity::Warning) — promotable to Error via
  `--strict-cited-sources`.
- New `rivet check sources [--update [--apply]]` audit subcommand:
  list every cited-source with its hash status, optionally refresh
  the sha256 + last-checked stamps in place.
- New `rivet docs schema-cited-sources` reference topic.
- Added the field to `dev`'s `requirement` type as the first opt-in.

## Phase 1 acceptance criteria (issue #237)

- [x] Schema engine recognizes `cited-source` as a typed field
- [x] `kind: file` backend round-trips: write artifact, change file,
  re-validate, get the diagnostic
- [x] `rivet validate --strict-cited-sources` errors on missing or
  stale `sha256`
- [x] `rivet check sources --update --apply` updates the artifact
  YAML correctly
- [x] `rivet docs schema-cited-sources` topic exists and documents
  per-kind backend behaviour
- [x] At least one schema (`dev`'s `requirement`) declares
  `cited-source` and a fixture exercises it (the integration test
  fixture)
- [x] `cited-source.uri` validation rejects unknown schemes (not in
  the allowlist)
- [x] No new failure mode introduced for projects without any
  `cited-source` field — unit + integration tests cover this

## Out of scope (deferred to later phases)

**Phase 2** (subsequent PR):
- `kind: url` and `kind: github` backends behind
  `--check-remote-sources` (the flag is already accepted in Phase 1
  but is a no-op).
- `oslc` / `reqif` / `polarion` backends gated by their respective
  feature flags.

**Phase 3+** (post-MVP):
- LLM-judge faithfulness check as opt-in `rivet check faithfulness`,
  Severity::Info, never gates CI.
- Periodic audit / cron-friendly `--since=30d` mode.

**Other**:
- Migration of existing `upstream-ref` strings (only one schema —
  `dev` — actually has `upstream-ref` declared; the migration
  recipe needs `rivet schema migrate` from #236 to land first).
  Phase 1 simply adds `cited-source` alongside the existing field so
  projects can opt in incrementally.

## Security model

URI scheme allowlist enforced at parse time (defence against
exfiltration / SSRF surface from untrusted YAML):
`file | http | https | github | oslc | reqif | polarion`.

`javascript:`, `ftp:`, custom protocols are rejected with a
`cited-source-shape` Error before any backend touches them.

Network-touching backends remain opt-in (Phase 2).

## Test plan

- [x] `cargo test --workspace` clean (882 rivet-core tests + 6 new
  integration tests pass; full workspace passes)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] `rivet docs check` clean (45 files, 0 violations)
- [x] Manual: `rivet docs schema-cited-sources` renders the new topic
- [x] Manual: `rivet validate` against the rivet repo itself surfaces
  no new diagnostics (no regression for projects without
  `cited-source`)

## Commits

- `feat(schema): cited-source as first-class typed field with URI scheme allowlist`
- `feat(cli): rivet validate --strict-cited-sources + rivet check sources`
- `docs(schema): rivet docs schema-cited-sources topic + CLI doc updates`
- `test(validate): cited-source drift fixture round-trip`

Closes parts of #237; remaining phases tracked in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)