### PR TITLE
feat(bundle): rivet bundle &lt;ID&gt; --depth N --as {yaml,jsonl} (#206)

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -338,6 +338,20 @@ enum Command {
         format: String,
     },
 
+    /// Bundle an artifact and its link-graph closure as a single pasteable document
+    Bundle {
+        /// Root artifact ID
+        id: String,
+
+        /// Number of link-graph hops to include (0 = root only)
+        #[arg(long, default_value_t = 1)]
+        depth: usize,
+
+        /// Output format: "yaml" (default) or "jsonl"
+        #[arg(long = "as", default_value = "yaml")]
+        format: String,
+    },
+
     /// List artifacts, optionally filtered by type
     List {
         /// Filter by artifact type
@@ -1696,6 +1710,7 @@ fn run(cli: Cli) -> Result<bool> {
             baseline.as_deref(),
         ),
         Command::Get { id, format } => cmd_get(&cli, id, format),
+        Command::Bundle { id, depth, format } => cmd_bundle(&cli, id, *depth, format),
         Command::Stats {
             filter,
             format,
@@ -5028,6 +5043,28 @@ fn cmd_get(cli: &Cli, id: &str, format: &str) -> Result<bool> {
     }
 
     Ok(true)
+}
+
+/// Bundle an artifact + its link-graph closure (issue #206).
+fn cmd_bundle(cli: &Cli, id: &str, depth: usize, format: &str) -> Result<bool> {
+    use rivet_core::bundle::{BundleFormat, bundle, render};
+
+    let Some(fmt) = BundleFormat::parse(format) else {
+        eprintln!("error: --as must be one of: yaml, jsonl");
+        return Ok(false);
+    };
+
+    let ctx = ProjectContext::load(cli)?;
+    match bundle(&ctx.store, id, depth) {
+        Ok(entries) => {
+            print!("{}", render(&entries, fmt));
+            Ok(true)
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            Ok(false)
+        }
+    }
 }
 
 /// List artifacts.

--- a/rivet-cli/src/mcp.rs
+++ b/rivet-cli/src/mcp.rs
@@ -110,6 +110,27 @@ pub struct GetParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct BundleParams {
+    #[schemars(description = "Root artifact ID")]
+    pub id: String,
+    #[schemars(
+        description = "Number of link-graph hops to include (0 = root only). Defaults to 1."
+    )]
+    #[serde(default = "default_bundle_depth")]
+    pub depth: usize,
+    #[schemars(description = "Output format: 'yaml' (default) or 'jsonl'")]
+    #[serde(default = "default_bundle_format")]
+    pub format: String,
+}
+
+fn default_bundle_depth() -> usize {
+    1
+}
+fn default_bundle_format() -> String {
+    "yaml".to_string()
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct CoverageParams {
     #[schemars(description = "Filter by traceability rule name")]
     pub rule: Option<String>,
@@ -344,6 +365,20 @@ impl RivetServer {
         Ok(CallToolResult::success(vec![Content::text(
             serde_json::to_string_pretty(&result).unwrap_or_default(),
         )]))
+    }
+
+    #[tool(
+        description = "Bundle an artifact and its link-graph closure into a single pasteable document. \
+                       Pass `id` (root), optional `depth` (default 1), and optional `format` ('yaml' or 'jsonl'). \
+                       Saves N round-trips of `rivet_get` when reasoning about a root and its neighbours."
+    )]
+    fn rivet_bundle(
+        &self,
+        Parameters(p): Parameters<BundleParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let text =
+            self.with_project(|proj| tool_bundle_rendered(proj, &p.id, p.depth, &p.format))?;
+        Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 
     #[tool(description = "Compute traceability coverage per rule")]
@@ -620,6 +655,14 @@ fn tool_stats_cached(proj: &McpProject) -> Value {
     }
 
     json!({"total": proj.store.len(), "types": types, "orphans": orphans, "broken_links": proj.graph.broken.len()})
+}
+
+fn tool_bundle_rendered(proj: &McpProject, id: &str, depth: usize, format: &str) -> Result<String> {
+    use rivet_core::bundle::{BundleFormat, bundle, render};
+    let fmt = BundleFormat::parse(format)
+        .ok_or_else(|| anyhow::anyhow!("format must be 'yaml' or 'jsonl', got {format:?}"))?;
+    let entries = bundle(&proj.store, id, depth)?;
+    Ok(render(&entries, fmt))
 }
 
 fn tool_get_cached(proj: &McpProject, id: &str) -> Result<Value> {

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -2394,3 +2394,168 @@ fn variant_matrix_loads_variants_dir() {
     assert!(stdout.contains("- variant: tiny-ci"));
     assert!(stdout.contains("- variant: full-ci"));
 }
+
+// ── rivet bundle (issue #206) ───────────────────────────────────────────
+
+/// `rivet bundle <ID> --depth 0` returns just the root.
+#[test]
+fn bundle_depth_zero_root_only() {
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "bundle",
+            "FEAT-001",
+            "--depth",
+            "0",
+        ])
+        .output()
+        .expect("run rivet bundle");
+
+    assert!(
+        output.status.success(),
+        "rivet bundle must exit 0. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("# rivet bundle (count=1, depth-max=0)"));
+    assert!(stdout.contains("- id: FEAT-001"));
+    // depth-0 must NOT pull in neighbours
+    assert!(!stdout.contains("- id: REQ-001"));
+    assert!(!stdout.contains("- id: REQ-002"));
+    assert!(!stdout.contains("- id: DD-031"));
+}
+
+/// `rivet bundle <ID> --depth 1 --as yaml` emits inline `# linktype -> target`
+/// annotations and the depth-1 closure.
+#[test]
+fn bundle_depth_one_yaml_with_annotations() {
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "bundle",
+            "FEAT-001",
+            "--depth",
+            "1",
+            "--as",
+            "yaml",
+        ])
+        .output()
+        .expect("run rivet bundle");
+
+    assert!(
+        output.status.success(),
+        "rivet bundle must exit 0. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("- id: FEAT-001"), "root absent: {stdout}");
+    assert!(stdout.contains("- id: REQ-001"), "neighbour REQ-001 absent");
+    assert!(stdout.contains("- id: REQ-002"), "neighbour REQ-002 absent");
+    assert!(
+        stdout.contains("# satisfies -> REQ-002"),
+        "inline link annotation missing"
+    );
+    assert!(
+        stdout.contains("# implements -> DD-031"),
+        "inline link annotation missing"
+    );
+}
+
+/// `rivet bundle <ID> --as jsonl` emits one JSON record per line, each
+/// independently parseable.
+#[test]
+fn bundle_jsonl_format() {
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "bundle",
+            "FEAT-001",
+            "--depth",
+            "1",
+            "--as",
+            "jsonl",
+        ])
+        .output()
+        .expect("run rivet bundle");
+
+    assert!(
+        output.status.success(),
+        "rivet bundle --as jsonl must exit 0. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert!(
+        lines.len() >= 2,
+        "jsonl needs root + neighbours, got {}",
+        lines.len()
+    );
+    for line in &lines {
+        let parsed: serde_json::Value =
+            serde_json::from_str(line).expect("each jsonl line must be valid JSON");
+        assert!(
+            parsed.get("id").is_some(),
+            "each entry must have an `id` field"
+        );
+        assert!(
+            parsed.get("depth").is_some(),
+            "each entry must have a `depth` field"
+        );
+    }
+}
+
+/// Missing artifact root → non-zero exit and a clear error message.
+#[test]
+fn bundle_missing_root_fails() {
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "bundle",
+            "DOES-NOT-EXIST-9999",
+        ])
+        .output()
+        .expect("run rivet bundle");
+
+    assert!(
+        !output.status.success(),
+        "rivet bundle on missing root must exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("DOES-NOT-EXIST-9999") || stderr.contains("not found"),
+        "stderr must explain the missing root, got: {stderr}"
+    );
+}
+
+/// Invalid `--as` value is rejected with a clear error.
+#[test]
+fn bundle_invalid_format_fails() {
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "bundle",
+            "FEAT-001",
+            "--as",
+            "xml",
+        ])
+        .output()
+        .expect("run rivet bundle");
+
+    assert!(
+        !output.status.success(),
+        "rivet bundle --as xml must exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("yaml") && stderr.contains("jsonl"),
+        "stderr must list valid formats, got: {stderr}"
+    );
+}

--- a/rivet-cli/tests/mcp_integration.rs
+++ b/rivet-cli/tests/mcp_integration.rs
@@ -175,7 +175,7 @@ fn parse_result(result: &CallToolResult) -> Value {
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_tools_list_returns_all_15_tools() {
+async fn test_tools_list_returns_all_16_tools() {
     let tmp = tempfile::tempdir().unwrap();
     create_test_project(tmp.path());
 
@@ -189,6 +189,7 @@ async fn test_tools_list_returns_all_15_tools() {
         "rivet_validate",
         "rivet_list",
         "rivet_get",
+        "rivet_bundle",
         "rivet_stats",
         "rivet_coverage",
         "rivet_schema",
@@ -345,6 +346,62 @@ async fn test_rivet_get_invalid_id() {
         result.is_err(),
         "expected error for nonexistent artifact, got: {result:?}"
     );
+
+    client.cancel().await.expect("cancel");
+}
+
+#[tokio::test]
+async fn test_rivet_bundle_yaml_depth_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_test_project(tmp.path());
+
+    let client = spawn_mcp_client(tmp.path()).await;
+
+    // DD-001 satisfies REQ-001 in the fixture; depth=1 should pull both in.
+    let mut args = serde_json::Map::new();
+    args.insert("id".to_string(), Value::String("DD-001".to_string()));
+    args.insert("depth".to_string(), Value::Number(1u64.into()));
+    args.insert("format".to_string(), Value::String("yaml".to_string()));
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("rivet_bundle").with_arguments(args))
+        .await
+        .expect("call_tool rivet_bundle");
+
+    let text = first_text(&result);
+    assert!(text.contains("- id: DD-001"), "root absent: {text}");
+    assert!(text.contains("- id: REQ-001"), "neighbour absent: {text}");
+    assert!(
+        text.contains("# satisfies -> REQ-001"),
+        "inline annotation absent: {text}"
+    );
+
+    client.cancel().await.expect("cancel");
+}
+
+#[tokio::test]
+async fn test_rivet_bundle_jsonl() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_test_project(tmp.path());
+
+    let client = spawn_mcp_client(tmp.path()).await;
+
+    let mut args = serde_json::Map::new();
+    args.insert("id".to_string(), Value::String("DD-001".to_string()));
+    args.insert("depth".to_string(), Value::Number(1u64.into()));
+    args.insert("format".to_string(), Value::String("jsonl".to_string()));
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("rivet_bundle").with_arguments(args))
+        .await
+        .expect("call_tool rivet_bundle");
+
+    let text = first_text(&result);
+    let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 2, "DD-001 + REQ-001 expected, got: {text}");
+    for line in &lines {
+        let _: Value = serde_json::from_str(line).expect("each line must parse as JSON");
+    }
 
     client.cancel().await.expect("cancel");
 }

--- a/rivet-core/src/bundle.rs
+++ b/rivet-core/src/bundle.rs
@@ -1,0 +1,415 @@
+//! Bundle: emit the typed link-graph closure of an artifact as a single,
+//! pasteable document for LLM context windows.
+//!
+//! Backs the `rivet bundle <ID> --depth N --as {yaml,jsonl}` CLI command and
+//! the `rivet_bundle` MCP tool. See issue #206 for the motivation: the
+//! natural reasoning workflow is `get root -> get neighbour -> get
+//! neighbour-of-neighbour` which is N round-trips for what should be one.
+//!
+//! Traversal is breadth-first over outgoing links and visit-once, so cycles
+//! are inherently safe. Targets that don't exist in the store are emitted
+//! as references inside the parent's `links:` list but are not expanded
+//! (they have no record of their own).
+
+use std::collections::{BTreeSet, VecDeque};
+
+use serde::Serialize;
+
+use crate::model::{Artifact, ArtifactId, Link};
+use crate::store::Store;
+
+/// Failure modes for `bundle`. Today there's exactly one — root not in
+/// the store. Kept as an enum so adding e.g. depth-bound errors later is
+/// non-breaking.
+#[derive(Debug, thiserror::Error)]
+pub enum BundleError {
+    #[error("artifact '{0}' not found in store")]
+    NotFound(String),
+}
+
+/// One artifact record in a bundle. Carries the artifact's typed payload
+/// plus the depth at which it was reached from the root, so a downstream
+/// reader (or LLM) can see how far each entry sits from the entry point.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct BundleEntry {
+    pub id: ArtifactId,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    pub title: String,
+    /// 0 = root, 1 = direct neighbour, etc.
+    pub depth: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<Link>,
+}
+
+impl BundleEntry {
+    fn from_artifact(a: &Artifact, depth: usize) -> Self {
+        Self {
+            id: a.id.clone(),
+            artifact_type: a.artifact_type.clone(),
+            title: a.title.clone(),
+            depth,
+            status: a.status.clone(),
+            description: a.description.clone(),
+            tags: a.tags.clone(),
+            links: a.links.clone(),
+        }
+    }
+}
+
+/// Output formats for a bundle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundleFormat {
+    /// Inline YAML with link-type annotations as comments.
+    Yaml,
+    /// One JSON object per line — for tool consumers.
+    Jsonl,
+}
+
+impl BundleFormat {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "yaml" => Some(Self::Yaml),
+            "jsonl" => Some(Self::Jsonl),
+            _ => None,
+        }
+    }
+}
+
+/// Build the link-graph closure of `root` to `depth` hops, breadth-first.
+///
+/// Returned in BFS order: root first, then depth-1 neighbours, then
+/// depth-2, and so on. Visit-once means the same artifact never appears
+/// twice; cycles terminate naturally. `depth = 0` returns just the root.
+pub fn bundle(store: &Store, root: &str, depth: usize) -> Result<Vec<BundleEntry>, BundleError> {
+    let root_artifact = store
+        .get(root)
+        .ok_or_else(|| BundleError::NotFound(root.to_string()))?;
+
+    let mut visited: BTreeSet<ArtifactId> = BTreeSet::new();
+    let mut queue: VecDeque<(ArtifactId, usize)> = VecDeque::new();
+    let mut out: Vec<BundleEntry> = Vec::new();
+
+    visited.insert(root_artifact.id.clone());
+    queue.push_back((root_artifact.id.clone(), 0));
+
+    while let Some((id, d)) = queue.pop_front() {
+        let Some(art) = store.get(&id) else {
+            // The root is guaranteed present (checked above); a missing
+            // mid-traversal id can only happen if a link points outside
+            // the store. Skip silently — the dangling target still shows
+            // up as a `target:` reference inside the parent's `links:`.
+            continue;
+        };
+        out.push(BundleEntry::from_artifact(art, d));
+        if d >= depth {
+            continue;
+        }
+        for link in &art.links {
+            if visited.insert(link.target.clone()) {
+                queue.push_back((link.target.clone(), d + 1));
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Render a bundle to the requested format.
+pub fn render(entries: &[BundleEntry], format: BundleFormat) -> String {
+    match format {
+        BundleFormat::Yaml => render_yaml(entries),
+        BundleFormat::Jsonl => render_jsonl(entries),
+    }
+}
+
+/// YAML rendering with inline `# <link-type> -> <target>` annotations on
+/// each link. We render by hand rather than using `serde_yaml::to_string`
+/// because comments can't round-trip through serde and the annotations
+/// are the whole point of the format ("an LLM reading top-to-bottom
+/// resolves references without a second lookup").
+fn render_yaml(entries: &[BundleEntry]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# rivet bundle (count={}, depth-max={})\n",
+        entries.len(),
+        entries.iter().map(|e| e.depth).max().unwrap_or(0),
+    ));
+    for entry in entries {
+        out.push_str(&format!("- id: {}\n", entry.id));
+        out.push_str(&format!("  type: {}\n", entry.artifact_type));
+        out.push_str(&format!("  depth: {}\n", entry.depth));
+        out.push_str(&format!("  title: {}\n", yaml_scalar(&entry.title)));
+        if let Some(status) = &entry.status {
+            out.push_str(&format!("  status: {}\n", yaml_scalar(status)));
+        }
+        if let Some(desc) = &entry.description {
+            out.push_str(&format!("  description: {}\n", yaml_scalar(desc)));
+        }
+        if !entry.tags.is_empty() {
+            out.push_str("  tags:\n");
+            for tag in &entry.tags {
+                out.push_str(&format!("    - {}\n", yaml_scalar(tag)));
+            }
+        }
+        if !entry.links.is_empty() {
+            out.push_str("  links:\n");
+            for link in &entry.links {
+                out.push_str(&format!("    # {} -> {}\n", link.link_type, link.target));
+                out.push_str(&format!("    - type: {}\n", link.link_type));
+                out.push_str(&format!("      target: {}\n", link.target));
+            }
+        }
+    }
+    out
+}
+
+/// JSONL rendering: one entry per line, no inline comments (JSON has
+/// none). Suitable for tool consumers / streaming readers.
+fn render_jsonl(entries: &[BundleEntry]) -> String {
+    let mut out = String::new();
+    for entry in entries {
+        let line = serde_json::to_string(entry)
+            .unwrap_or_else(|e| format!("{{\"error\":\"serialize: {e}\"}}"));
+        out.push_str(&line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Quote a YAML scalar if it contains characters that would otherwise
+/// trigger flow-style ambiguity. Conservative — over-quoting is fine
+/// for a paste-into-LLM document; under-quoting breaks YAML parsers.
+fn yaml_scalar(s: &str) -> String {
+    let needs_quote = s.is_empty()
+        || s.contains(':')
+        || s.contains('#')
+        || s.contains('\n')
+        || s.contains('"')
+        || s.contains('\'')
+        || s.starts_with('-')
+        || s.starts_with('?')
+        || s.starts_with('!')
+        || s.starts_with('&')
+        || s.starts_with('*')
+        || s.starts_with('[')
+        || s.starts_with('{')
+        || s.trim() != s;
+    if needs_quote {
+        let escaped = s
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n");
+        format!("\"{escaped}\"")
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn make(id: &str, art_type: &str, title: &str, links: Vec<(&str, &str)>) -> Artifact {
+        Artifact {
+            id: id.into(),
+            artifact_type: art_type.into(),
+            title: title.into(),
+            description: None,
+            status: None,
+            tags: vec![],
+            links: links
+                .into_iter()
+                .map(|(t, target)| Link {
+                    link_type: t.into(),
+                    target: target.into(),
+                })
+                .collect(),
+            fields: BTreeMap::new(),
+            provenance: None,
+            source_file: None,
+        }
+    }
+
+    fn store_with(artifacts: Vec<Artifact>) -> Store {
+        let mut s = Store::new();
+        for a in artifacts {
+            s.upsert(a);
+        }
+        s
+    }
+
+    #[test]
+    fn depth_zero_returns_root_only() {
+        let store = store_with(vec![
+            make(
+                "REQ-001",
+                "requirement",
+                "root",
+                vec![("satisfies", "REQ-002")],
+            ),
+            make("REQ-002", "requirement", "leaf", vec![]),
+        ]);
+        let b = bundle(&store, "REQ-001", 0).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].id, "REQ-001");
+        assert_eq!(b[0].depth, 0);
+    }
+
+    #[test]
+    fn depth_one_returns_root_plus_neighbours() {
+        let store = store_with(vec![
+            make(
+                "REQ-001",
+                "requirement",
+                "root",
+                vec![("satisfies", "REQ-002"), ("blocks", "REQ-003")],
+            ),
+            make("REQ-002", "requirement", "n1", vec![("derives", "REQ-004")]),
+            make("REQ-003", "requirement", "n2", vec![]),
+            make("REQ-004", "requirement", "deep", vec![]),
+        ]);
+        let b = bundle(&store, "REQ-001", 1).unwrap();
+        assert_eq!(b.len(), 3);
+        assert_eq!(b[0].id, "REQ-001");
+        assert_eq!(b[0].depth, 0);
+        let neighbours: BTreeSet<_> = b[1..].iter().map(|e| e.id.as_str()).collect();
+        assert!(neighbours.contains("REQ-002"));
+        assert!(neighbours.contains("REQ-003"));
+        assert!(!neighbours.contains("REQ-004"));
+    }
+
+    #[test]
+    fn depth_two_includes_two_hop_closure() {
+        let store = store_with(vec![
+            make(
+                "REQ-001",
+                "requirement",
+                "root",
+                vec![("satisfies", "REQ-002")],
+            ),
+            make(
+                "REQ-002",
+                "requirement",
+                "mid",
+                vec![("derives", "REQ-003")],
+            ),
+            make("REQ-003", "requirement", "leaf", vec![]),
+        ]);
+        let b = bundle(&store, "REQ-001", 2).unwrap();
+        assert_eq!(b.len(), 3);
+        assert_eq!(b[2].id, "REQ-003");
+        assert_eq!(b[2].depth, 2);
+    }
+
+    #[test]
+    fn cycle_terminates() {
+        // A -> B -> A
+        let store = store_with(vec![
+            make("A", "requirement", "a", vec![("links-to", "B")]),
+            make("B", "requirement", "b", vec![("links-to", "A")]),
+        ]);
+        let b = bundle(&store, "A", 5).unwrap();
+        // Each artifact must appear exactly once.
+        assert_eq!(b.len(), 2);
+        let ids: Vec<_> = b.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, vec!["A", "B"]);
+    }
+
+    #[test]
+    fn dangling_target_not_emitted() {
+        let store = store_with(vec![make(
+            "REQ-001",
+            "requirement",
+            "root",
+            vec![("satisfies", "REQ-MISSING")],
+        )]);
+        let b = bundle(&store, "REQ-001", 5).unwrap();
+        // Only the root expands; REQ-MISSING is referenced in its links
+        // but has no record of its own.
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].links.len(), 1);
+        assert_eq!(b[0].links[0].target, "REQ-MISSING");
+    }
+
+    #[test]
+    fn missing_root_errors() {
+        let store = store_with(vec![]);
+        let err = bundle(&store, "REQ-001", 1).unwrap_err();
+        assert!(matches!(err, BundleError::NotFound(_)));
+    }
+
+    #[test]
+    fn yaml_renders_inline_link_annotations() {
+        let store = store_with(vec![
+            make(
+                "REQ-001",
+                "requirement",
+                "root",
+                vec![("satisfies", "REQ-002")],
+            ),
+            make("REQ-002", "requirement", "leaf", vec![]),
+        ]);
+        let b = bundle(&store, "REQ-001", 1).unwrap();
+        let out = render(&b, BundleFormat::Yaml);
+        // The `# satisfies -> REQ-002` comment is the whole point.
+        assert!(
+            out.contains("# satisfies -> REQ-002"),
+            "missing inline annotation: {out}"
+        );
+        // The structured form is still emitted alongside.
+        assert!(out.contains("- type: satisfies"));
+        assert!(out.contains("target: REQ-002"));
+    }
+
+    #[test]
+    fn yaml_header_reports_count_and_max_depth() {
+        let store = store_with(vec![
+            make("R", "requirement", "root", vec![("links-to", "L")]),
+            make("L", "requirement", "leaf", vec![]),
+        ]);
+        let b = bundle(&store, "R", 3).unwrap();
+        let out = render(&b, BundleFormat::Yaml);
+        assert!(out.starts_with("# rivet bundle (count=2, depth-max=1)\n"));
+    }
+
+    #[test]
+    fn jsonl_one_record_per_line() {
+        let store = store_with(vec![
+            make("R", "requirement", "root", vec![("links-to", "L")]),
+            make("L", "requirement", "leaf", vec![]),
+        ]);
+        let b = bundle(&store, "R", 1).unwrap();
+        let out = render(&b, BundleFormat::Jsonl);
+        let lines: Vec<_> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        // Each line is independently parseable as JSON.
+        for line in &lines {
+            let _: serde_json::Value = serde_json::from_str(line).unwrap();
+        }
+    }
+
+    #[test]
+    fn yaml_scalar_quotes_when_needed() {
+        assert_eq!(yaml_scalar("plain"), "plain");
+        assert_eq!(yaml_scalar("has: colon"), "\"has: colon\"");
+        assert_eq!(yaml_scalar(""), "\"\"");
+        assert_eq!(yaml_scalar("# starts hash"), "\"# starts hash\"");
+        assert_eq!(yaml_scalar("- starts dash"), "\"- starts dash\"");
+    }
+
+    #[test]
+    fn format_parse_accepts_known_values() {
+        assert_eq!(BundleFormat::parse("yaml"), Some(BundleFormat::Yaml));
+        assert_eq!(BundleFormat::parse("jsonl"), Some(BundleFormat::Jsonl));
+        assert_eq!(BundleFormat::parse("xml"), None);
+    }
+}

--- a/rivet-core/src/lib.rs
+++ b/rivet-core/src/lib.rs
@@ -40,6 +40,7 @@
 pub mod adapter;
 pub mod agent_pipelines;
 pub mod bazel;
+pub mod bundle;
 pub mod cited_source;
 pub mod commits;
 pub mod compliance;


### PR DESCRIPTION
## Summary

Closes #206 — implements the `rivet bundle <ID> --depth N --as {yaml,jsonl}` CLI command, the `rivet_bundle` MCP tool, and the `rivet-core/src/bundle.rs` module. An LLM agent reasoning about an artifact and its neighbours can now get the full link-graph closure in **one** round-trip instead of N — closing the gap the issue body identified after Karpathy's [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).

## What changed

- **`rivet-core/src/bundle.rs`** (new). Breadth-first, visit-once traversal over `Store::get` + `Artifact::links`, returning a depth-stamped `Vec<BundleEntry>`. Cycles terminate via the visited set. Depth 0 = root only; depth 1 = root + direct neighbours. Dangling targets (links pointing outside the store) appear as `target:` references inside the parent's `links:` list but are not expanded.
- **`BundleFormat::{Yaml, Jsonl}` rendering**. YAML is hand-rendered (not `serde_yaml`) because the `# satisfies -> REQ-002` inline annotations are the whole point of the format and serde can't round-trip comments. JSONL is one `serde_json` record per line for tool consumers / streaming readers.
- **`rivet-cli/src/main.rs`** — new `Command::Bundle { id, depth, format }` variant with `--depth` (default 1) and `--as` (default `yaml`). Handler `cmd_bundle` loads the project context, calls `bundle::bundle`, prints the rendered output. Invalid `--as` values produce a clear error listing the valid options.
- **`rivet-cli/src/mcp.rs`** — new `rivet_bundle` MCP tool with `BundleParams { id, depth, format }`. Defaults match the CLI. Returns the rendered bundle as text content.

## Acceptance — issue #206 (lifted from the [2026-04-26](https://github.com/pulseengine/rivet/issues/206#issuecomment-4322898285) + [2026-05-09](https://github.com/pulseengine/rivet/issues/206#issuecomment-4412519919) triage comments)

- [x] **New module `rivet-core/src/bundle.rs`** with closure traversal over `Store` + `Link` graph, depth-bounded — `bundle::bundle()`, lines 90–122.
- [x] **`rivet bundle <ID> --depth N --as {yaml,jsonl}` CLI command** — `Command::Bundle` variant + `cmd_bundle` handler.
- [x] **MCP tool `rivet_bundle`** so agents call this without shelling — `mcp.rs`, decorated `#[tool(...)]` on `rivet_bundle`.
- [x] **Output carries inline link annotations** (`# satisfies -> REQ-004` style) — proven by `bundle_depth_one_yaml_with_annotations` (CLI) and `test_rivet_bundle_yaml_depth_one` (MCP).
- [x] **Snapshot/regression test fixture: depth-0 → only root; depth-1 → root + neighbours; depth-2 → two-hop closure** — `depth_zero_returns_root_only`, `depth_one_returns_root_plus_neighbours`, `depth_two_includes_two_hop_closure` in `bundle::tests`.
- [x] **Cycle handling tested** (artifact A → B → A does not loop) — `cycle_terminates`.
- [x] **Markdown rendering explicitly out of scope** per the issue body.
- [x] **Commit trailer `Implements: REQ-007` (CLI) and `Refs: FEAT-010` (MCP)** — present.

## Test plan

- [x] `cargo test -p rivet-core --lib` — **931 pass** (920 prior + 11 new `bundle::tests`).
- [x] `cargo test -p rivet-cli --test cli_commands` — **66 pass** (61 prior + 5 new bundle tests: depth-0 root only, depth-1 + annotations, jsonl shape, missing-root non-zero exit, invalid-format rejection).
- [x] `cargo test -p rivet-cli --test mcp_integration` — **24 pass** (22 prior + 2 new bundle tests; tools-list count test bumped 15 → 16 to register `rivet_bundle`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo run --release -p rivet-cli -- validate` — `6 errors / 140 warnings / 0 broken cross-refs` — byte-identical to pristine `main`. The 6 errors live in the `spar:` external fixture and are unaffected.
- [x] `cargo run --release -p rivet-cli -- docs check` — `PASS (47 files scanned, 0 violations)`.
- [ ] CI on this PR — verified by GHA.

## Out of scope

- **Markdown rendering**, per the issue body's "Out of scope" section. YAML preserves typed structure with zero information loss; markdown would re-introduce ambiguity rivet's typed model exists to remove.
- **`docs/getting-started.md` deep-dive on bundle** — left for a docs-only follow-up so the surface lands first and stays focused (one-PR-per-issue rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — issue-triage agent run 2026-05-09.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJu9Vcj1gPWGrrjCYqpwyg)_