### PR TITLE
fix(stpa): correct TCL numbering to ISO 26262-8 (TCL1) — issue #254 A1

### DIFF
--- a/safety/stpa/tool-qualification.yaml
+++ b/safety/stpa/tool-qualification.yaml
@@ -11,9 +11,18 @@
 # s-expression evaluator, variant/PLE system, Zola export, needs-json
 # import, MCP write tools, and git hook integration.
 #
-# Tool Confidence Level (TCL): TCL 1 (highest) — rivet's output is
-# directly used as compliance evidence. A false PASS from rivet can
-# prevent detection of a safety-critical gap.
+# Tool Confidence Level (TCL): TCL1 (ISO 26262-8 §11.4.7) — rivet's
+# output is directly used as compliance evidence, but oracle-gated
+# validation raises Tool error Detection (TD) enough that the TI×TD
+# matrix lands at TCL1. A false PASS from rivet can prevent detection
+# of a safety-critical gap; the TI/TD analysis under Workstream A of
+# the tool-qualification dossier qualifies that claim.
+#
+# Cross-walk: ISO 26262 numbers TCL inversely to DO-330. 26262 TCL1
+# is the *lowest* confidence demand (TCL3 highest); DO-330 TQL-1 is
+# the *highest* rigor (TQL-5 lowest). The legacy "TCL 1 (highest)"
+# wording in this file mixed the two conventions; this file now
+# follows ISO 26262 numbering.
 #
 # Reference: STPA Handbook §2.3, ISO 26262-8 §11.4.7
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes the self-contradictory "TCL 1 (highest)" header in `safety/stpa/tool-qualification.yaml` — Workstream A1 of #254. The legacy wording mixed ISO 26262-8 §11.4.7 acronyms (TCL1 is the *lowest* confidence demand) with DO-330 numbering (TQL-1 is the *highest* rigor). The triage decomposition explicitly carved A1 out as landable independently once the lead-regime decision was made; that decision landed on #254 on 2026-05-01 (ISO 26262 confirmed as the lead regime).

Comment-only YAML change. No schema, no Rust, no validation logic touched.

## Acceptance — A1 of #254 Workstream A

> A1. Rename the existing STPA's TCL annotation. Change `safety/stpa/tool-qualification.yaml` line 14 from "TCL 1 (highest)" to match ISO 26262-8 numbering. (~1h)

Per maintainer's 2026-05-01 17:14 comment on #254:
> Fix by writing "TCL1" with cross-walk note.

Mapped to bullets:

- [x] **Header rewritten as "TCL1 (ISO 26262-8 §11.4.7)"** — no parenthetical that contradicts the standard.
- [x] **TCL1 rationale documented inline** — oracle-gated validation raises TD enough to keep the TI×TD matrix at TCL1; the safety risk (false PASS preventing detection of a safety-critical gap) is still framed explicitly so the comment carries its weight.
- [x] **Cross-walk paragraph added** — documents the inverse numbering between ISO 26262 (TCL1 lowest, TCL3 highest) and DO-330 (TQL-1 highest, TQL-5 lowest). Future readers won't repeat the same mix-up.
- [x] **`rivet validate` clean against the baseline** — error set is byte-identical to pristine main (the 6 pre-existing errors live in the `spar:` external fixture and are unaffected).
- [x] **Commit trailer `Implements: REQ-002`** (STPA artifact change per CLAUDE.md trailer reference).

## Out of scope (Workstream A continues in follow-up PRs)

This PR intentionally does **not** close #254. The remaining workstream items each warrant a focused PR:

- **A2** — new `tool-confidence` typed artifact in `schemas/iso-26262.yaml` with `ti: TI1..TI3`, `td: TD1..TD3`, derived `tcl`, link-field `qualification-evidence`. (~4h)
- **A3** — new `ai-found-defect` artifact type in `schemas/common.yaml` plus `defect-against` and `corrects` link types. (~4h)
- **A4** — `docs/design/tool-qualification-dossier.md` and `rivet docs tool-qualification` topic with the seven required sections (TOR, Use Cases, Verification Plan, Configuration Baseline, Known Limitations, Tool Error Detection & Reporting, TCL/TQL Position Statement per regime). (~1-2 days)
- **A5** — `rivet --qualification-mode` flag and `rivet stats --qualification` emitting the configuration-baseline manifest. (~1 day)

A2 and A3 are the natural next slices once this lands.

## Test plan

- [x] `cargo run -p rivet-cli -- validate` — error count unchanged from pristine main (6 errors / 140 warnings / 0 broken cross-refs); error set byte-identical to baseline (`diff /tmp/baseline-errors.txt /tmp/post-edit-errors.txt` empty).
- [x] No Rust source touched — `cargo build` / `cargo clippy` / `cargo test` not exercised by a YAML comment edit.
- [x] Pre-commit hook (rivet validate via `.claude/settings.json`) passed at commit time.

Refs: #254

🤖 Generated with [Claude Code](https://claude.com/claude-code) — issue-triage agent run 2026-05-01.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PT3jgdk3TGsRiPqvCGKHyy)_