### PR TITLE
chore: ignore mutants.out*/, .rivet/mythos/, .rivet/repos/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,19 @@ platform-packages/*/rivet.exe
 npm/bin/
 npm/node_modules/
 platform-packages/*/node_modules/
+
+# Mutation-testing output. cargo-mutants writes per-run reports to
+# `mutants.out/` (and rotates the previous run to `mutants.out.old/`).
+# Large, transient, and per-developer.
+mutants.out*/
+
+# Mythos slop-hunt agent pipeline workproducts. Drafts, ranking JSON,
+# comparison reports. Per-run artefacts; the pipeline source lives under
+# scripts/mythos/, but its transient outputs do not belong in version
+# control.
+.rivet/mythos/
+
+# Cross-repo external clones. `rivet sync` populates this from each
+# external declared in rivet.yaml. Per-developer working tree, never
+# committed. (Tracked .rivet/ files like agent-context.md stay tracked.)
+.rivet/repos/


### PR DESCRIPTION
## Summary

Three transient working-tree paths that have been showing up as untracked across recent sessions:

- **\`mutants.out/\` + \`mutants.out.old/\`** — cargo-mutants per-run output. Large, transient, per-developer. cargo-mutants rotates the previous run to \`.old\` automatically; \`mutants.out*/\` covers both.
- **\`.rivet/mythos/\`** — slop-hunt agent pipeline workproducts (drafts, ranking JSON, comparison reports). The pipeline source lives under \`scripts/mythos/\`; transient outputs belong outside VCS.
- **\`.rivet/repos/\`** — destination for \`rivet sync\` external clones. Per-developer working tree, never committed. Sibling tracked \`.rivet/\` files (\`agent-context.md\`, \`provenance-pending.json\`) stay tracked.

No behaviour change; none of these were ever committed, but they pollute \`git status\` output and create a small risk of accidental capture via \`git add .\`.

## Test plan

- [x] \`git status --short\` after the change shows only intended modifications
- [x] Existing tracked \`.rivet/\` files (\`agent-context.md\`, \`provenance-pending.json\`) remain tracked (the ignore pattern is per-subdirectory, not blanket \`.rivet/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)