### PR TITLE
fix(ci): make Release workflow idempotent on existing tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,15 +281,27 @@ jobs:
           sha256sum * > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
-      - name: Create Release
+      - name: Create or update Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
-          gh release create "$VERSION" \
-            --title "Rivet $VERSION" \
-            --generate-notes \
-            release/*
+          # Idempotent: if a release already exists for this tag (e.g.
+          # the maintainer ran `gh release create` manually after pushing
+          # the tag), upload assets to the existing release. Otherwise
+          # create the release with assets. `--clobber` lets re-runs
+          # overwrite assets that a previous failed attempt partially
+          # uploaded.
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "::notice::Release $VERSION already exists; uploading assets"
+            gh release upload "$VERSION" --clobber release/*
+          else
+            echo "::notice::Creating Release $VERSION with assets"
+            gh release create "$VERSION" \
+              --title "Rivet $VERSION" \
+              --generate-notes \
+              release/*
+          fi
 
   # ── Publish VS Code Extension to Marketplace ──────────────────────────
   # Runs after create-release so the VSIX is always on the Release page


### PR DESCRIPTION
## Problem

The \`Create Release\` step in \`.github/workflows/release.yml\` runs:

\`\`\`bash
gh release create \"\$VERSION\" --title \"Rivet \$VERSION\" --generate-notes release/*
\`\`\`

This fails with \`a release with the same tag name already exists\` if a maintainer ran \`gh release create\` manually right after pushing the tag.

That is exactly what happened on every release in this session — v0.5.0, v0.5.1, **and v0.6.0** all hit this failure. Net effect: each release page exists with the auto-generated changelog notes but has **no binary / VSIX / SHA256 assets** attached.

## Fix

Make the step idempotent:

\`\`\`bash
if gh release view \"\$VERSION\" >/dev/null 2>&1; then
  gh release upload \"\$VERSION\" --clobber release/*
else
  gh release create \"\$VERSION\" --title \"Rivet \$VERSION\" --generate-notes release/*
fi
\`\`\`

If the release already exists, upload assets to it. Otherwise create it from scratch. \`--clobber\` lets re-runs overwrite assets that a previous failed attempt partially uploaded.

## Backfill plan

After this lands, the v0.5.0 / v0.5.1 / v0.6.0 releases all need their binaries uploaded. Re-running the Release workflow on each tag via \`workflow_dispatch\` (or pushing a no-op tag update) will trigger the now-idempotent \`Create or update Release\` step, which will detect the existing release and upload the binaries that were built but never published.

## Test plan

- [ ] CI green
- [ ] After merge: re-run Release workflow on v0.6.0 (most recent), verify assets land on the release page
- [ ] If successful, backfill v0.5.1 and v0.5.0 the same way
- [ ] Future releases: maintainer can still run \`gh release create\` manually right after pushing the tag (for the changelog) without breaking the asset upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)