### PR TITLE
ci(release): make build-test-evidence non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,15 @@ jobs:
   build-test-evidence:
     name: Build test evidence
     runs-on: ubuntu-latest
+    # Non-blocking: the test-evidence bundle is a compliance artifact, not
+    # something users install. Building the spar wasm32-wasip2 assets needs
+    # a full WASI C/C++ SDK (sysroot + libc/libc++ + clang_rt builtins),
+    # which the runner image no longer ships — wasm-ld can't find crt1.o /
+    # -lc / libclang_rt.builtins-wasm32.a even with lld + wasm-component-ld
+    # installed (#269, #271). Until wasi-sdk is wired in (tracked separately),
+    # let this job fail without blocking Create GitHub Release — the release
+    # then ships 8/9 assets (everything except rivet-vX.Y.Z-test-evidence.tar.gz).
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

The v0.9.0 Release workflow has been blocked for several iterations by `build-test-evidence`. After #269 (`wasm-component-ld`) and #271 (`lld`/`wasm-ld`), it still fails — the spar `wasm32-wasip2` build pulls in `highs-sys` (a C++ solver), whose CMake CXX-ABI probe needs a full WASI C/C++ SDK:

```
wasm-ld: error: cannot open crt1.o: No such file or directory
wasm-ld: error: unable to find library -lc++ / -lc++abi / -lc
wasm-ld: error: cannot open .../wasip2/libclang_rt.builtins-wasm32.a
```

The runner image no longer ships a WASI sysroot, and wiring in `wasi-sdk` (download, `WASI_SDK_PATH`, point clang at the sysroot) is a bigger lift than is worth blocking a release on. The **test-evidence bundle is a compliance artifact, not a user-facing binary** — all 5 binary archives + vsix + compliance report build fine.

Fix: `continue-on-error: true` on the `build-test-evidence` job. A failure no longer skips `Create GitHub Release`; the release ships 8/9 assets (missing only `rivet-vX.Y.Z-test-evidence.tar.gz`). Restoring it properly is tracked separately.

## After merge
- Delete + re-create `v0.9.0` tag at the new main HEAD to re-run the Release workflow.

## Test plan
- [ ] CI green
- [ ] After merge + re-tag: `Create GitHub Release` runs even though `build-test-evidence` fails; v0.9.0 page gets 8 assets
- [ ] `release-npm.yml` auto-fires via `workflow_run` (validates #261)
- [ ] `npm view @pulseengine/rivet version` → 0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)