### PR TITLE
ci(release-npm): switch to workflow_run trigger so npm publish auto-fires

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -8,10 +8,26 @@ name: Release NPM
 #
 # Platform packages MUST be published before the root package so npm can
 # resolve optionalDependencies on the first install after tag.
+#
+# Trigger: workflow_run on the Release workflow, NOT release: published.
+# Reason: Release creates the GitHub Release page using the default
+# GITHUB_TOKEN, and GitHub deliberately suppresses downstream workflow
+# triggers from runs that authenticated with GITHUB_TOKEN (loop-prevention
+# guarantee). workflow_run is the documented escape hatch for chaining
+# workflows in this case. Note: workflow_run only fires when this file is
+# present on the default branch.
+
+# Release variant: serialize per-release, never cancel. A cancelled npm
+# publish run can leave platform packages published but root package
+# missing — first-install resolution would fail until manual cleanup.
+concurrency:
+  group: release-npm-${{ github.event.workflow_run.head_branch || github.event.inputs.version || github.ref }}
+  cancel-in-progress: false
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -24,6 +40,9 @@ permissions:
 jobs:
   publish-platform-packages:
     name: Publish platform package (${{ matrix.platform }})
+    # Skip on failed/cancelled upstream Release runs. Always run for
+    # manual workflow_dispatch (used for backfills).
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -60,12 +79,23 @@ jobs:
       - name: Resolve version
         id: version
         env:
-          EVENT_TAG: ${{ github.event.release.tag_name }}
+          # workflow_run: head_branch is the tag name (e.g. v0.8.0) when
+          # the upstream Release workflow ran on a tag push.
+          # workflow_dispatch: the user-supplied tag input (used for
+          # backfills of releases whose initial workflow_run never fired).
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
           INPUT_TAG: ${{ github.event.inputs.version }}
         run: |
-          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          TAG="${INPUT_TAG:-$RUN_BRANCH}"
           if [ -z "$TAG" ]; then
             echo "No tag provided" >&2
+            exit 1
+          fi
+          # Guard: only publish for release tags. Release.yml is currently
+          # only triggered by tag push, but this guard makes the workflow
+          # safe against accidental manual runs of Release on a branch ref.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Tag '$TAG' is not a release tag (expected vX.Y.Z); skipping" >&2
             exit 1
           fi
           VERSION="${TAG#v}"
@@ -113,6 +143,7 @@ jobs:
   publish-root-package:
     name: Publish root package (@pulseengine/rivet)
     needs: publish-platform-packages
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -125,10 +156,10 @@ jobs:
       - name: Resolve version
         id: version
         env:
-          EVENT_TAG: ${{ github.event.release.tag_name }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
           INPUT_TAG: ${{ github.event.inputs.version }}
         run: |
-          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          TAG="${INPUT_TAG:-$RUN_BRANCH}"
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Diagnoses why `release-npm.yml` hasn't fired since v0.6.0 and fixes it.
- The Release workflow creates the GitHub Release page using `GITHUB_TOKEN`. GitHub deliberately suppresses downstream workflow triggers from runs that authenticated with `GITHUB_TOKEN` (loop-prevention guarantee), so the historical `release: published` trigger on this file never fires for v0.7.0 / v0.8.0 — both stuck without npm publication despite binaries being on the Release page.
- Switches the trigger to `workflow_run` on the upstream Release workflow — the documented escape hatch for chaining workflows when the upstream uses `GITHUB_TOKEN`.

## Why this approach

| Option | Cost | Tradeoff |
|---|---|---|
| **A: `workflow_run` (this PR)** | ~10 lines of YAML | Clean, no PAT needed, no rotation |
| B: PAT in `release.yml`'s `gh release create` | Generate / store / rotate a `RELEASE_PAT` secret | Keeps original trigger semantics; ongoing PAT chore |
| C: Inline npm-publish jobs into `release.yml` | Largest refactor | Loses workflow isolation |

Picked A.

## Notable changes

- `head_branch` on a tag-pushed source workflow is the tag name itself (e.g. `v0.8.0`), so version resolution stays one liner.
- Tag-format guard added: only proceeds if `TAG` matches `^v[0-9]+\.[0-9]+\.[0-9]+`.
- Both jobs gated on `workflow_run.conclusion == 'success'` so failed/cancelled Release runs don't fire downstream publishes; `workflow_dispatch` bypasses the gate for manual backfills.
- Adds the standard "release-variant" `concurrency:` block consistent with #258.

## Backfill plan

Once this lands on `main`, manually dispatch the npm publish for the two stuck releases:

```bash
gh workflow run release-npm.yml -f version=v0.7.0
gh workflow run release-npm.yml -f version=v0.8.0
```

Both have all 5 platform binary archives present on their Release pages, so the platform-package jobs will succeed and the root `@pulseengine/rivet` package will publish.

## Conflict note

`#258` (CI concurrency hardening) also touches `release-npm.yml`'s top section. If #258 lands first, this PR will need a small rebase to keep the new variable names (`workflow_run.head_branch` instead of `release.tag_name`). Either order works.

## Test plan

- [ ] CI yamllint passes on this PR.
- [ ] After merge: `gh workflow run release-npm.yml -f version=v0.7.0` → all 5 platform packages publish, then root publishes.
- [ ] After v0.7.0 backfill: `gh workflow run release-npm.yml -f version=v0.8.0` → same.
- [ ] Verify `npm view @pulseengine/rivet version` returns `0.8.0`.
- [ ] Future v0.9.0 release auto-triggers `release-npm.yml` via `workflow_run` (validates the actual fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)