### PR TITLE
chore(release): v0.6.0 — schema migrate + cited-source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-04-29
+
+Theme: schema migration + cited-source faithfulness. Two marquee
+features landing together — both surfaced during the post-0.5.0
+fresh-user dogfood (#236, #237).
+
+### Added
+
+- **`rivet schema migrate <target-preset>`** — git-rebase-style preset/
+  version migration with snapshot/abort. Phase 1 ships the diff engine
+  + plan/apply/abort/status/finish. Three change classes (mechanical,
+  decidable-with-policy, conflict). Mechanical-only auto-applied;
+  conflicts bail loudly (Phase 2 will add merge-conflict-style markers
+  + `--continue` / `--skip`). Storage layout under `.rivet/migrations/
+  <ts>-<src>-to-<tgt>/` with full pre-migration snapshot, manifest,
+  state file. One canned recipe ships:
+  `schemas/migrations/dev-to-aspice.yaml` covering type renames
+  (`requirement` -> `sw-req`, `feature` -> `sw-arch-component`),
+  link-type renames (`satisfies` -> `derives-from`), and policy
+  declarations (`unmapped-fields: keep-as-orphan`). 8 unit tests
+  + 5 integration tests covering apply, abort byte-symmetry, and
+  roundtrip. `rivet docs schema-migrate` documents the state machine
+  and recipe format. (#238 / issue #236)
+
+- **`cited-source` typed schema field** — first-class affordance for
+  artifacts citing external sources. Field shape:
+  `{ uri, kind: file|url|github|oslc|reqif|polarion, sha256, last-checked }`.
+  Phase 1 ships the `kind: file` backend: `rivet validate`
+  re-reads cited files, recomputes sha256, emits a new
+  `cited-source-drift` diagnostic on mismatch (severity Warning by
+  default, Error with `--strict-cited-sources`). URI scheme allowlist
+  enforced at validation time to mitigate exfiltration / SSRF surface.
+  New `rivet check sources` subcommand walks every cited-source and
+  surfaces drift; `--update` interactively refreshes hashes,
+  `--update --apply` batch-updates. The `dev` preset's `requirement`
+  type opts in first; other presets adopt incrementally via overlay.
+  `rivet docs schema-cited-sources` documents per-kind backend
+  behaviour, the `last-checked` semantics, and the security model.
+  (#239 / issue #237)
+
+  Phase 2 backends (`url`, `github`, `oslc`, `reqif`, `polarion`)
+  are deferred. Phase 3 LLM-judge layer documented as opt-in
+  `Severity::Info` future work; *not* shipped here. The cited paper
+  (arXiv 2604.19459) is explicitly *not* the motivation — it studies
+  formal-proof faithfulness, not prose-to-prose comparison;
+  RAG-grounding (FActScore, FaithEval) is the right literature for
+  the LLM-judge path if/when it materializes.
+
+### Workspace
+
+- Workspace, vscode-rivet, and npm root package versions bumped to
+  0.6.0. Platform packages stay on the release-npm.yml override path.
+
+### Verified
+
+- cargo check, cargo clippy --workspace -- -D warnings,
+  cargo test -p rivet-cli (passes including new migrate + cited-source
+  integration tests),
+- `rivet schema migrate aspice` (plan + apply on a fresh `dev`
+  project) returns PASS,
+- `rivet validate` on a `cited-source: { kind: file, ... }` fixture
+  catches drift after the underlying file changes,
+- `rivet check sources --update --apply` restores PASS state.
+
 ## [0.5.1] — 2026-04-28
 
 Theme: post-0.5.0 first-contact polish. Three fresh-user dogfood passes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/rivet",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Rivet — SDLC traceability, validation, and MCP server for safety-critical systems (ISO 26262, DO-178C, ASPICE, STPA)",
   "main": "index.js",
   "bin": {

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bumps workspace, vscode-rivet, and npm root packages to 0.6.0. Platform packages stay on the release-npm.yml override path.

Bundles two already-merged marquee feature PRs as a release:
- **#238** — `feat(schema): rivet schema migrate Phase 1` (closes #236 Phase 1)
- **#239** — `feat(validate): cited-source typed field + sha256 stamp Phase 1` (closes #237 Phase 1)

## What ships

### `rivet schema migrate <target-preset>` (#238)

Git-rebase-style preset/version migration. Phase 1 ships:
- Diff engine (~1k SLOC) classifying changes as mechanical / decidable-with-policy / conflict
- `rivet schema migrate <target>` with `--apply`, `--abort`, `--status`, `--finish`
- `.rivet/migrations/<ts>-<src>-to-<tgt>/` storage with `plan.yaml`, `manifest.yaml`, `state`, `snapshot/`
- Canned recipe `schemas/migrations/dev-to-aspice.yaml`
- 8 unit tests + 5 integration tests (apply / abort byte-symmetry / roundtrip)
- `rivet docs schema-migrate` topic

Deferred to Phase 2: conflict markers in YAML, `--continue` / `--skip` / `--edit`, dashboard surface.

### `cited-source` typed field + sha256 stamp (#239)

First-class schema affordance for artifacts citing external sources.
- Field shape: `{ uri, kind: file|url|github|oslc|reqif|polarion, sha256, last-checked }`
- URI scheme allowlist enforced at validation time (exfiltration / SSRF mitigation)
- `kind: file` backend: re-reads cited file, recomputes sha256, emits `cited-source-drift` diagnostic on mismatch
- `--strict-cited-sources` flag promotes drift warnings to errors
- New `rivet check sources [--update [--apply]]` subcommand
- `dev` preset's `requirement` opts in first; other presets adopt incrementally

Deferred to Phase 2: remote backends (`url`, `github`, `oslc`, `reqif`, `polarion`).
Deferred to Phase 3: optional LLM-judge layer (opt-in `Severity::Info` only, never gates CI).

## Test plan

- [ ] CI green
- [ ] `rivet schema migrate aspice` (plan + apply on a fresh `dev` project) returns PASS
- [ ] `rivet validate` on a `cited-source: { kind: file, ... }` fixture catches drift after the underlying file changes
- [ ] `rivet check sources --update --apply` restores PASS state
- [ ] After merge: tag v0.6.0 and create the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)