### PR TITLE
chore(ci): add concurrency control to all workflows

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,10 @@
 name: Benchmarks
 
+# Cancel superseded PR runs; protect main + scheduled runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
 
+# Cancel superseded PR runs; protect main + scheduled runs.
+# `head_ref || ref` keys per-PR-source-branch on PRs, falls back to ref on push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,5 +1,12 @@
 name: Compliance Report
 
+# Compliance variant: produces compliance reports / signed artifacts. Group
+# for serialization but never cancel — partially-completed compliance runs
+# leave registries / attestations in inconsistent state.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -9,6 +9,13 @@ name: Release NPM
 # Platform packages MUST be published before the root package so npm can
 # resolve optionalDependencies on the first install after tag.
 
+# Release variant: serialize per-release, never cancel. A cancelled npm
+# publish run can leave platform packages published but root package
+# missing — first-install resolution would fail until manual cleanup.
+concurrency:
+  group: release-npm-${{ github.event.release.tag_name || github.event.inputs.version || github.ref }}
+  cancel-in-progress: false
+
 on:
   release:
     types: [published]

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -24,13 +24,6 @@ concurrency:
   group: release-npm-${{ github.event.workflow_run.head_branch || github.event.inputs.version || github.ref }}
   cancel-in-progress: false
 
-# Release variant: serialize per-release, never cancel. A cancelled npm
-# publish run can leave platform packages published but root package
-# missing — first-install resolution would fail until manual cleanup.
-concurrency:
-  group: release-npm-${{ github.event.release.tag_name || github.event.inputs.version || github.ref }}
-  cancel-in-progress: false
-
 on:
   workflow_run:
     workflows: ["Release"]

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -24,6 +24,13 @@ concurrency:
   group: release-npm-${{ github.event.workflow_run.head_branch || github.event.inputs.version || github.ref }}
   cancel-in-progress: false
 
+# Release variant: serialize per-release, never cancel. A cancelled npm
+# publish run can leave platform packages published but root package
+# missing — first-install resolution would fail until manual cleanup.
+concurrency:
+  group: release-npm-${{ github.event.release.tag_name || github.event.inputs.version || github.ref }}
+  cancel-in-progress: false
+
 on:
   workflow_run:
     workflows: ["Release"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release
 
+# Release variant: serialize per-tag, never cancel. A cancelled release
+# mid-publish leaves the GitHub Release page, registries, and per-target
+# binary archives in inconsistent state.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     tags:


### PR DESCRIPTION
## Summary

Adds top-level `concurrency:` blocks to all workflows per the org-wide CI Concurrency Hardening brief. Superseded PR runs are cancelled; main / tag / scheduled / release runs are protected.

## Why

Org-wide stats (2026-05-02): 93 workflows queued across the org; oldest queued job 23h old. Rivet has been intermittently sitting at 5h+ stalls on chore PRs (#246, #256). Without concurrency control, every PR push starts a fresh run while older runs on superseded commits keep executing for zero useful signal.

## Variants applied

| File | Variant | Reason |
|---|---|---|
| `benchmarks.yml` | **default** | regular CI |
| `ci.yml` | **default** | regular CI |
| `compliance.yml` | **compliance** | name + produces compliance reports; never cancel |
| `release.yml` | **release** | tag-triggered binary publish; never cancel |
| `release-npm.yml` | **release** | npm publish; never cancel; keyed on tag-name with fallback |

## Already had correct concurrency, left alone

- `rivet-delta.yml`: groups by `pull_request.number`, always cancels — correct for a PR-only workflow.
- `fuzz.yml`: groups by ref, `cancel-in-progress: false` — correct for hybrid push+schedule (one fuzz run per ref, scheduled corpus growth never lost).

## Verification

- [x] All YAMLs parse via Python `yaml.safe_load`.
- [x] Diff is workflow-files-only (5 files, 32 insertions, 0 deletions).
- [ ] **Verify on this PR**: push a no-op follow-up commit. The earlier PR run should show **Cancelled** in Actions UI within ~30s; the new run starts.
- [ ] **Verify post-merge**: the post-merge `main` run completes normally (not cancelled).

## Out of scope (separate work)

Per the brief: not changing `runs-on:`, not splitting matrices, not changing caching, not minimizing `permissions:`. Those depend on this landing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
