### PR TITLE
ci(release): install wasm-component-ld in build-test-evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,13 @@ jobs:
         with:
           tool: cargo-nextest,cargo-llvm-cov
 
+      # wasm32-wasip2 component builds link via wasm-component-ld. Recent
+      # nightlies have stopped bundling it with the target's tools, so the
+      # spar WASM build fails with `Executable "wasm-component-ld" doesn't
+      # exist!`. Install it explicitly.
+      - name: Install wasm-component-ld
+        run: cargo install --locked wasm-component-ld
+
       - name: Build spar WASM assets
         run: |
           git clone --depth 1 https://github.com/pulseengine/spar.git ../spar


### PR DESCRIPTION
## Summary

The v0.9.0 Release workflow failed: `build-test-evidence` errored with `clang++: error: unable to execute command: Executable "wasm-component-ld" doesn't exist!` during the spar `wasm32-wasip2` build, which skipped `Create GitHub Release` (it's in that job's `needs:`), blocking the entire release.

`wasm-component-ld` is the WASI Preview 2 component linker. Recent Rust nightlies have stopped bundling it with the `wasm32-wasip2` target's tools, so `dtolnay/rust-toolchain@nightly` + `targets: wasm32-wasip2` no longer provides it. v0.8.0 happened to land on a nightly that still bundled it.

Fix: `cargo install --locked wasm-component-ld` before the WASM build step.

## After merge
- Delete + re-create the `v0.9.0` tag at the new main HEAD so the Release workflow re-runs with this fix (the v0.9.0 tag published nothing, so re-tagging is safe).

## Test plan
- [ ] CI green
- [ ] After merge + re-tag: Release workflow's `build-test-evidence` passes, `Create GitHub Release` runs, v0.9.0 release page gets all 9 assets
- [ ] `release-npm.yml` auto-fires via `workflow_run` (validates #261)
- [ ] `npm view @pulseengine/rivet version` → 0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)