### PR TITLE
ci(release): install lld (wasm-ld) for build-test-evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,12 +183,18 @@ jobs:
         with:
           tool: cargo-nextest,cargo-llvm-cov
 
-      # wasm32-wasip2 component builds link via wasm-component-ld. Recent
-      # nightlies have stopped bundling it with the target's tools, so the
-      # spar WASM build fails with `Executable "wasm-component-ld" doesn't
-      # exist!`. Install it explicitly.
-      - name: Install wasm-component-ld
-        run: cargo install --locked wasm-component-ld
+      # wasm32-wasip2 builds need two linkers that recent toolchains/runner
+      # images no longer provide out of the box:
+      #   - wasm-component-ld: the WASI Preview 2 component linker (nightly
+      #     stopped bundling it with the target's tools).
+      #   - wasm-ld: the LLVM wasm linker, invoked by clang++ when a C/C++
+      #     dependency (e.g. highs-sys, pulled in transitively by spar)
+      #     does a CMake CXX-ABI probe targeting wasm. Provided by `lld`.
+      - name: Install wasm linkers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lld
+          cargo install --locked wasm-component-ld
 
       - name: Build spar WASM assets
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #269. With `wasm-component-ld` installed, the v0.9.0 Release workflow's `build-test-evidence` gets further but fails again — `highs-sys v1.12.1` (transitive C++ dep via spar) does a CMake CXX-ABI probe targeting wasm and clang++ can't find `wasm-ld`:

```
error: failed to spawn "wasm-ld"
clang++: error: linker command failed with exit code 1
```

`wasm-ld` is the LLVM wasm linker — shipped in the `lld` apt package. Install it alongside `wasm-component-ld`.

## After merge
- Delete + re-create the `v0.9.0` tag at the new main HEAD to re-run the Release workflow with this fix. (v0.9.0 has published nothing yet, so re-tagging is safe.)

If `build-test-evidence` STILL fails after this on yet another missing wasm toolchain component, the better fix is to make that job `continue-on-error: true` so the release isn't blocked by compliance-artifact tooling — the binary builds (what users install) all succeed.

## Test plan
- [ ] CI green
- [ ] After merge + re-tag: `build-test-evidence` passes, `Create GitHub Release` runs, v0.9.0 page gets all 9 assets
- [ ] `release-npm.yml` auto-fires via `workflow_run` (validates #261)
- [ ] `npm view @pulseengine/rivet version` → 0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)