### PR TITLE
docs(design): three roadmap design tracks for v0.10 (variant, cross-org, TCL)

### DIFF
--- a/docs/design/cross-org-supplier-traceability.md
+++ b/docs/design/cross-org-supplier-traceability.md
@@ -1,0 +1,609 @@
+# Cross-Organizational / Supplier-Management Traceability for Rivet
+
+Audience: rivet maintainers and ALM-tool users planning OEM-supplier
+traceability work. Scope: how rivet should represent the case where the
+top of a project sits in one organization, parts of the chain are in-house
+variants, and other parts are owned by an external supplier whose model,
+field names, and even toolchain are not under our control.
+
+## 1. Executive summary
+
+Rivet's traceability story today is single-organization. `rivet sync`,
+`rivet lock`, `rivet baseline verify`, and the cross-repo `prefix:ID`
+syntax all assume the dependency's `rivet.yaml` is reachable, parseable,
+and uses rivet's own schema vocabulary. As soon as one downstream party
+runs Polarion, DOORS, or just a different field convention, the model
+breaks: links go dangling, coverage looks red, and the "boundary" is
+invisible to the auditor. This note proposes (a) a typed
+**`external-anchor`** artifact that explicitly marks a chain end at an
+organizational boundary, (b) a structured **`derives-from-external`**
+link target, (c) a 3-state coverage outcome (`SATISFIED` /
+`EXTERNAL_BOUNDARY` / `UNCOVERED`) so audit reports stop conflating
+"missing in our store" with "delegated to a supplier", (d) a
+field-mapping recipe schema reusing `schemas/migrations/` and (e) a
+provenance trail that records what was received, when, in what format,
+and whose hash. The MVP is small (~3 weeks of work) and lives entirely
+on top of today's file-based, server-less architecture.
+
+## 2. Today's state in rivet
+
+What's there:
+
+- **`externals:` in `rivet.yaml`** ([model.rs:271-285](../../rivet-core/src/model.rs))
+  declares dependency repos with `git`, `path`, `ref`, and a `prefix`
+  used for cross-repo linking (`rivet:REQ-001`).
+- **`rivet sync`** ([externals.rs:92-296](../../rivet-core/src/externals.rs))
+  clones / fetches / symlinks externals into `.rivet/repos/<prefix>`.
+- **`rivet lock`** writes `rivet.lock` pinning each external to a commit
+  SHA ([externals.rs:527-555](../../rivet-core/src/externals.rs)).
+- **`rivet baseline verify`** ([externals.rs:714-746](../../rivet-core/src/externals.rs))
+  cross-checks that each external repo carries a `baseline/<name>` git tag,
+  so a release boundary can be signed off across repos.
+- **Cross-repo backlinks** ([externals.rs:788-820](../../rivet-core/src/externals.rs))
+  scan an external's artifacts for inbound links to local IDs.
+- **Circular and version-conflict detection** ([externals.rs:592-651, 834-893](../../rivet-core/src/externals.rs))
+  for the externals graph.
+- **`schemas/common.yaml`** declares the link-type vocabulary
+  (`derives-from`, `allocated-from`, `satisfies`, `verifies`, etc.) but
+  every link target is a flat string ID — no notion of *who owns the
+  target*.
+- **ReqIF adapter** ([reqif.rs](../../rivet-core/src/reqif.rs)) and the
+  in-progress **OSLC client** ([oslc.rs](../../rivet-core/src/oslc.rs))
+  are the two cross-tool wires rivet has today. Both are individually
+  scoped exporters, not federation primitives.
+- **`cited-source` typed field** (shipped 0.7.0,
+  [cited_source.rs](../../rivet-core/src/cited_source.rs)) lets an
+  artifact carry `{ uri, kind, sha256, last-checked }` — a sha-stamped
+  pointer to an upstream source. Phase 1 implements only `kind: file`;
+  `kind: oslc | reqif | polarion` round-trip but skip remote checks.
+- **`schemas/migrations/`** ([dev-to-aspice.yaml](../../schemas/migrations/dev-to-aspice.yaml))
+  and the migrate engine ([migrate.rs](../../rivet-core/src/migrate.rs))
+  ship a typed mapping recipe for type-rename / link-rename / field-map
+  with three policy classes (`drop`, `keep-as-orphan`, `strict`). This
+  is the closest existing primitive to "supplier uses different field
+  names than I do".
+
+What's missing for cross-org / supplier traceability:
+
+- **No notion of "the chain ends here intentionally."** A requirement
+  whose downstream is owned by a supplier looks identical to one we
+  forgot to satisfy. Coverage is binary: covered / uncovered.
+- **No structured external link target.** A link's `target:` is a
+  string. There is no type-safe slot for "supplier acme, contract
+  4711, doc-id REQ-SW-022, fetched 2026-04-20, sha256 …".
+- **No federation handshake.** `rivet sync` requires the supplier to
+  ship a full rivet repo. Real suppliers ship ReqIF, Excel, Word, or
+  in best case a Polarion REST endpoint behind OAuth.
+- **No field-mapping at the artifact-import boundary.** The migrate
+  engine is for "schema-to-schema in our store", not "the supplier
+  hands me ReqIF where `priority: P1` means `priority: must`".
+- **No provenance for federated artifacts.** When an external artifact
+  appears in our graph it carries the same shape as a local one — no
+  "received-at, source-tool, hash-at-fetch, contract-ref" record.
+- **Coverage gaps.** `compute_coverage`
+  ([coverage.rs:116-199](../../rivet-core/src/coverage.rs)) walks the
+  link graph and counts forward / backward links. It does not check
+  whether an unsatisfied requirement happens to terminate at a
+  supplier boundary, so the reporter can't distinguish
+  "we missed it" from "supplier owes us this".
+
+## 3. Competitor / standards survey
+
+### 3.1 Polarion (Siemens / Polarion ALM)
+
+Polarion's two relevant primitives are **cross-project linking**
+and the **ALM Connector / OSLC adapter**. Within a single Polarion
+instance, projects can link work items across project boundaries with
+a single role (`linkedWorkItems`) and the work item is reachable via
+its global URI. Across instances or to non-Polarion tools Polarion
+relies on either OSLC (preferred for IBM ELM / DOORS Next interop) or
+ReqIF round-trip for OEM-supplier exchange. The "external boundary"
+case is handled by treating the foreign requirement as an **external
+work item** whose source-of-truth lives outside Polarion: the local
+work item carries a hyperlink-typed custom field plus optional
+"linked external work item" metadata. Change-of-custody is handled by
+*re-importing* the supplier's ReqIF and reconciling against an
+existing `ReqIF.ForeignID`. Status: works but largely manual; the
+auditor sees the foreign reference but the fidelity is whatever the
+ReqIF profile preserved (see
+[polarion-reqif-fidelity.md §2](polarion-reqif-fidelity.md) for what
+that means in practice — provenance and typed custom fields are the
+big ABSENT cluster).
+
+(Sources verified: I have read the existing rivet doc
+[polarion-reqif-fidelity.md](polarion-reqif-fidelity.md) which itself
+warns that some Polarion entity claims are training-only, unverified.
+WebFetch of `developer.siemens.com/polarion/rest-api-spec.html` and
+public Polarion docs was denied in this environment.)
+
+### 3.2 IBM DOORS / DOORS Next (DNG)
+
+DOORS classic supports module-to-module links inside a single
+database, with **link modules** acting as the broker. Supplier
+exchange relied on DXL exports, ReqIF (DOORS 9.4+), or the IBM
+Rational Synergy gateway. DOORS Next uses OSLC-RM and OSLC-CM as the
+wire format; cross-repo traceability is a first-class concept via
+**configuration-managed baselines** (Global Configuration
+Management / GCM in Jazz Team Server). The "external boundary"
+pattern is the OSLC `Link` to a remote `oslc:Resource` — the local
+side stores the URI and an `oslc:label`, and the consumer follows
+the link via HTTP. If the remote tool is unreachable or the consumer
+has no credentials, DNG shows the link as "unresolved" without
+treating it as an integrity violation. **Lessons for rivet**:
+(1) the boundary needs to be a representable state, not an error;
+(2) configuration baselines are how you pin a release across an
+inter-org tree.
+
+### 3.3 sphinx-needs (Open-source)
+
+sphinx-needs is the closest open-source analogue to rivet's
+file-based model. It supports **`needs_external_needs`** in
+`conf.py` (verified via WebFetch:
+<https://sphinx-needs.readthedocs.io/en/latest/configuration.html>):
+each entry is `{ base_url, json_url|json_path, version, id_prefix,
+target_url, css_class }` and represents read-only federated access
+to needs published by another project. External needs are flagged
+internally with `is_external = True` so filters can include /
+exclude them. Critically, sphinx-needs does *not* try to round-trip:
+external needs cannot be edited locally and are hyperlinked back to
+the publisher. This is exactly the "chain ends here" semantic rivet
+is missing.
+
+What sphinx-needs lacks (and rivet should not copy): no notion of
+*contract* or *expected derivatives* — the consumer cannot say "I
+expect this supplier to produce a `verification` for each
+`requirement` I delegated".
+
+### 3.4 OSLC (Open Services for Lifecycle Collaboration)
+
+OSLC is the OASIS-hosted suite of REST/RDF specs for cross-tool
+traceability. The relevant pieces:
+
+- **OSLC Core** — service-provider discovery, query syntax, ETags.
+- **OSLC RM / QM / CM / AM** — domain shapes for requirements,
+  quality, change, architecture management. Rivet already maps the
+  first three ([oslc.rs:60-140](../../rivet-core/src/oslc.rs)).
+- **OSLC Configuration Management** — global configurations for
+  cross-tool baselines.
+- **Tracked Resource Set (TRS)** — change feeds for incremental sync
+  between tools.
+
+OSLC's "external boundary" model is implicit: a link's target is a
+URI in another service provider, possibly under another tenant. ETag
+versioning lets a consumer detect drift. **Known gap (industry
+folklore, not from a verified source)**: OSLC presupposes that all
+tools are reachable and authenticated; it has no canonical answer for
+"the supplier publishes a snapshot once a quarter and you can't poll
+their server", which is the realistic OEM-tier-1 case in automotive.
+This is precisely the gap rivet's file-based + git-coordinated
+approach can fill if it copies the *link semantics* (URI + ETag /
+hash) without inheriting the *protocol assumption* (live HTTP).
+
+### 3.5 ReqIF (OMG, ISO 29148-aligned)
+
+ReqIF is the OMG-standardised XML interchange format for
+requirements (current public version 1.2; 1.3 widely implemented).
+Core elements: `SPEC-OBJECT` (a requirement), `SPEC-OBJECT-TYPE`
+(its shape), `ATTRIBUTE-DEFINITION` and `DATATYPE-DEFINITION` (its
+fields), `SPEC-RELATION` and `SPEC-RELATION-TYPE` (links).
+Supplier-relevant fields: `IDENTIFIER` (tool-internal), `LONG-NAME`
+(human title), and the critical `ReqIF.ForeignID` and
+`ReqIF.ForeignCreatedOn` attributes that survive a round-trip
+between tools — they are the de facto identity carrier between OEM
+and supplier. The **Automotive ReqIF Implementation Guide** (HIS
+working group, picked up by ProSTEP iViP) standardises the OEM
+delivery: which attribute names mean what (status, ASIL, variant
+classification), how to handle change cycles, and how to encode
+typed custom fields. **Lessons for rivet**: ReqIF is the lowest
+common denominator for offline supplier exchange — *if* you can
+preserve `ForeignID` on the way in and out, you have a poor man's
+federation handshake. Rivet's current ReqIF round-trip drops
+provenance entirely
+([polarion-reqif-fidelity.md §2-3](polarion-reqif-fidelity.md)).
+
+(Sources: WebFetch to the OMG ReqIF spec page and Wikipedia were
+denied. The above relies on the existing rivet `reqif.rs`
+implementation and the polarion-reqif-fidelity.md design doc which
+references reqif.rs line-by-line, plus the author's training-cutoff
+knowledge of the standard. Spot-check before committing to specific
+attribute names.)
+
+### 3.6 AUTOSAR ARXML (automotive supplier handoff)
+
+AUTOSAR uses ARXML (XML schema) as the contract between OEM and
+tier-1 supplier for software components: SWC port interfaces, data
+types, ECU configuration. ARXML has typed namespaces and a strict
+schema, so the "field mapping" problem is largely already solved at
+the standard level — the cost is paid up-front by everyone agreeing
+to AUTOSAR's vocabulary. Crucially, ARXML has the concept of a
+**partial delivery**: a supplier may ship an ARXML file containing
+only their components, and an OEM tool merges multiple ARXML files
+into a system view. This is a pull-mode federation that rivet could
+mirror at the artifact level: each party publishes their slice; the
+audit consumer merges. The trade-off is the merge has to be
+deterministic and conflict-free, which is why ARXML has explicit
+namespace rules.
+
+### 3.7 ISO 26262 Part 8 §5 — interfaces within distributed development
+
+Part 8 §5 of ISO 26262:2018 ("Interfaces within distributed
+developments") is the standards anchor for OEM-supplier safety work.
+It requires a **DIA (Development Interface Agreement)** that
+identifies what each party owns, how change is communicated, and
+how evidence is exchanged. The DIA is a contract, not a tool, but
+its concepts map directly to the rivet design proposed below:
+
+- *Items and elements assigned to each party* → rivet artifacts
+  tagged with the owner.
+- *Communication of work products* → the federation handshake.
+- *Joint review and confirmation measures* → the
+  EXTERNAL_BOUNDARY coverage state plus a `received-status` field.
+
+(Source: standard text, training-only — not WebFetched in this
+session. The DIA concept is well-known in automotive; the user
+should confirm specific clause numbers before quoting in audit
+material.)
+
+### 3.8 ASPICE PAM 4.0 — SUP.10 and SUP.8
+
+ASPICE PAM 4.0 SUP.10 (Change Request Management) and SUP.8
+(Configuration Management) cover the inter-organizational interface
+implicitly: SUP.10.BP3 (analyze change requests) and BP6 (track
+status) and SUP.8.BP4 (establish baselines) all assume that change
+and config can be communicated across the OEM-supplier boundary.
+They do not prescribe a wire format. Rivet's existing
+`baseline verify` is the SUP.8.BP4 primitive at the file level;
+nothing in rivet today maps to SUP.10 cross-org change tracking.
+
+### 3.9 Academic literature
+
+I cannot verify these in this session (WebFetch / WebSearch were
+denied for general queries) but the relevant literature, by
+training-data recall, includes:
+
+- Cleland-Huang et al., "Software Traceability: Trends and Future
+  Directions" (FOSE 2014) — surveys link semantics including
+  inter-organisational; identifies "boundary trace" as an open
+  problem.
+- Mäder & Egyed, "Assessing the effect of requirements
+  traceability" — empirical, single-org but the maintenance-cost
+  argument generalises.
+- ProSTEP iViP whitepapers on cross-OEM ReqIF exchange — practical
+  guidance on field mapping.
+
+The literature is sparser than for single-org RE traceability;
+"federation" gets more coverage in the data-management / linked-data
+side (TRS, OSLC) than in the RE-process side. **Be honest about the
+gap**: this is a niche where industry practice (ReqIF round-trips,
+DIA documents) leads academic study.
+
+## 4. Design proposal
+
+### 4.1 New artifact type: `external-anchor`
+
+Declared in `schemas/common.yaml` so every domain inherits it:
+
+```yaml
+artifact-types:
+  - name: external-anchor
+    description: |
+      A typed leaf representing the point at which an
+      in-house traceability chain hands off to an external
+      supplier or organization. The chain is intentionally
+      not followed further; the supplier owns what's
+      downstream. Used to keep coverage honest at the
+      organizational boundary.
+    fields:
+      - name: source-of-truth
+        type: mapping
+        required: true
+        # who owns it: supplier name, contract reference, doc ID
+      - name: expected-derived-types
+        type: list<string>
+        required: true
+        # what we expect the supplier to produce
+        # (e.g. ["sw-req", "verification"])
+      - name: received-status
+        type: enum
+        allowed-values:
+          - not-received
+          - received-as-reqif
+          - received-as-pdf
+          - received-as-oslc
+          - received-as-polarion-export
+          - received-as-arxml
+          - received-other
+        required: true
+      - name: contract-reference
+        type: string
+        required: false
+      - name: cited-source
+        type: cited-source  # already-shipped typed field
+        required: false
+```
+
+The `expected-derived-types` field is the contract: it tells
+coverage what the supplier *should* produce. The
+`received-status` field is the lifecycle state: `not-received`
+flags an open delivery; the `received-as-*` variants stamp what
+the auditor saw. The optional `cited-source` re-uses the typed
+sha-stamped field shipped in 0.7.0 to attach the actual delivered
+artefact (a ReqIF file, a PDF, an OSLC URI).
+
+### 4.2 Cross-org link semantics: `derives-from-external`
+
+Today's link model has `link_type: string` and
+`target: string` ([model.rs:13-19](../../rivet-core/src/model.rs)).
+Cross-org work needs structured target metadata. Rather than
+break the existing model, propose a *mapped* target form for the
+new link type:
+
+```yaml
+links:
+  - type: derives-from-external
+    target:
+      org: acme-electronics
+      contract: PO-4711
+      doc-id: REQ-SW-022
+      last-synced: 2026-04-20
+      sha256: 7f3c…
+      # optional: pointer to the local external-anchor artifact
+      anchor: ANCHOR-ACME-001
+```
+
+YAML detail: `target:` becomes a mapping when `type` is
+`*-external`; it stays a string for all existing link types. The
+schema validates the shape per link type. The `anchor` field is
+the audit-trail pointer back into our store: every external link
+*should* terminate at an `external-anchor` artifact so that
+coverage can find the boundary.
+
+### 4.3 Three-state coverage
+
+`CoverageEntry`
+([coverage.rs:53-72](../../rivet-core/src/coverage.rs)) currently
+stores `covered` and `uncovered_ids`. Extend to:
+
+```rust
+pub struct CoverageEntry {
+    // existing fields...
+    pub satisfied: usize,
+    pub external_boundary: usize,
+    pub external_boundary_ids: Vec<String>,
+    pub uncovered: usize,        // strictly missing
+    pub uncovered_ids: Vec<String>,
+}
+```
+
+The boundary classification rule: when computing whether artifact
+A satisfies a rule via link `derives-from`, walk forward; if the
+link target is an `external-anchor` whose
+`expected-derived-types` contains the rule's required type, count
+as `external_boundary`, not `uncovered`. The auditor sees a
+report like:
+
+```
+ASPICE SWE.1 → SWE.2 coverage:
+  satisfied:           42 / 50 (84%)
+  external boundary:    6 / 50 (12%)  — delegated to acme, gtech
+  uncovered:            2 / 50  (4%)  — REQ-SW-019, REQ-SW-024
+```
+
+Audit-grade because the sum is still 100% and the boundary count
+is non-zero only when an explicit `external-anchor` exists.
+
+### 4.4 Federation handshake
+
+Three options, ranked by cost-to-implement and coverage of real
+supplier patterns:
+
+**Option A: pull mode** (`rivet supplier pull <anchor-id>`).
+Rivet reads the `cited-source` on the anchor and does the right
+thing per kind:
+- `kind: file` — re-hash the local file.
+- `kind: reqif` — fetch / read the ReqIF, run a field-mapping
+  recipe, store the resulting artifacts under
+  `.rivet/supplier-cache/<anchor-id>/`, update the anchor's
+  `received-status` and `last-synced`.
+- `kind: oslc` — TRS sync (Phase 2; reuse oslc.rs).
+- `kind: polarion` — REST sync (depends on a future polarion.rs).
+
+**Option B: push mode** — supplier ships a manifest. The supplier
+runs `rivet supplier publish` in their own repo, which produces a
+signed manifest (artifact list + hashes + ReqIF / OSLC / native
+payload). The OEM consumes via `rivet supplier ingest <manifest>`.
+
+**Option C: ReqIF / OSLC bridge only.** Treat the anchor's
+`cited-source` as the wire format. No new federation layer; rely
+on existing standards. Lowest-cost, highest-leverage on legacy
+supplier toolchains.
+
+**Recommendation: ship A first**, with an MVP that only handles
+`kind: reqif` and `kind: file`. Push and OSLC are Phase 2. This
+keeps the supplier's tool-of-record optional — they keep using
+Polarion or DOORS, the OEM consumes ReqIF.
+
+### 4.5 Field mapping at the boundary
+
+Reuse `schemas/migrations/` recipe shape
+([migrate.rs:62-149](../../rivet-core/src/migrate.rs)) but apply
+it at *import* time, not at *schema-version-bump* time:
+
+```yaml
+# .rivet/supplier-mappings/acme-to-rivet.yaml
+mapping:
+  name: acme-to-rivet
+  source: { external: acme }     # marker: not a preset, an external
+  target: { preset: aspice }
+  type-rewrites:
+    - from: SwRequirement       # acme's type name
+      to: sw-req
+  field-map:
+    - from: priority
+      to: priority
+      value-map:
+        P1: must
+        P2: should
+        P3: may
+  link-rewrites:
+    - from: traceTo
+      to: derives-from
+  policies:
+    unmapped-fields: keep-as-orphan
+    unmapped-link-types: drop
+```
+
+The mapping recipe is invoked by `rivet supplier pull` between
+"parsed external artifacts" and "stored under
+.rivet/supplier-cache/". Every mapped artifact carries a
+provenance breadcrumb (§4.6) so the auditor can recover the
+original.
+
+### 4.6 Provenance trail for federated artifacts
+
+Extend the existing `Provenance` struct
+([model.rs:26-51](../../rivet-core/src/model.rs)) with an optional
+`federation` block:
+
+```rust
+pub struct FederationProvenance {
+    pub source_org: String,        // "acme-electronics"
+    pub source_tool: String,       // "polarion-3.21" / "doors-9.7" / "reqif-1.2"
+    pub source_id: String,         // ForeignID at the supplier
+    pub anchor: String,            // local external-anchor artifact ID
+    pub fetched_at: String,        // ISO-8601
+    pub source_hash: String,       // sha256 of the wire payload
+    pub mapping_recipe: Option<String>, // recipe path, if applied
+}
+```
+
+Federated artifacts are written to
+`.rivet/supplier-cache/<anchor-id>/<source-id>.yaml` (gitignored
+by default; the project may opt to commit a curated subset). This
+means the auditor's view *includes* the imported artifacts but the
+local repo doesn't co-mingle them with first-party work. A new
+`rivet supplier list` shows received deliveries; `rivet supplier
+diff <anchor-id>` shows what changed since the last pull.
+
+## 5. Open questions
+
+1. **Server-less feasibility.** Pull-mode (§4.4 option A) keeps
+   rivet file-based. Push-mode requires a publishing endpoint —
+   could be a static site (manifest.json + signed payload) on the
+   supplier's side, no live server needed. OSLC TRS is the only
+   path that fundamentally wants a running service. Recommend:
+   skip OSLC TRS in the MVP; revisit when a real customer asks.
+2. **Authentication.** ReqIF over HTTPS gives transport security
+   but no signing. Options: PGP-signed manifests (high friction),
+   sigstore / cosign (requires infrastructure), or "signed by git
+   commit on the supplier's published-manifests repo" (cheap,
+   re-uses git's signature infrastructure). Recommend: defer to
+   Phase 2; the MVP records `source_hash` per fetch, which is the
+   primitive every signing scheme needs anyway.
+3. **What's the smallest useful MVP?** — see §6.
+4. **Subcommand placement.** The work spans current
+   `rivet externals` (config, sync, lock) and could plausibly
+   become `rivet supplier`. Recommendation: introduce
+   `rivet supplier` as a new top-level so the audit story is
+   clear; keep `rivet externals` for the rivet-to-rivet case.
+   `rivet externals` is for "another team running rivet";
+   `rivet supplier` is for "another organization, possibly not
+   running rivet".
+5. **Coverage report representation.** Should
+   `external_boundary` count be displayed alongside `satisfied`
+   and `uncovered`, or under a separate "supplier delegation"
+   panel? Recommend the former (single 100% sum, three colours)
+   so the auditor's first glance shows the org boundary
+   explicitly.
+6. **Anchor lifecycle.** When does an `external-anchor` go away?
+   When the supplier's deliverable is integrated and re-imported
+   as first-party? Recommend: never auto-delete; require an
+   explicit `rivet supplier promote <anchor-id>` that converts
+   delegated artifacts to local ones and archives the anchor.
+7. **Variant / PLE interaction.** A supplier may deliver one
+   variant and not another. The `external-anchor` should support
+   the existing `when:` clause from variant work so coverage
+   per-variant honours the supplier scope. Out of MVP; flag for
+   Phase 2.
+8. **Cycles.** A supplier may depend on us (rare but real in
+   joint-venture work). The existing circular-dep detection
+   ([externals.rs:834-893](../../rivet-core/src/externals.rs))
+   handles this for git-based externals; the supplier path needs
+   the same check on the federation graph. Cheap to add.
+
+## 6. Recommendation
+
+**File this as a feature issue and break it into a 3-step rollout.**
+The design is mature enough: every primitive proposed here either
+extends a typed field rivet already has (`cited-source`,
+`provenance`, `migrate.rs` recipes) or follows a precedent set by
+sphinx-needs / DOORS Next. The unknowns (auth, server-less push,
+variant interaction) are deferrable.
+
+**MVP scope (issue #1, ~3 weeks)** — the smallest version that
+demonstrates the boundary-coverage semantic:
+
+1. `external-anchor` artifact type in `schemas/common.yaml`
+   (declarative, no code change beyond schema validation).
+2. Coverage extension: `external_boundary` count + ID list, with
+   the rule "an artifact terminating at an `external-anchor`
+   whose `expected-derived-types` covers the missing type counts
+   as boundary, not uncovered." 30-40 LOC change in `coverage.rs`.
+3. `rivet supplier list` and `rivet supplier check` (read-only
+   commands that surface anchors and boundary coverage).
+4. Doc topic `rivet docs supplier` explaining the model.
+
+That alone makes the auditor story honest: "we have 47
+in-house-satisfied requirements, 6 delegated to acme (boundary),
+2 genuinely uncovered." No federation, no field mapping, no
+imports — just the language to express the boundary.
+
+**Phase 2 (issue #2, ~4-6 weeks)**:
+
+5. `derives-from-external` link type with structured target.
+6. `cited-source` backends for `kind: reqif` (read-only, with
+   sha verification at fetch time).
+7. `rivet supplier pull <anchor-id>` for `kind: file | reqif`,
+   storing under `.rivet/supplier-cache/`.
+8. `FederationProvenance` block on imported artifacts.
+
+**Phase 3 (issue #3, scope-tbd)**:
+
+9. Field-mapping recipes (`schemas/supplier-mappings/`).
+10. `rivet supplier publish` for the rivet-to-rivet supplier
+    case (manifest emission).
+11. OSLC / Polarion / GitHub-issues backends for `cited-source`.
+12. Variant-aware anchors (`when:` clause).
+13. `rivet supplier promote <anchor-id>` to convert a delegated
+    chain to first-party.
+
+The MVP is honest: it *describes* the boundary without
+*federating* across it. That is the audit-critical step. The
+federation work in Phase 2 is where ReqIF / OSLC actually wires
+in and provenance gets stamped per-fetch.
+
+## 7. Evidence register
+
+| Claim | Evidence |
+|-------|----------|
+| `externals:` schema and prefix model | [model.rs:271-285](../../rivet-core/src/model.rs) |
+| `rivet sync` clones / fetches into `.rivet/repos/<prefix>` | [externals.rs:92-296](../../rivet-core/src/externals.rs) |
+| `rivet lock` writes `rivet.lock` with commit pins | [externals.rs:527-555](../../rivet-core/src/externals.rs) |
+| `rivet baseline verify` checks `baseline/<name>` git tags across externals | [externals.rs:714-746](../../rivet-core/src/externals.rs) |
+| Cross-repo backlink scanner | [externals.rs:788-820](../../rivet-core/src/externals.rs) |
+| Circular-dep + version-conflict detection in externals graph | [externals.rs:592-651, 834-893](../../rivet-core/src/externals.rs) |
+| `cited-source` typed field with sha256 + `last-checked` | [cited_source.rs](../../rivet-core/src/cited_source.rs) |
+| `cited-source` allowed schemes include `oslc`, `reqif`, `polarion` (round-trip in Phase 1, no backend) | [cited_source.rs:53-81, 95-97](../../rivet-core/src/cited_source.rs) |
+| Migration recipe shape (type-rewrites, link-rewrites, field-map, policies) | [migrate.rs:62-149](../../rivet-core/src/migrate.rs); [dev-to-aspice.yaml](../../schemas/migrations/dev-to-aspice.yaml) |
+| Coverage today is 2-state (covered / uncovered) | [coverage.rs:53-72, 116-199](../../rivet-core/src/coverage.rs) |
+| Common link types (`derives-from`, `allocated-from`, etc.) | [schemas/common.yaml:67-102](../../schemas/common.yaml) |
+| ReqIF round-trip drops provenance and coerces non-string fields | [polarion-reqif-fidelity.md §2](polarion-reqif-fidelity.md); [reqif.rs:782, 968-970](../../rivet-core/src/reqif.rs) |
+| OSLC client maps RM / QM / CM domains | [oslc.rs:60-140](../../rivet-core/src/oslc.rs) |
+| sphinx-needs `needs_external_needs` is read-only federated | WebFetch <https://sphinx-needs.readthedocs.io/en/latest/configuration.html> |
+| Polarion / DOORS / OSLC / ReqIF / AUTOSAR / ISO 26262 / ASPICE specifics | training-data only — WebFetch was denied for the standards source pages in this session. **Spot-check before committing to specific clause numbers or attribute names in audit material.** |
+
+---
+
+Refs: REQ-020 (cross-repo links), REQ-025 (adapters), FEAT-001
+(export / interop surface). New requirement candidates:
+**REQ-NEW-supplier-anchor**, **REQ-NEW-boundary-coverage**.

--- a/docs/design/tool-confidence-level.md
+++ b/docs/design/tool-confidence-level.md
@@ -1,0 +1,709 @@
+<!-- rivet-docs-check: design-doc-aspirational-ok -->
+
+# Tool Confidence Level (TCL) — research and design for rivet
+
+**Status:** design / research note (not a qualification opinion)
+**Audience:** safety leads, sales engineers fielding TCL questions, rivet
+maintainers planning a `tool-qualification` workstream
+**Date:** 2026-04-27
+**Refs:** `docs/design/iso26262-artifact-mapping.md` §C row 32, `docs/design/ai-safety-cyber-hitl.md`,
+`safety/stpa/tool-qualification.yaml`, `safety/stpa-sec/tool-qualification-sec.yaml`,
+`schemas/iso-pas-8800.yaml` (`ai-tool-qual`), `schemas/score.yaml` (`tsf.classification`),
+`schemas/en-50128.yaml` (`tool-qualification`), `docs/oracles.md`,
+`docs/mutation-testing.md`, `SAFETY.md`, `docs/verification.md`.
+
+> **Source-fetch limitation, called out up front.** Live web fetch was
+> denied for this session. Standard-clause references in §2 are quoted
+> from the author's prior reading and the rivet repo's own training-time
+> citations; entries flagged *(unverified clause-level)* must be
+> re-checked against a paid copy of the standard before any external
+> publication. The internal-rivet citations (file paths and code) are
+> verified against `main` at the date above.
+
+---
+
+## 1. Executive summary
+
+Rivet today positions itself in the existing
+`safety/stpa/tool-qualification.yaml` STPA at **TCL 1** — a self-claim,
+no qualification dossier, scoped to "rivet validates and we trust the
+output." That claim is honest as a *target* but is not yet supported by
+the dossier-shaped evidence an auditor expects. The user is correct that
+**TCL 1 is the wrong terminal answer for an AI-in-the-loop traceability
+substrate**: a tool whose explicit job is to make AI-authored evidence
+auditable cannot disclaim error-detection responsibility the way a
+read-only ALM can. The right level for rivet's intended role is **TCL 2
+with a TCL 3 path**, supported by the ingredients already shipped (Verus,
+Kani, Rocq, mutation testing, oracle-gated pipelines, cited-source hash
+verification, schema-migrate snapshot/abort, structural validators)
+plus three new artifacts: a typed `tool-confidence` record, a
+qualification dossier topic in `rivet docs`, and an `ai-found-defect`
+provenance type. Polarion's TCL 1 self-claim is defensible *only*
+because the human review workflow is the detection mechanism — when AI
+drafts the artifact, that defence weakens, and rivet's higher bar
+becomes the right shape for the same role.
+
+---
+
+## 2. Standards primer — TCL / TQL / TI / TD across five regimes
+
+Each regime asks the same two questions of every development tool used
+on a safety project: **Could a tool error end up in the safety case?**
+(impact) and **Would we catch it before it does?** (detection /
+qualification). Different standards encode the answer with different
+letters.
+
+### 2.1 ISO 26262:2018 Part 8, Clause 11 — automotive
+
+*(Clause numbers below are from training-time references; the structure
+is widely published in conference talks and TÜV white-papers, but
+verbatim wording requires the paid standard.)*
+
+The clause defines two parameters and one derived classification:
+
+- **TI — Tool Impact.** Two values: **TI1** (no possibility that a
+  malfunctioning tool inserts/fails-to-detect errors in a safety-related
+  item) and **TI2** (such a possibility exists).
+- **TD — Tool error Detection.** Three values: **TD1** (high confidence
+  the user/process detects a tool error before it reaches the safety
+  case), **TD2** (medium confidence), **TD3** (low or no confidence).
+- **TCL — Tool Confidence Level.** Derived from the (TI, TD) cell:
+
+  | TI \ TD     | TD1  | TD2  | TD3  |
+  |-------------|------|------|------|
+  | **TI1**     | TCL1 | TCL1 | TCL1 |
+  | **TI2**     | TCL1 | TCL2 | TCL3 |
+
+  TCL1 is the lowest confidence demand (no qualification evidence
+  required); TCL3 is the highest. Confusingly, several standards (and
+  several rivet documents) use "TCL 1" to mean "highest confidence" —
+  see §2.6 below for the convention rivet should adopt.
+
+- **Qualification methods.** For TCL2/TCL3, ISO 26262-8 Table 4 lists:
+  (a) **increased confidence from use** (proven-in-use evidence), (b)
+  **evaluation of the tool development process** against a recognised
+  standard, (c) **validation of the software tool**, (d) **development
+  in accordance with a safety standard**. Method choice depends on ASIL
+  of the work product the tool touches.
+
+### 2.2 IEC 61508-3:2010 — generic functional safety
+
+- **T1 / T2 / T3 categories.** T1 = no impact on safety code (e.g. text
+  editor). T2 = supports verification / cannot insert errors but can
+  fail to detect them (e.g. test runner, coverage tool). T3 = generates
+  output used directly in safety code or its verification (e.g.
+  compiler, code generator, model-to-C tool).
+- **Annex C-D / Table A.3** *(unverified clause-level)* lists
+  techniques required per SIL: T3 tools at SIL 3/4 require validation
+  evidence, T2 at SIL 3/4 requires demonstrated suitability, T1 needs
+  none.
+- The IEC 61508 framing is closer to TI than to TD — the category
+  records *what the tool can do*, not what the user catches. TD is
+  implicit in the qualification activities for T2/T3.
+
+### 2.3 DO-178C / DO-330 — civil aviation
+
+- **DO-178C §12.2** classifies tools as **Tool Type 1** (output
+  becomes part of airborne software), **Tool Type 2** (eliminates,
+  reduces, or automates verification activities and could fail to
+  detect errors), and **Tool Type 3** (legacy term, merged into the
+  others in the C revision).
+- **DO-330 TQL-1 to TQL-5.** The Tool Qualification Level matrix maps
+  (Tool Type, DAL of the software the tool affects) to a TQL:
+
+  | Tool criteria \ DAL  | A    | B    | C    | D    |
+  |----------------------|------|------|------|------|
+  | Criteria 1 (Type 1)  | TQL-1| TQL-2| TQL-3| TQL-4|
+  | Criteria 2 (Type 2)  | TQL-4| TQL-4| TQL-5| TQL-5|
+  | Criteria 3 (Type 2 mild) | TQL-5| TQL-5| TQL-5| TQL-5|
+
+  *(Cell values from training-time references; the matrix shape is
+  widely published, exact entries should be re-checked.)*
+  TQL-1 demands the most rigorous DO-330 process activities; TQL-5 the
+  least.
+
+### 2.4 EN 50128:2011 — railway software
+
+- **Class T1 / T2 / T3** mirrors IEC 61508. Clause 6.7 *(unverified)*
+  enumerates qualification expectations: documented requirements,
+  verified outputs, traceability of tool versions. SIL 3/4 raise the
+  bar for T2/T3.
+- The rivet schema `schemas/en-50128.yaml` already declares a
+  `tool-qualification` artifact-type (currently with empty `fields:` —
+  a bookkeeping placeholder, not a typed record).
+
+### 2.5 ISO/SAE 21434:2021 — automotive cybersecurity
+
+- Tool considerations live in **Clause 5.4.6** *(unverified)*: tools
+  affecting cybersecurity work products inherit confidence-management
+  obligations analogous to ISO 26262-8 §11. The standard does not
+  introduce a separate TCL/TQL ladder; the expectation is that the
+  same tool be qualified once for the joint safety + security
+  toolchain. Practical impact: a TCL2 claim should cover both the
+  STPA artifact set *and* the STPA-Sec artifact set rivet ships.
+
+### 2.6 ISO/PAS 8800:2024 — AI in road vehicles
+
+- Introduces a five-level **TQL-1..TQL-5** ladder for tools that author,
+  verify, or qualify AI elements. The rivet schema
+  `schemas/iso-pas-8800.yaml` exposes this as the `ai-tool-qual.tool-class`
+  field.
+- Higher TQL is required when the tool touches data quality, training,
+  or operational evidence for the AI element. A traceability tool
+  binding `requirement` to `ai-element` (rivet's exact role) sits
+  squarely in this ladder's middle range, not at TQL-5 (lowest).
+
+### 2.7 Numbering convention warning
+
+ISO 26262, EN 50128, IEC 61508: **lower number = lower bar.** TCL3 / T3
+demand the most evidence.
+
+DO-330, ISO/PAS 8800: **lower number = higher bar.** TQL-1 demands the
+most evidence.
+
+Rivet's `safety/stpa/tool-qualification.yaml` line 14 says
+"Tool Confidence Level (TCL): TCL 1 (highest)." That is the **DO-330
+convention** applied to a 26262 acronym — sloppy and an audit-review
+flag in itself. The rivet documentation should switch consistently to
+the standard-native numbering and never abbreviate "TCL 1" without the
+regime in front of it. **Recommendation A1** (see §8): rename the
+existing artifact's TCL annotation to "ISO 26262 TCL3" (highest) or
+"DO-330 TQL-2" (whichever frame the team picks for v0.5.0).
+
+---
+
+## 3. Polarion's TCL claim — analysis
+
+*(Live fetch of Polarion's tool-qualification kit was unavailable this
+session. The summary below is from prior reading and `docs/design/polarion-reqif-fidelity.md`.
+Verbatim quotation requires re-fetch from siemens.com before external
+use.)*
+
+### 3.1 What Siemens publicly says
+
+- Siemens publishes a **Polarion ALM Tool Qualification Kit** for ISO
+  26262 (and adjacent IEC 62304 / DO-178C kits). It is a *self-claim*
+  package with a tool-operational-requirements document, a verification
+  procedure, qualification report, and a tool-error log. *(unverified
+  in this session; reproduce against current Siemens download portal
+  before quoting.)*
+- The classification typically asserted in their kit is **TCL1 in ISO
+  26262 terms** — i.e. *no qualification evidence required* — based on
+  the argument that **Polarion is a passive ALM repository whose output
+  is reviewed by qualified humans** before it is used in the safety
+  case. The kit covers the residual TI2/TD1 risk by documenting the
+  human review workflow as the detection mechanism.
+- This is a TI2/TD1 → TCL1 argument. It is internally consistent: an
+  ALM tool *can* output a wrong artifact (TI2), but the standard
+  workflow inserts a human reviewer between Polarion's output and the
+  safety case (TD1).
+
+### 3.2 Is the user right that TCL1 is "too low"?
+
+**The user is right for rivet, and only conditionally right for Polarion.**
+
+The TI2/TD1 → TCL1 derivation is sound *given the assumption that the
+human review is independent and competent*. That assumption holds
+reasonably well when:
+
+- The artifact author is a human who typed the requirement.
+- The reviewer reads the *full* artifact text, not a summary.
+- The reviewer's domain knowledge is sufficient to detect a wrong link.
+
+It begins to fail when:
+
+- The author is an AI and the reviewer's effective oversight is "skim
+  the diff." (Automation bias is a recognised effect — EU AI Act
+  Article 14 explicitly names it as something the human-oversight
+  designate must be trained against.)
+- The reviewer relies on the tool's *aggregate* output (coverage
+  percentages, pass/fail summaries) rather than re-deriving each
+  judgment.
+- The tool surface is large enough that no single reviewer can hold the
+  full toolchain configuration in their head.
+
+Both the second and third bullet apply to *any* sufficiently rich ALM
+under heavy use, AI or not. The first bullet is the AI-specific
+intensifier the user is pointing at: it doesn't fundamentally change
+the math, but it makes TD1 (high detection confidence) much harder to
+defend with a straight face. In TI/TD terms, **AI-authored content shifts
+TD from TD1 to TD2 unless the tool itself supplies a non-human
+detection layer.** That non-human detection layer is precisely what
+rivet ships (validate, oracle-gated pipelines, cited-source hashing)
+and what plain Polarion does not.
+
+So Polarion's TCL1 is conditionally honest *for human-authored
+content* and increasingly threadbare *for AI-authored content*. Rivet's
+opportunity is to be the tool that lets the customer keep TCL1 by
+contributing TD-raising machinery to the toolchain, **not** to claim
+TCL1 as a passive ALM peer of Polarion.
+
+### 3.3 Scope and conditional language to expect
+
+Customer claims based on the Polarion kit are typically conditioned on:
+
+- "When used as configured" — the qualification covers a specific
+  configuration baseline; user-added scripts / extensions / custom
+  workflows fall outside.
+- "When integrated with X" — the kit may presume specific integrations
+  (Polarion → Jenkins, Polarion → Bitbucket) and exclude others.
+- The kit is a *supplier-provided argument*; the project's safety
+  manager still owns the final TCL decision in the project context.
+
+Rivet should adopt the same shape: any qualification claim must name
+the configuration baseline, the integrations in scope, and the
+explicit responsibility split with the customer's safety manager.
+
+---
+
+## 4. Competitor baseline — what other ALM / traceability tools claim
+
+| Tool | Public TCL/TQL claim | Basis | Source posture |
+|---|---|---|---|
+| **IBM DOORS / DOORS Next** | ISO 26262 TCL1 / IEC 61508 T2 in customer dossiers; not generally a public claim | Self + customer audit | Closed; per-customer NDA dossier |
+| **Siemens Polarion ALM** | ISO 26262 TCL1 via supplier kit | Self-claim + reviewer-as-detection | Public-ish (kit available to customers) |
+| **PTC codeBeamer** | ISO 26262 / IEC 62304 / DO-178C "tool qualification kit" available | Self + supplier kit | Per-customer |
+| **Jama Connect** | "Compliant-ready" framing (ISO 26262, IEC 62304) — TCL1 typical | Self-claim, human-review-as-detection | Public marketing |
+| **Ansys medini analyze** | ISO 26262 TCL3 (highest) for FMEDA / FTA — *they* generate numeric safety evidence | Validation + supplier kit | Public |
+| **BTC EmbeddedPlatform** | ISO 26262 TCL3 / DO-330 TQL-4 for back-to-back & MIL/SIL/PIL | Validation + supplier kit | Public |
+| **sphinx-needs** | No TCL claim. Project-level documentation only. | None | OSS |
+| **strictDoc** | No TCL claim. | None | OSS |
+| **rivet (today)** | Aspirational TCL3-per-26262 (highest, miscalled "TCL1" in the existing STPA), no dossier yet | Self-STPA, no kit | OSS |
+
+*(Rows above are from training-time references and `docs/design/polarion-reqif-fidelity.md`;
+verify current marketing claims against vendor sites before publishing externally.)*
+
+The pattern is consistent: **passive ALM stays at TCL1 by leaning on
+human review; tools that *generate* numeric safety output (medini, BTC)
+go all the way to TCL3 with a real validation dossier.** Rivet sits in
+the middle: it is not a pure ALM (it generates coverage metrics, runs
+oracles, scores variants, validates traceability rules) and it is not a
+numeric safety calculator (it does not compute SPFM/LFM/PMHF).
+
+The honest peer group for rivet is **medini / BTC**, not Polarion. The
+practical bar is therefore **TCL2 with a TCL3 path**, not "match
+Polarion's TCL1."
+
+---
+
+## 5. Rivet's safeguards mapped to TI / TD
+
+The TI / TD framing is the right axis to evaluate each rivet feature
+against. *Lower TI* means the tool *cannot* introduce / fail-to-detect
+an error in the first place. *Higher TD* means even if the tool errs,
+the user / process catches it before it reaches the safety case.
+
+### 5.1 What rivet actually authors versus consumes
+
+Rivet's **direct outputs** that could become safety-case evidence:
+
+1. `rivet validate` PASS/FAIL verdicts (used as gating evidence in CI).
+2. `rivet coverage` numeric percentages (used as evidence of trace
+   completeness).
+3. `rivet export` / Zola export pages (used as the *form* in which
+   evidence reaches an auditor).
+4. ReqIF / OSLC roundtrip outputs (used to feed Polarion / DOORS).
+5. Commit-traceability matrix from `rivet commits` (used as evidence
+   that code changes trace to requirements).
+6. Variant-emit manifest (used to scope a release to a configuration).
+7. `rivet check <oracle>` JSON envelopes (gating decisions in
+   pipelines).
+
+Each of those is a TI2 surface — a wrong output here can degrade the
+safety case. There is no TI1 (no-impact) feature in rivet's main path,
+and that is the point: rivet exists to be in the safety case, not
+adjacent to it.
+
+### 5.2 TD-raising machinery rivet already ships
+
+For each safeguard, the question is: *does it lower TI (rivet cannot
+emit a wrong output here) or raise TD (even if rivet does, we catch it
+before it lands in the safety case)?*
+
+| # | Safeguard | TI / TD effect | Strength | Reference |
+|---|---|---|---|---|
+| 1 | **Typed schema with `deny_unknown_fields`** | Lowers TI: ill-typed input fails fast, not silently | Strong | `rivet-core/src/model.rs:62-100` |
+| 2 | **Bidirectional link oracle (`rivet check bidirectional`)** | Raises TD: forward/inverse link drift is a bidir-clean violation | Strong | `docs/oracles.md` §1 |
+| 3 | **Schema-driven validation (`rivet validate`)** | Lowers TI: link cardinality, allowed-values, traceability-rules enforced before output | Strong | `rivet-core/src/validate.rs` |
+| 4 | **Verus specs (`#[cfg(verus)]`)** | Lowers TI for the verified subset (partial coverage) | Medium (partial) | `rivet-core/src/verus_specs.rs`, `verus/BUILD.bazel` |
+| 5 | **Kani BMC harnesses** | Lowers TI: panic-freedom + key invariants of validate / coverage / parse-artifact-ref proven up to bounded inputs | Strong (bounded) | `rivet-core/src/proofs.rs` |
+| 6 | **Rocq proofs (`proofs/rocq/Schema.v`, `Validation.v`)** | Lowers TI: schema-satisfiability, monotonicity, validation termination, broken-link soundness, store insert/lookup, backlink symmetry — all proved | Strong (axiomatic) | `proofs/rocq/Schema.v` §1 header |
+| 7 | **Mutation testing 16-shard** | Raises TD on the test suite itself: catches assertions that don't constrain behaviour | Strong (ASIL B/C/D thresholds 0.80 / 0.85 / 0.90) | `docs/mutation-testing.md` |
+| 8 | **Property-based tests + proptest_core** | Lowers TI: store consistency, validation determinism, backlink symmetry randomly stress-tested | Strong | `docs/verification.md` §4 |
+| 9 | **Differential testing against ref parser** | Lowers TI on the YAML parser specifically | Strong | `rivet-core/tests/yaml_test_suite.rs` |
+| 10 | **Provenance auto-stamp (PostToolUse hook)** | Raises TD: every AI-touched artifact is labelled, so reviewer knows what to scrutinise | Strong | `schemas/common.yaml` `provenance` block + Claude Code hook |
+| 11 | **Cited-source hash verification** | Raises TD: an external source cited in a rivet artifact is hashed at stamp time; drift is detected on next validate | Strong (file backend, Phase 1) | `rivet-core/src/cited_source.rs` |
+| 12 | **Schema-migrate snapshot/abort** | Lowers TI on migrations: a migration that would corrupt the store is aborted before write | Strong | `rivet-core/src/migrate.rs` (see `rivet docs schema-migrate`) |
+| 13 | **Oracle-gated agent pipelines** | Raises TD on AI-authored content: every agent step must clear a deterministic oracle before merge | Strong | `docs/oracles.md` "Pipeline wiring" |
+| 14 | **`rivet docs check` (docs-coverage gate)** | Raises TD on documentation-claim drift: stale "runs in CI" / "N artifacts" claims are caught | Medium | `rivet-core/src/doc_check.rs` |
+| 15 | **`rivet check review-signoff`** | Raises TD: a `released` artifact whose reviewer == author fires; closes the "AI approved its own work" loophole | Strong | `docs/oracles.md` §2 |
+| 16 | **Commit-trailer enforcement (`rivet commits`)** | Raises TD on the commit→artifact link: code change without trailer fails CI | Strong | `CLAUDE.md` "Commit Traceability" |
+| 17 | **`rivet validate` deterministic across re-runs (proptest)** | Lowers TI: same input twice gives same output (no nondeterminism in the safety verdict) | Strong | proptest "Validation determinism" |
+| 18 | **Restriction-lint set (SCRC Phase 1, DD-058/DD-059)** | Lowers TI: panic / unwrap / arithmetic-side-effects / cast-truncation lints are workspace-`warn` and CI-`-D warnings`. Source-level UB classes blocked. | Strong | `SAFETY.md`, `Cargo.toml` `[workspace.lints.clippy]` |
+| 19 | **STPA self-analysis (`safety/stpa/tool-qualification.yaml`)** | Raises TD: the rivet team itself has applied STPA to rivet's outputs; the seven hazards H-TQ-001..007 each have a `system-constraint` saying which oracle / test catches it | Strong | file in repo |
+
+### 5.3 What is *missing* to support a real TCL2 claim
+
+Honest gaps blocking a TCL2 dossier:
+
+- **Tool Operational Requirements (TOR)** document. ISO 26262 §11 / DO-330
+  expect a TOR — "what the tool is for, what it is *not* for, the use
+  cases and assumptions." Rivet has `docs/what-is-rivet.md` and
+  `docs/getting-started.md` but no TOR-shaped artifact.
+- **Configuration baseline.** A TCL2 claim must name the qualified
+  binary version, schema versions, oracle versions, and dependency
+  hashes. Rivet has Cargo.lock + `cargo deny` but no published
+  baseline manifest tied to a release.
+- **Tool error log + classification.** ISO 26262 §11 expects a
+  *known-issues log* with risk-classified entries. Rivet has GitHub
+  issues but no qualification-flavoured `tool-defect` artifact type.
+- **Qualification-test suite (separate from the project's own tests).**
+  Rivet's test suite proves rivet-core invariants. A qualification kit
+  re-states, in an auditor-friendly procedure document, *which inputs
+  rivet shall produce which outputs for*. The existing tests are the
+  raw material; they need a docstring + procedure document on top.
+- **`tool-confidence` typed artifact.** Already noted as a gap in
+  `docs/design/iso26262-artifact-mapping.md` row 32 (Section C #8). The
+  schema sketch there is small and tractable — see §7 below.
+- **`ai-found-defect` artifact type.** No type today exists for
+  recording an AI-flagged contradiction in the artifact graph. This is
+  exactly the surface the user identified as missing.
+- **Independence of authoring vs verification.** `rivet validate` is
+  authored by the same team that authors rivet's artifacts — for a
+  customer's qualification it is "self-test." The customer must be
+  able to run an *independent* validation harness; today they can
+  (rivet is open source) but the TCL2 dossier needs to make this
+  explicit.
+
+---
+
+## 6. The AI-in-the-loop angle
+
+This is the decisive section for the user's question. The traditional
+TI2/TD1 → TCL1 argument relies on a human review step that is *the*
+detection mechanism. When the same human reviews twenty AI-authored
+artifacts in a sitting, that review step degrades — not because the
+human is incompetent but because the *unit of judgment* (one artifact
+versus the diff of an entire feature batch) shifted under them.
+
+### 6.1 Where rivet's TD machinery substitutes for the eroded human review
+
+| Erosion vector | Rivet's mechanical compensator | Caught how |
+|---|---|---|
+| AI hallucinates a link target | `rivet validate` broken-link check | At commit time / pre-commit hook |
+| AI hallucinates a *plausible* link target that exists but is semantically wrong | `rivet check bidirectional` + schema's `source-types` / `target-types` constraints | At validate time |
+| AI cites a paper that doesn't exist | cited-source `kind: file` hash mismatch | At validate time (with `--check-remote-sources` for URLs once Phase 2 lands) |
+| AI claims "all 47 requirements verified" when 3 are unverified | `rivet coverage` recomputes from artifacts, not from claim text | At validate time |
+| AI re-uses an artifact ID for a different concept | unique-ID enforcement in `Store::insert` (proptest "Duplicate rejection") | At parse time |
+| AI approves its own work | `rivet check review-signoff` (reviewer must differ from author) | At release-gate time |
+| AI commits without traceability trailer | `rivet commits` CI gate + commit-msg hook | At commit time |
+| AI introduces a contradiction across two artifacts | s-expression evaluator's `forall` / `exists` quantifiers in `traceability-rules` | At validate time |
+| AI silently changes the meaning of a schema | schema-migrate snapshot/abort | At migrate time |
+| AI's edits drift from a documentation claim | `rivet docs check` invariant engine | At CI time |
+| AI introduces typed-but-unwired code (Mythos #1) | oracle-pair (excision + git history) under `rivet pipelines` | At pipeline run |
+
+The *shape* of the substitution is: **rivet replaces the implicit
+"human caught it on review" with explicit deterministic oracles whose
+JSON output is itself an audit artifact.** Each row above is a TD-raise
+that is mechanically replayable — the auditor can see *which* oracle
+caught *which* defect *when*, by re-running it.
+
+### 6.2 The missing piece — `ai-found-defect`
+
+The user's specific concern is: when AI flags a contradiction (rather
+than introduces one), that *finding* is itself a tool output that
+should be traceable. Today, rivet has nowhere to put it. The agent
+finds the contradiction, reports it in chat, the human acknowledges,
+the artifact graph never records the event.
+
+Proposed artifact type:
+
+```yaml
+# schemas/common.yaml — additive, type lives in the common base
+artifact-types:
+  - name: ai-found-defect
+    description: >
+      A defect (contradiction, broken invariant, missing link, stale
+      reference, etc.) reported by an AI agent against the artifact
+      graph. The defect has structured provenance (which agent,
+      which oracle, which session) so a human reviewer can re-run the
+      finding and either accept it (escalating to a defect-correction
+      change-request) or reject it (recording the rejection rationale).
+    fields:
+      - { name: severity,       type: string, required: true,
+          allowed-values: [info, warning, error, critical] }
+      - { name: detection-method, type: string, required: true,
+          allowed-values: [oracle, validate, agent-reasoning,
+                           cited-source-drift, doc-check, manual] }
+      - { name: oracle-id,      type: string, required: false,
+          description: "ID of the oracle that fired, if any" }
+      - { name: detected-by,    type: string, required: true,
+          description: "agent identifier (e.g. claude-opus-4-7)" }
+      - { name: session-id,     type: string, required: false }
+      - { name: reproducer,     type: string, required: false,
+          description: "shell command that reproduces the finding" }
+      - { name: triage-status,  type: string, required: true,
+          allowed-values: [open, accepted, rejected, deduplicated],
+          default: open }
+      - { name: rejection-rationale, type: string, required: false }
+    link-fields:
+      - { name: against,        link-type: defect-against,
+          target-types: ["*"], cardinality: one-or-many, required: true }
+      - { name: corrected-by,   link-type: corrects,
+          target-types: [change-request, design-decision],
+          cardinality: zero-or-many }
+```
+
+Crucial properties:
+
+- It is **first-class typed evidence**, not chat history.
+- It carries the **reproducer** so a future auditor can replay the
+  finding deterministically.
+- The triage state machine forces a human to either accept or reject;
+  there is no "lost in the chat" outcome.
+- It is link-targeted at the offending artifact, so impact analysis
+  (`rivet impact`) sees AI-flagged defects the same as human-filed
+  ones.
+
+This is the artifact that operationalises the user's intent: *"any
+error found while AI is working would get reflected into [the safety
+case]."* The reflection is the typed `ai-found-defect`, the
+traceability is the `defect-against` link, the closure is the
+`corrects` link. None of these exist today.
+
+### 6.3 How AI-found-defect composes with the TCL claim
+
+In TI/TD terms the new artifact does both jobs:
+
+- **Lowers TI of the AI subsystem.** Today rivet has TD-raising oracles
+  but no record of *the AI itself catching errors*; once
+  `ai-found-defect` exists, the AI's detection successes become
+  evidence the toolchain works.
+- **Raises TD on the artifact graph.** A reviewer-facing dashboard
+  view of open `ai-found-defect`s becomes a hard pre-release gate: no
+  artifact reaches `released` while a `defect-against` link points at
+  it from an `open` finding.
+
+Together with the existing 19 safeguards in §5.2 this is enough to
+defend a **TI2/TD1 → TCL1** position even for AI-authored content,
+which is what the user is implicitly asking for.
+
+---
+
+## 7. Design proposal
+
+### 7.1 Three-layer dossier outline
+
+A `rivet docs tool-qualification` topic and a
+`docs/design/tool-qualification-dossier.md` companion would carry these
+sections:
+
+1. **Tool Operational Requirements (TOR).** What rivet is, what it is
+   not, scope of qualified use, scope of *unqualified* use. Includes
+   the "structural-only enforcement" disclaimer from `ai-safety-cyber-hitl.md` §5.4.
+2. **Tool Use Cases.** Enumerated authoring / linking / validating /
+   reporting / exporting cases, each with input → output → known
+   limitation rows.
+3. **Tool Verification Plan.** Maps each use case to the oracle / test /
+   proof that demonstrates correctness. The 19-row table in §5.2 above
+   is the seed.
+4. **Configuration Baseline.** Released binary version, Cargo.lock
+   hash, schemas/ hash, oracle inventory, MCP-tool inventory,
+   dependency vet status (`cargo vet`).
+5. **Known Limitations & Defect Log.** The current set of open issues
+   with risk classification — which TI/TD cell they sit in.
+6. **Tool Error Detection & Reporting Process.** How a customer
+   reports a tool error; how rivet triages it; SLA. Pointer to the
+   `ai-found-defect` artifact type for in-project findings.
+7. **TCL/TQL Position Statement per Regime.** ISO 26262, IEC 61508,
+   DO-178C, EN 50128, ISO/PAS 8800 — the claim, the basis, the
+   conditions of use. **The claim is per-customer-project; rivet
+   provides the dossier, the customer's safety manager makes the
+   decision.**
+
+### 7.2 New artifacts and code surfaces (smallest viable)
+
+**Schema**
+- `tool-confidence` artifact in `schemas/iso-26262.yaml` (matches
+  `iso26262-artifact-mapping.md` §C #8): fields `ti: TI1..TI2`,
+  `td: TD1..TD3`, `tcl` derived, link-fields for `qualification-evidence`.
+- `ai-found-defect` artifact in `schemas/common.yaml` (so every preset
+  inherits it).
+- `defect-against` link type and `corrects` link type in
+  `schemas/common.yaml`.
+
+**CLI**
+- `rivet docs tool-qualification` topic, sourced from
+  `docs/design/tool-qualification-dossier.md`.
+- `rivet check ai-defects-open` oracle: fires when any
+  `ai-found-defect` with `triage-status: open` has a `defect-against`
+  link to an artifact whose `status` is `released` or `approved`. This
+  is the gate that operationalises §6.2.
+- `rivet --qualification-mode` flag (or environment variable
+  `RIVET_QUALIFICATION_MODE=1`) that disables features outside the
+  qualified set. Initial proposal: disables `rivet add --no-validate`,
+  forces `--check-remote-sources` on validate, requires `provenance.reviewed-by`
+  on every `released` artifact, disables MCP write tools that bypass
+  validation.
+- `rivet stats --qualification` to emit a configuration-baseline
+  manifest (binary version, schema hashes, oracle list, dependency
+  vet) for the dossier.
+
+**Tests / proofs**
+- A new Rocq theorem in `proofs/rocq/Validation.v`:
+  `validate_no_false_pass` — every artifact whose links violate
+  `target-types` is reported by `validate`. (The current 4-theorem set
+  proves *broken-link* soundness; this widens to all link-type
+  violations.)
+- A property test for `ai-found-defect` triage state machine: every
+  finding has exactly one terminal state (accepted | rejected |
+  deduplicated) and one open state.
+- A qualification-flavoured integration test:
+  `rivet-core/tests/qualification_kit.rs` — runs the dossier examples
+  end-to-end and golden-checks the JSON envelopes.
+
+### 7.3 Renaming the existing STPA's TCL annotation
+
+`safety/stpa/tool-qualification.yaml` line 14 needs the §2.7
+correction. Two options:
+
+- **Option A:** keep the ISO 26262 framing, change "TCL 1 (highest)"
+  to "TCL 3 (highest demand)." Audit-clean, project-internal change.
+- **Option B:** switch to DO-330 framing, change to "TQL-2." Useful if
+  rivet is more often deployed in DO-178C contexts.
+
+Option A is the lighter change; recommended.
+
+### 7.4 Smallest deliverable that moves the needle
+
+In order of "hours to ship × audit-impact-per-hour":
+
+1. **Rename TCL annotation in the existing STPA** (1h, removes a
+   literal audit-flag in our own dogfood file). Recommendation A1.
+2. **Add `tool-confidence` typed artifact to `schemas/iso-26262.yaml`**
+   (4h, closes `iso26262-artifact-mapping.md` row 32). Recommendation A2.
+3. **Add `ai-found-defect` to `schemas/common.yaml`** (4h, the only
+   way the user's "AI errors get reflected" requirement becomes a
+   typed artifact). Recommendation A3.
+4. **Write `docs/design/tool-qualification-dossier.md` + `rivet docs tool-qualification`**
+   (1-2 days, replaces the customer-facing "where's your kit?"
+   conversation with a doc URL). Recommendation A4.
+5. **Add `rivet --qualification-mode` flag + `rivet stats --qualification`** (1 day,
+   gives the customer's safety manager a one-command snapshot for the
+   dossier). Recommendation A5.
+
+Total: roughly one developer-week to move from "TCL1 in our own
+dogfood STPA" to "TCL2 dossier draft published, reviewable."
+
+---
+
+## 8. Recommendation
+
+### 8.1 The user's framing is correct, with one nuance
+
+> "Polarion is TCL1 because Siemens is backing it up; for rivet that
+> level must be larger because we want the tool to be part of the
+> toolchain especially to ensure any error found while AI is working
+> would get reflected into this."
+
+Yes. The nuance: **Polarion's TCL1 is TI2/TD1 where the human review
+is the TD layer; rivet's TCL1-target is TI2/TD1 where rivet's *own
+mechanical detection* is the TD layer.** Same letter, different
+underlying argument, much stronger evidence base.
+
+The number rivet should aim for, in ISO 26262 numbering, is therefore:
+
+- **TI2** (rivet output can affect the safety case — yes, by design).
+- **TD1** (rivet's own validate / oracles / cited-source / docs-check /
+  ai-found-defect mechanism gives high detection confidence even when
+  the upstream author is an AI).
+- **→ TCL1** in 26262 *units*, but with the qualification-evidence
+  bundle of a TCL2 tool, because the TD1 claim is non-trivial and
+  must be defended.
+
+In DO-330 units: **TQL-4 with TQL-3 path** — the practical equivalent
+for a tool that automates verification activities (Tool Type 2) on
+DAL-B/C work.
+
+### 8.2 Concrete next step
+
+**Open an issue and start workstream A.** The five A-items in §7.4 are
+sized for one developer-week. The dossier draft is the long pole; the
+schema additions are mechanical.
+
+Single most important open question for the user:
+
+> **Which regime is the lead?** ISO 26262 (automotive), DO-178C
+> (aviation), or IEC 62304 (medical)? The answer governs the dossier
+> structure, the TCL/TQL numbering, and which customer pilots to
+> prioritise. The other two follow as cross-walks. Without picking
+> one, the dossier ends up a "supports five regimes" generic kit —
+> which is exactly the shape Polarion ships and exactly the shape the
+> user's instinct says is too low.
+
+### 8.3 What this design *does not* claim
+
+- Rivet is **not** TCL-qualified today. The work above produces a
+  *dossier*; the customer's safety manager makes the project-level
+  qualification call.
+- The `ai-found-defect` type does **not** turn AI-flagged contradictions
+  into safety-case evidence. It turns them into *traceable defect
+  records* that a qualified human still has to triage.
+- The `--qualification-mode` flag does **not** make rivet a
+  development-tool-per-safety-standard. It restricts rivet to a
+  qualifiable subset of its features so the dossier scope stays
+  manageable.
+
+These three honest disclaimers belong on the `rivet docs tool-qualification`
+topic.
+
+---
+
+## 9. Sources
+
+Internal (verified against `main` at 2026-04-27):
+
+- `docs/design/iso26262-artifact-mapping.md` — §C row 32 "Tool
+  confidence (TCL/TD)" gap; numbering of `tool-confidence` schema
+  proposal.
+- `docs/design/ai-safety-cyber-hitl.md` — §2 standard-by-standard
+  human-role table; §5 four-point HITL contract.
+- `docs/design/polarion-reqif-fidelity.md` — Polarion field mapping;
+  status-enum and provenance gaps.
+- `docs/design/ai-evidence-trend-research.md` — competitor-tool field
+  map (BTC, medini, codeBeamer, Polarion, Jama).
+- `safety/stpa/tool-qualification.yaml` — the existing TCL claim
+  (mis-numbered, see §2.7).
+- `safety/stpa-sec/tool-qualification-sec.yaml` — security STPA
+  for the qualification toolchain.
+- `schemas/iso-pas-8800.yaml` — `ai-tool-qual.tool-class: TQL-1..5`.
+- `schemas/score.yaml` — `tsf.classification: TI1..TI3`.
+- `schemas/en-50128.yaml` — `tool-qualification` artifact type
+  (placeholder).
+- `docs/oracles.md` — oracle catalog (bidirectional, review-signoff,
+  gaps-json).
+- `docs/mutation-testing.md` — ASIL-keyed mutation-score floors.
+- `docs/verification.md` — ASPICE SWE.4/5/6 mapping; proptest catalog.
+- `SAFETY.md` — SCRC Phase 1/2 lint set; Verus/Kani/Rocq inventory.
+- `proofs/rocq/Schema.v` — six theorems already proved; `Validation.v`
+  for the new `validate_no_false_pass` proposal.
+- `rivet-core/src/cited_source.rs` — sha256 stamping; Phase 1 file
+  backend, Phase 2 URL backend.
+- `rivet-core/src/doc_check.rs` — eight documentation invariants.
+
+External (cited from training-time references; **re-fetch before
+external publication** — live web access was denied this session):
+
+- ISO 26262-8:2018 §11 — Tool qualification; TI/TD/TCL framework;
+  Table 4 qualification methods.
+- ISO 26262-6 Table 13 — coverage techniques per ASIL (mutation
+  analysis recommended at C/D).
+- IEC 61508-3:2010 — T1/T2/T3 categories, Annex C-D tables.
+- DO-178C §12.2 + DO-330 — TQL-1..5 matrix.
+- EN 50128:2011 §6.7 — tool qualification expectations.
+- ISO/SAE 21434:2021 §5.4.6 — cybersecurity tool considerations.
+- ISO/PAS 8800:2024 — TQL-1..5 for AI element tools.
+- Siemens Polarion ALM Tool Qualification Kit (siemens.com,
+  publicly downloadable) — TI2/TD1/TCL1 self-claim with reviewer-as-detection
+  defence.
+- EU AI Act Article 14 — automation-bias warning relevant to §3.2.

--- a/docs/design/variant-aware-properties.md
+++ b/docs/design/variant-aware-properties.md
@@ -1,0 +1,600 @@
+# Variant-Aware Properties on Requirements
+
+Status: design report, draft.
+Audience: rivet maintainers; future SAT/SMT solver authors; safety
+auditors evaluating rivet's variant story.
+Date: 2026-04-27.
+Companion doc: [`pure-variants-comparison.md`](../pure-variants-comparison.md).
+
+> Note on sources: the live `WebSearch` / `WebFetch` tools were denied
+> in this session. The competitor surveys below therefore rely on
+> training-data recollection (last update: late 2025) plus rivet's own
+> `pure-variants-comparison.md`. Citations to PV's user manual reuse
+> the line-numbered references already verified in that companion doc.
+> Claims that I cannot verify against a primary source are marked
+> *(unverified)*.
+
+## 1. Problem
+
+Rivet today has a feature model (FODA tree, group types, cross-tree
+constraints, typed feature attributes), variant configurations
+(`{ name, selects: [...] }`), a feature-to-artifact binding model
+(`bindings.yaml`), and a 7-format emitter. The flow is:
+
+> *feature-model* + *variant-config* → *resolved feature set* + *binding-driven
+> source manifest*
+
+What rivet **cannot** express today is a per-variant *value* on a
+requirement field. Concrete motivating example:
+
+```yaml
+# artifacts/requirements.yaml — TODAY
+- id: REQ-THERMAL-01
+  type: requirement
+  title: Operating temperature envelope
+  description: The unit shall function within its declared envelope.
+  fields:
+    max-temp-c: 80          # ← single value, no variant axis
+    min-temp-c: -20
+```
+
+But the engineering reality is:
+
+| variant     | max-temp-c | min-temp-c | rationale                     |
+|-------------|------------|------------|-------------------------------|
+| automotive  | 80         | -40        | AEC-Q100 grade-3              |
+| industrial  | 100        | -40        | IEC 60068-2 broader range     |
+| consumer    | 70         |   0        | commercial part baseline      |
+
+These are the same requirement (`REQ-THERMAL-01` — same intent, same
+verification, same parent rationale, same upstream stakeholder), just
+with different numeric bounds depending on which product the variant
+binds. There is no clean way to encode this today. The available
+workarounds are all wrong:
+
+- Three separate REQs (`REQ-THERMAL-01-AUTO`, `…-IND`, `…-CON`):
+  triples the artifact count, breaks
+  derives-from links, and the diff becomes "one of four artifacts
+  changed" rather than "the value of this field changed".
+- A free-form `description` string with all three values: machine-
+  unreadable, no validation, defeats `rivet validate`.
+- Smuggling the values into feature attributes
+  (`automotive.max-temp-c = 80`): re-anchors the data on the *feature*,
+  losing the connection to the requirement, and only works for
+  attributes the emitter knows about.
+
+This gap matters for ISO 26262 / IEC 61508 / DO-178C arguments where
+the same safety requirement legitimately admits different bound
+values per safety integrity level, market, or sourcing strategy. A
+PSAC ("here are the requirements for our DO-178C Level B build") needs
+to print a *single, variant-resolved* artifact set. Rivet must be the
+tool that produces it from a maintained-once source.
+
+## 2. Today's State (reference)
+
+What rivet's data model commits to right now:
+
+- `Artifact.fields: BTreeMap<String, serde_yaml::Value>` — the
+  field map is variant-blind. There is one slot per field name.
+  (`rivet-core/src/model.rs:131`)
+- `FeatureBinding.bindings[feature].artifacts: Vec<String>` — features
+  bind to artifact *IDs*, not field-level slots.
+  (`rivet-core/src/feature_model.rs:213`)
+- `SourceEntry.when: Option<String>` — *source globs* can carry a
+  per-variant `when:` predicate (Gap 5 in the PV comparison). This is
+  the only existing per-variant-value mechanism in rivet, and it
+  proves the predicate plumbing is already in place.
+  (`rivet-core/src/feature_model.rs:243`)
+- `attribute-schema:` on the feature model gives typed feature
+  attributes (`AttributeKind::{Bool, Int, Float, Str, Enum}`), but
+  again these live on the *feature*, not the artifact field.
+  (`rivet-core/src/feature_model.rs:87`)
+- `rivet variant solve / value / attr / verify-config` operate on
+  `ResolvedVariant` — a flat selected feature set plus per-feature
+  origins and source manifest. There is no
+  artifact-resolution step in the variant pipeline at all.
+
+## 3. Competitor Survey
+
+### 3.1 Polarion (Siemens)
+
+Polarion's "Variant Management" extension *(unverified)* layers on top
+of pure::variants integration. Its data model treats Work Items
+(requirements, test cases, …) as the unit of variability and supports:
+
+- **Custom fields per Work Item**: any project can define typed custom
+  fields (`int`, `string`, `enum`, `date`, `richtext`).
+- **Calculated fields**: a custom field can be backed by a Velocity
+  expression that reads other fields, the WorkItem context, and
+  *(in variant builds)* the active variant configuration.
+  *(unverified — calculated-field-per-variant exact semantics.)*
+- **Variant-specific specifications**: Polarion ships a "Variant
+  Specification Document" feature where the document body is rendered
+  per-variant (much like a sphinx-needs filter). The underlying
+  WorkItem is single, but the rendered text contains
+  conditional sections.
+
+Pattern: **single artifact, per-variant rendering driven by an
+expression language and an active-variant context object**. The data
+is single-master; the projection is variant-aware.
+
+### 3.2 IBM DOORS Next + pure::variants
+
+DOORS Next stores Module artifacts; pure::variants integrates by
+adding a "Variability" property on a module (or on individual
+artifacts) that points at a feature expression. Then there are two
+shapes I'm aware of:
+
+- **Visibility**: an artifact appears in a variant only if its
+  variability expression evaluates to true. This is the
+  sphinx-needs-style filter. It does not change *values*; it
+  hides/shows entire artifacts.
+- **Attribute-level variability** *(unverified — believed to require
+  pure::variants 5+)*: a per-attribute restriction expression. Each
+  attribute slot can carry a list of `{ value, restriction }`
+  alternatives, the first whose restriction is true wins. PV calls
+  these "non-fixed values with restrictions" (PV manual §5.8 line
+  1488 — see companion doc) and the same pattern is exposed in DOORS
+  via the integration. This is exactly the missing primitive in rivet.
+
+### 3.3 sphinx-needs
+
+sphinx-needs uses **tags + filter strings** to turn a single
+requirements set into multiple per-variant outputs. A `:status:` field
+plus directives like `.. needfilter::` produce filtered tables per
+build configuration. It does not natively support "the same need has
+field value X in variant A and value Y in variant B" — the canonical
+workaround is conditional Sphinx content (`only::` directives) or
+splitting into multiple needs that share a common parent and are
+linked back via `links:` / `triggers:`.
+
+In other words: sphinx-needs treats variants as a **rendering filter**,
+not a value-binding. It is closer to rivet's existing
+`rivet variant filter-artifacts` story than to per-field value override.
+
+### 3.4 pure::variants — Variation Points within Requirements
+
+PV's primary mechanism is **Variation Points in Source/Documents**
+(PV manual §5.10 — variant transformation). Conditional fragments
+inside a source file are gated by `PVSCL:IFCOND … ENDCOND` macros that
+the variant transform evaluates. Applied to requirements: a single
+requirement document can contain alternate text for max-temp, gated
+by `PVSCL:IFCOND(automotive)`. The transform produces the right
+document per variant.
+
+This is **textual** variation — it doesn't model "field max-temp-c is
+80 for automotive" as structured data; it models "this paragraph
+appears for automotive, that paragraph for industrial". Round-trip
+parse-back is therefore lossy.
+
+PV also has **attribute restrictions** (§5.8 line 1488): when a
+feature attribute lists multiple candidate values each with a
+`restriction:` pvSCL expression, the first true restriction wins.
+This is the pattern that, ported to artifact fields, yields
+option **A2** in this doc.
+
+### 3.5 FeatureIDE / Clafer / TVL
+
+- **FeatureIDE**: attributes per feature, similar to rivet today.
+  Extension projects (`FeatureIDE-Numerical`, FAMA bindings) add
+  attribute calculations during configuration analysis. *(unverified —
+  current state of art.)*
+- **Clafer** (the language): unifies feature models and metamodels.
+  Concrete examples in the literature show numeric attributes being
+  computed from feature selections, e.g.
+  `MaxTemp -> integer = if Automotive then 80 else 100`. Clafer's
+  built-in solver (Choco or Z3 backend) can both generate variants and
+  solve "find me the variant with `MaxTemp ≥ 90`".
+- **TVL (Text-based Variability Language)**, Classen et al. ~2011:
+  features carry attributes; `if`-style attribute definitions are a
+  first-class construct. Constraints over attributes are SAT/SMT
+  decided. Rivet's s-expression language is in the same family.
+
+The pattern across these languages: **attribute = feature × predicate
+→ value**, with the predicate evaluated against the active variant
+configuration.
+
+### 3.6 Academic literature
+
+Trustworthy entries from training data:
+
+- Czarnecki & Eisenecker, *Generative Programming* (2000): introduces
+  *staged configuration* — features are picked in stages, each stage
+  resolves a subset of attributes. Today's rivet collapses both
+  stages into one solve.
+- Apel, Batory, Kästner, Saake, *Feature-Oriented Software Product
+  Lines* (2013): chapter on "feature attributes" — surveys mechanisms
+  for attaching numeric / string values to features and propagating
+  them.
+- Sinnema et al., **COVAMOF**: a variability-modelling framework that
+  separates *variation points* from *variants* and from *values*. The
+  three-way separation is exactly what rivet is missing today.
+- Karataş et al., **Attributed Feature Models** (~2010): formalises
+  the "feature has typed attributes, constraints range over
+  attributes" extension, including the SMT encoding. This is the
+  decidable backbone if we go that route.
+- Benavides et al. surveys on "Automated analysis of feature models",
+  Information Systems 35 (~2010 and updated multiple times): the
+  reference list of analyses that become decidable once attributes
+  are typed and constraints compile to SMT-LIB.
+- Chen et al., **Variability-aware analysis** literature
+  (TypeChef/Featherweight Featherweight): per-variant-value support
+  inside a single artifact, with the artifact being a *partial
+  configuration* that the solver completes per variant. Rivet's
+  closest analogue would be a "partial artifact" with some fields
+  unresolved until a variant is bound.
+
+## 4. Design Space
+
+Five candidate shapes. I score each on
+**(V) validator complexity**, **(D) dashboard rendering**,
+**(T) traceability preservation**, **(A) AI-tool friendliness**,
+**(F) audit-friendliness**.
+
+### A. Field overrides per variant — `fields-per-variant:`
+
+```yaml
+- id: REQ-THERMAL-01
+  type: requirement
+  title: Operating temperature envelope
+  fields:
+    max-temp-c: 80          # default / fallback
+    min-temp-c: -20
+  fields-per-variant:
+    automotive: { max-temp-c: 80,  min-temp-c: -40 }
+    industrial: { max-temp-c: 100, min-temp-c: -40 }
+    consumer:   { max-temp-c: 70,  min-temp-c:   0 }
+```
+
+Variant lookup is a flat `BTreeMap<String, BTreeMap<String, Value>>`.
+At resolve time the active variant name selects the override map; any
+field not mentioned falls through to `fields:`.
+
+- V: trivial — `merge(fields, fields_per_variant.get(active))`.
+- D: trivial — dashboard either renders the merged view (active
+  variant set) or a small expandable table of per-variant values.
+- T: clean — the artifact ID stays singular, derives-from / verifies /
+  satisfies links unchanged.
+- A: high — this is the literal shape an LLM produces when asked
+  "make this requirement variant-aware".
+- F: medium-high — auditors see all values in one file with one ID.
+  Caveat: the *active variant* needs to be recorded in the audit
+  output so the printed value is provenance-stamped.
+
+Risk: tightly coupled to **variant names** (string keys). Renaming a
+variant in `bindings.yaml` requires rewriting every artifact that
+mentions it. Mitigation: `rivet validate` cross-checks variant keys
+against the binding model's `variants:` list.
+
+### B. Variation expressions — `max-temp-c: "(if (= variant 'automotive) 80 100)"`
+
+```yaml
+- id: REQ-THERMAL-01
+  fields:
+    max-temp-c: "(cond
+                   ((selected automotive) 80)
+                   ((selected industrial) 100)
+                   ((selected consumer)   70)
+                   (else 80))"
+```
+
+Re-uses rivet's existing s-expression language; values become
+expressions that resolve against the active feature set.
+
+- V: medium — needs `sexpr_eval` extended with a numeric arithmetic
+  branch *(rivet's current sexpr is predicate-only — see PV-comparison
+  section 3)*. Type-checking the result against the field's declared
+  type adds another step.
+- D: medium — printing "80 (auto) | 100 (ind) | 70 (con)" requires the
+  dashboard to *evaluate the expression for every declared variant*,
+  which is fine but introduces dashboard-side dependency on the solver.
+- T: clean.
+- A: medium — LLMs can write s-expressions, but at the cost of YAML
+  human-readability. A reviewer reading the diff sees `(cond …)` not
+  `automotive: 80`.
+- F: medium — auditors must trust the evaluator. Adds an evaluation
+  trace requirement.
+
+Strength: composes — `(* (if eu 80 75) (if asil-d 1.1 1.0))`
+expressions are possible without new schema. Weakness: the schema
+type-system has to allow "expression returning T" everywhere a value
+of type `T` is allowed, which is invasive.
+
+### C. Multiple bound artifacts — `REQ-THERMAL-01-AUTO`
+
+The status quo workaround, written down. Each variant gets its own
+artifact, linked back to a parent abstract requirement.
+
+- V: zero new code.
+- D: clutter — three artifacts in every list view; needs
+  variant-active filter to hide siblings.
+- T: damaged. `derives-from` links must fan out to all three; impact
+  analysis multiplies. Auditor question "what is the verification
+  evidence for REQ-THERMAL-01" needs a join.
+- A: low — verbose, lots of repeated boilerplate.
+- F: low — auditor sees three "almost identical" requirements and
+  asks why.
+
+This is the no-design option. Including it for completeness; rejected.
+
+### D. Reference into variant attributes — `max-temp-c: "$variant.max-temp-c"`
+
+The values live on the **variant config** (or on a feature attribute);
+the artifact field references them.
+
+```yaml
+# variants/automotive.yaml
+selects: [automotive, asil-c]
+attributes:
+  max-temp-c: 80
+  min-temp-c: -40
+
+# artifacts/requirements.yaml
+- id: REQ-THERMAL-01
+  fields:
+    max-temp-c: "$variant.max-temp-c"
+```
+
+- V: medium — needs a `$variant.X` resolver hook in field validation.
+- D: medium — same dashboard-side eval as B.
+- T: clean.
+- A: medium — separates the data from the artifact, harder for an LLM
+  to keep coherent across files.
+- F: medium-high — values flow from a single source-of-truth (the
+  variant). Auditors love single-source-of-truth.
+
+The significant downside: it pushes ownership of *requirement field
+values* into the *variant config*, which inverts the natural author
+workflow. The requirements engineer wants to write the values next to
+the requirement; they don't want to context-switch into the variant
+file.
+
+### E. sphinx-needs-style filter — `applies-to: [automotive]` per artifact
+
+Stay with one-value-per-field, but tag each (potentially duplicated)
+artifact with the variants it applies to, and filter at render time.
+
+```yaml
+- id: REQ-THERMAL-01
+  applies-to: [automotive, consumer]
+  fields:
+    max-temp-c: 80
+- id: REQ-THERMAL-01
+  applies-to: [industrial]
+  fields:
+    max-temp-c: 100
+```
+
+- V: needs duplicate-ID-with-disjoint-applies-to to be allowed —
+  invasive change to a bedrock invariant.
+- D: medium.
+- T: artifact-ID is no longer unique → wrecks every existing
+  query/link mechanism.
+- A: low.
+- F: low — duplicate IDs are an instant audit smell.
+
+Rejected. Too disruptive.
+
+## 5. Recommendation
+
+**Adopt option A as the v1 mechanism, with a forward-compatible
+escape hatch into option B for advanced cases.**
+
+### 5.1 Why A first
+
+- Zero new evaluator. The merge is a `BTreeMap` overlay — `fields` is
+  the default, `fields-per-variant[active]` overrides keys.
+- LLM-friendliness matters: the rivet user base writes YAML by hand or
+  via Claude Code. Authors should be able to read the file and
+  *immediately* understand what value applies in which variant.
+- Auditors get a single artifact ID, all values in one place, and a
+  variant-stamped resolved view.
+- Composes cleanly with the existing typed-attribute schema work
+  (Gap 1): every value in `fields-per-variant` is type-checked
+  against the same field schema as `fields`.
+- Forward-compatible: option B's expressions can land later as a
+  *value-shape*: a YAML scalar today, a `(cond …)` string tomorrow,
+  parsed lazily by the same field validator.
+
+### 5.2 YAML shape
+
+```yaml
+- id: REQ-THERMAL-01
+  type: requirement
+  title: Operating temperature envelope
+  description: The unit shall function within its declared envelope.
+  status: approved
+  fields:
+    priority: must
+    category: non-functional
+    # Default values — used when no active variant or no override:
+    max-temp-c: 80
+    min-temp-c: -20
+  fields-per-variant:
+    automotive:
+      max-temp-c: 80
+      min-temp-c: -40
+    industrial:
+      max-temp-c: 100
+      min-temp-c: -40
+    consumer:
+      max-temp-c: 70
+      min-temp-c: 0
+```
+
+### 5.3 Worked example — multi-field, partial overrides
+
+```yaml
+- id: REQ-AUTH-01
+  type: requirement
+  title: Session timeout
+  fields:
+    priority: must
+    timeout-minutes: 30        # default
+    require-mfa: false         # default
+  fields-per-variant:
+    enterprise:
+      timeout-minutes: 15
+      require-mfa: true
+    healthcare:
+      timeout-minutes: 5       # HIPAA stricter
+      require-mfa: true
+    # `personal` variant: no override → uses defaults
+```
+
+### 5.4 Worked example — variant key bound to a feature, not a config
+
+For users who have built a small product (one feature model, no
+explicit `VariantConfig`), allow keying by feature name as well:
+
+```yaml
+- id: REQ-THERMAL-01
+  fields:
+    max-temp-c: 80
+  fields-per-variant:
+    # keys can be either variant-config names OR feature names.
+    # Resolver checks variant-config first, then feature.
+    automotive: { max-temp-c: 80 }
+    industrial: { max-temp-c: 100 }
+```
+
+### 5.5 Validate / serve / migrate semantics
+
+- **Validate (no active variant)**: every key in `fields-per-variant`
+  must (a) be a declared variant-config name *or* a feature name, and
+  (b) every value must satisfy the field schema (type, allowed-values,
+  range). The default `fields:` block is also validated. The artifact
+  is marked `valid` if all of those hold. `--strict` additionally
+  errors on unknown variant keys; default mode warns.
+- **Validate `--variant <name>`**: applies the override layer for
+  `<name>`, validates the merged view, *and additionally* validates
+  the default view. Both must pass.
+- **Resolve**: rivet exposes
+  `Artifact::resolved_fields(variant: &str) -> BTreeMap<String, Value>`
+  that returns the merged view. Implemented behind the existing
+  `Artifact` API; existing call sites keep working because they read
+  `fields` (now defined as "default fields").
+- **Serve / dashboard**: a variant selector at the top of the
+  dashboard sets the active variant; field cells render the merged
+  value with a small marker if the value came from an override (e.g.
+  `100 (industrial)`). A "show all variants" toggle expands to a
+  per-variant table. The chosen variant is stamped into every
+  exported artifact (PDF, ReqIF, JSON).
+- **Migrate**: existing artifacts have no `fields-per-variant` — the
+  default view stays the only view, behaviour unchanged. A new
+  migration `add-variant-overrides` shells in empty
+  `fields-per-variant: {}` slots into all requirement-typed artifacts
+  for users who want to start the variant-aware journey.
+- **Cited-source semantics**: `cited-source` field unchanged; if a
+  variant overrides the source, that's per-variant variation in
+  authority too — the override layer applies to the cited-source slot
+  exactly the same way as any other field.
+
+### 5.6 Validator error messages
+
+Two new error classes:
+
+- `Variant key 'foo' in fields-per-variant is not declared in any
+  variant config or feature; expected one of: automotive, industrial,
+  consumer.`
+- `Field 'max-temp-c' in fields-per-variant.industrial: schema
+  declares type=int with range [0, 200]; got 'one-hundred' (string).`
+
+### 5.7 Open questions
+
+1. **Partial completeness.** If the active variant has *no* override
+   for a field that exists in another variant's overrides, is that an
+   error, a warning, or fine (fall through to default)? Default
+   answer: fine — the default-fields slot is by definition the
+   fallback. But ISO 26262 may want "every variant must explicitly
+   override every safety-relevant field" → opt-in `fields-per-variant:
+   exhaustive: true`.
+
+2. **Combinatorial explosion.** What if variant axes are orthogonal
+   (market × ASIL × cooling-class = 30 combinations)? Hard-coding 30
+   override blocks per artifact is unworkable. The pragmatic answer:
+   keys can be **predicates** in option B form once that lands —
+   `"(and automotive (>= asil-numeric 3))": { max-temp-c: 70 }` — but
+   then key uniqueness becomes a constraint-set problem, not a string
+   match. Park for v2.
+
+3. **SAT/SMT decidability.** Option A's resolution is `O(1)` per
+   field. Option B's resolution can be made decidable if the
+   expression language is restricted to QF\_LIA (linear integer
+   arithmetic) over feature booleans + typed attributes. Going there
+   requires a Z3 / cvc5 dependency or a bespoke solver. v1 stays in
+   option A's plain map territory.
+
+4. **Test surface.** With variant-aware fields, every variant becomes
+   a multiplier on the test matrix. The dogfood tests in
+   `tests/dogfood/` already enumerate variants for binding solves;
+   they need to grow a `for variant in declared_variants` outer loop
+   for any test that reads field values.
+
+5. **ReqIF / OSLC export interplay.** ReqIF expects single-value
+   attributes per requirement. Round-tripping a variant-aware rivet
+   artifact through ReqIF requires either (a) explode-on-export
+   (each variant becomes a separate ReqIF specification) or
+   (b) export-with-active-variant only. Polarion's ReqIF export does
+   the latter; that's the lower-impact default.
+
+6. **Diff and impact ergonomics.** A change to
+   `fields-per-variant.automotive.max-temp-c` should show up as
+   "automotive max-temp-c changed: 80 → 90" in `rivet diff` /
+   `rivet impact`, not as "fields-per-variant changed". Both diff
+   tools need a YAML-path-aware variant key recognition.
+
+### 5.8 MVP scope (v1)
+
+- Schema: add `fields-per-variant:
+  BTreeMap<String, BTreeMap<String, serde_yaml::Value>>` to
+  `Artifact`. Optional, default empty.
+- Validate: variant-key cross-check against the binding model;
+  per-field type-check identical to the existing `fields:` validator.
+- Resolve API: `Artifact::resolved_fields(variant_name: &str)`.
+- CLI: `rivet show REQ-XXX --variant automotive` shows the
+  merged view; `rivet validate --variant automotive` validates
+  resolved.
+- Dashboard: variant selector + per-cell override-marker.
+- Tests: dogfood pass updated to enumerate per-variant resolution;
+  golden-file tests for one motivating example.
+
+Out of scope for v1 (track in follow-ups):
+
+- Option B expressions in field values.
+- Predicate-keyed overrides (combinatorial axes).
+- Exhaustiveness checks (`exhaustive: true`).
+- ReqIF / OSLC explode-on-export.
+- SAT-/SMT-driven attribute calculations.
+
+## 6. TL;DR
+
+- Single-master, per-variant overrides: keep one artifact, add a
+  `fields-per-variant:` map keyed by variant config or feature name.
+- The default `fields:` block remains the fallback — backwards
+  compatible.
+- Resolution is a flat `BTreeMap` overlay, no new evaluator needed.
+- `rivet validate --variant <name>` validates both default and
+  resolved views.
+- Forward-compatible to expression-based values (option B) without
+  schema rework.
+
+## 7. Single most important open question
+
+**Do we want variant keys to be exclusive (each artifact field has
+exactly one variant override that applies, derived from the active
+variant config) or compositional (multiple keys can apply
+simultaneously and merge in declaration order, allowing
+multi-axis variation like `automotive × asil-c`)?**
+
+Exclusive is simpler to validate, simpler to render in a dashboard,
+and matches PV's first-true-wins semantics. Compositional is what
+real product-line engineering needs once the variant axes are
+orthogonal (market × safety-level × cooling-class), but it breaks
+key uniqueness and pulls in predicate-keyed overrides — which is
+option B in disguise.
+
+The answer determines whether v1 ships with a `BTreeMap<String,
+…>` keyed-by-variant-name (exclusive) or a `Vec<{ when, fields }>`
+ordered list (compositional) underneath the same `fields-per-variant:`
+surface.

--- a/docs/design/variant-aware-properties.md
+++ b/docs/design/variant-aware-properties.md
@@ -328,7 +328,9 @@ selects: [automotive, asil-c]
 attributes:
   max-temp-c: 80
   min-temp-c: -40
+```
 
+```yaml
 # artifacts/requirements.yaml
 - id: REQ-THERMAL-01
   fields:


### PR DESCRIPTION
## Summary

Commits three substantial design notes that have been sitting uncommitted in the working tree — each represents one of the next strategic workstreams toward v0.10. Anchoring them publicly so the roadmap is visible, the issue tracker is the authoritative discussion surface, and external reviewers (NLnet, prospective contributors, auditors) can read where rivet is heading.

| Commit | Doc | Refs | Pages |
|---|---|---|---|
| [\`d3a6f1a\`](../commit/d3a6f1a) | \`docs/design/variant-aware-properties.md\` | [#255](https://github.com/pulseengine/rivet/issues/255) | 25 KB / ~600 lines |
| [\`24650ef\`](../commit/24650ef) | \`docs/design/cross-org-supplier-traceability.md\` | [#253](https://github.com/pulseengine/rivet/issues/253) | 29 KB / ~609 lines |
| [\`bbeb3ad\`](../commit/bbeb3ad) | \`docs/design/tool-confidence-level.md\` | iso26262-artifact-mapping.md §C row 32 | 38 KB / ~709 lines |

### What each doc proposes

**variant-aware-properties.md (#255)** — Per-variant field VALUES on a single artifact, so \`REQ-THERMAL-01\` can have \`max-temp-c: 80\` for the automotive variant and \`100\` for the industrial variant without splitting the requirement and breaking link semantics. Surveys five design options against Polarion, DOORS Next + pure::variants, sphinx-needs, pure::variants variation points, FeatureIDE / Clafer / TVL, and the academic literature (COVAMOF, Attributed Feature Models, TypeChef). Recommends option A — \`fields-per-variant:\` keyed by variant config or feature name, first-match-wins — with multi-axis composition and t-wise sampling explicitly deferred to v2.

**cross-org-supplier-traceability.md (#253)** — How rivet should represent the OEM-supplier boundary case: typed \`external-anchor\` artifact, structured \`derives-from-external\` link target, three-state coverage (\`SATISFIED\` / \`EXTERNAL_BOUNDARY\` / \`UNCOVERED\`), field-mapping recipe at the import boundary, and \`FederationProvenance\` on imported artifacts. Surveys Polarion OSLC connector, DOORS Next GCM, sphinx-needs \`needs_external_needs\`, OSLC Core/RM/QM/CM, ReqIF + ProSTEP iViP, AUTOSAR ARXML, ISO 26262-8 §5 DIA, ASPICE SUP.10 / SUP.8. Identifies the gap rivet fills: copies OSLC's link semantics without inheriting its live-HTTP protocol assumption. 3-phase rollout from MVP (~3 weeks) through full federation handshake.

**tool-confidence-level.md** — Cross-walk of TCL / TQL across ISO 26262, IEC 61508, DO-178C / DO-330, EN 50128, ISO/SAE 21434, ISO/PAS 8800. Argues for **TCL2-with-TCL3-path** as rivet's honest position (peer group is medini / BTC, not Polarion). Documents the 19 shipped safeguards that map to TI / TD parameters. Proposes a new \`ai-found-defect\` typed artifact that operationalises "any AI-flagged contradiction becomes a traceable record" — the missing piece for auditing AI-assisted engineering. Three-layer dossier outline (TOR / use cases / verification plan / configuration baseline / known limitations / error-detection process / TCL position) and a five-step rollout to a publishable dossier.

### Why now

1. **Roadmap visibility.** v0.10 work is being scoped against these three tracks. Committing them moves the discussion from "files on the maintainer's disk" to "public reference the issue tracker can link to."
2. **NLnet grant submission anchor.** Cross-org and variant work map directly to grant workstreams 3 and 4. Auditors of the proposal can read the design notes to see substance behind the workstream descriptions.
3. **External-reviewer onboarding.** Each doc names its competitors honestly and its open questions explicitly — making the design surface readable for someone joining the project cold.

## Test plan

Docs-only commits. No code, no schema changes, no functional behaviour change. The PR triggers the standard \`Docs Check\` CI step (already runs across all PRs).

- [x] \`docs:\` commits — no artifact trailer required per CLAUDE.md exempt-types
- [x] Each doc references the relevant open issue or sibling design note
- [x] \`cargo check --workspace\` unaffected (no Rust code touched)
- [ ] CI \`Docs Check\` step passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)