### PR TITLE
fix(export): compliance bundle was 842 MB dashboard mirror

### DIFF
--- a/.github/actions/compliance/action.yml
+++ b/.github/actions/compliance/action.yml
@@ -40,9 +40,23 @@ inputs:
     default: 'dark'
 
   offline:
-    description: 'When true, uses system fonts instead of loading Google Fonts. For air-gapped environments.'
+    description: 'When true, uses system fonts instead of loading Google Fonts. For air-gapped environments. Defaults to true for compliance reports — auditors typically open the bundle disconnected.'
     required: false
-    default: 'false'
+    default: 'true'
+
+  single-page:
+    description: >
+      When true, emits a single self-contained `index.html` (typically
+      1-5 MB) with all sections inline — index / requirements / documents
+      / STPA / EU AI Act / coverage / matrix / validation / graph. This
+      is the audit-bundle shape: one file, no per-page navigation, no
+      external resources, browser-openable offline.
+
+      When false, emits the full multi-page dashboard mirror (hundreds
+      of pages, ~100s of MB). Useful for browseable hosted docs but
+      oversized for an audit deliverable.
+    required: false
+    default: 'true'
 
   # ── Rivet tool ─────────────────────────────────────────────────────
   rivet-version:
@@ -170,6 +184,7 @@ runs:
         REPORT_HOMEPAGE: ${{ inputs.homepage }}
         REPORT_VERSIONS: ${{ inputs.other-versions }}
         REPORT_OFFLINE: ${{ inputs.offline }}
+        REPORT_SINGLE_PAGE: ${{ inputs.single-page }}
       run: |
         ARGS="--format html --output ${REPORT_OUTPUT}"
         ARGS="$ARGS --theme ${REPORT_THEME}"
@@ -185,6 +200,10 @@ runs:
 
         if [ "$REPORT_OFFLINE" = "true" ]; then
           ARGS="$ARGS --offline"
+        fi
+
+        if [ "$REPORT_SINGLE_PAGE" = "true" ]; then
+          ARGS="$ARGS --single-page"
         fi
 
         eval rivet export $ARGS

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -6573,9 +6573,9 @@ fn cmd_export_gherkin(
 fn cmd_export_html(
     cli: &Cli,
     output: Option<&std::path::Path>,
-    _single_page: bool,
-    _theme: &str,
-    _offline: bool,
+    single_page: bool,
+    theme: &str,
+    offline: bool,
     _homepage: Option<&str>,
     _version_label: Option<&str>,
     _versions_json: Option<&str>,
@@ -6592,6 +6592,51 @@ fn cmd_export_html(
     // Load project state using the same pipeline as `rivet serve`.
     let state = serve::reload_state(&project_path, &schemas_dir, 0)
         .context("loading project for export")?;
+
+    // ── Single-page mode (audit-bundle shape) ────────────────────────
+    //
+    // The multi-page export below mirrors the `rivet serve` dashboard
+    // (~800 pages, ~800 MB) which is useful for browsing but not for an
+    // audit bundle. `--single-page` short-circuits to the dedicated
+    // single-page renderer in `rivet_core::export::render_single_page`:
+    // one self-contained `index.html` with the index / requirements /
+    // documents / STPA / EU-AI-Act / coverage / matrix / validation /
+    // graph sections inline, ~3-5 MB total. This is the path the
+    // `.github/actions/compliance` action calls; the CLI previously
+    // ignored the flag (the parameters were `_`-prefixed).
+    if single_page {
+        let config = rivet_core::export::ExportConfig {
+            theme: match theme {
+                "light" => rivet_core::export::ExportTheme::Light,
+                _ => rivet_core::export::ExportTheme::Dark,
+            },
+            offline,
+        };
+        let project_name = state.context.project_name.clone();
+        let version = env!("CARGO_PKG_VERSION").to_string();
+        let html = rivet_core::export::render_single_page(
+            &state.store,
+            &state.schema,
+            &state.graph,
+            &state.cached_diagnostics,
+            &project_name,
+            &version,
+            &config,
+            &state.doc_store,
+        );
+        let out_dir = output.unwrap_or(std::path::Path::new("dist"));
+        std::fs::create_dir_all(out_dir)
+            .with_context(|| format!("creating {}", out_dir.display()))?;
+        let out_file = out_dir.join("index.html");
+        std::fs::write(&out_file, &html)
+            .with_context(|| format!("writing {}", out_file.display()))?;
+        println!(
+            "Exported single-page HTML ({} bytes) to {}",
+            html.len(),
+            out_file.display(),
+        );
+        return Ok(true);
+    }
 
     // Auto-detect baseline snapshot for delta rendering.
     let snap_dir = project_path.join("snapshots");

--- a/rivet-core/src/export.rs
+++ b/rivet-core/src/export.rs
@@ -1871,8 +1871,12 @@ fn render_section_graph(store: &Store, link_graph: &LinkGraph) -> String {
                 .get(n.as_str())
                 .map(|a| a.title.clone())
                 .unwrap_or_default();
-            let sublabel = if title.len() > 28 {
-                Some(format!("{}...", &title[..26]))
+            let sublabel = if title.chars().count() > 28 {
+                // Truncate by chars, not bytes — `&title[..26]` panics when
+                // byte 26 falls inside a multi-byte UTF-8 character (e.g.
+                // the em-dash `—`, 3 bytes). Take 26 chars and append `…`.
+                let truncated: String = title.chars().take(26).collect();
+                Some(format!("{truncated}…"))
             } else if title.is_empty() {
                 None
             } else {


### PR DESCRIPTION
## Summary

The release pipeline shipped \`rivet-v0.9.0-compliance-report.tar.gz\` at **842 MB** — a static mirror of the \`rivet serve\` dashboard (every page, source mirror, AADL viewer JS, per-schema help pages). That's a browseable website dump, not the audit-quality bundle the artifact name promises. Auditors opening this archive got a confusing browse tree instead of a focused dossier.

Three surgical changes restore the audit-bundle shape:

### 1. \`rivet-cli/src/main.rs\` — wire the CLI flags through

\`cmd_export_html\` declared \`single_page\`, \`theme\`, and \`offline\` parameters all prefixed with \`_\` — explicitly ignored. The CLI advertised \`--single-page\` in \`--help\`; the binary swallowed it silently. Un-underscored and wired through:

- \`--single-page true\`: short-circuit at the top of the function, call \`rivet_core::export::render_single_page\` (already exists at \`export.rs:2451\`), write one \`index.html\`, return.
- \`--offline true\`: build \`ExportConfig { offline: true }\` so no external fonts are loaded.
- \`--theme light|dark\`: select \`ExportTheme::Light\` or \`ExportTheme::Dark\`.

### 2. \`rivet-core/src/export.rs\` — UTF-8 boundary panic in \`render_single_page\`

The graph-node sublabel at line 1875 did \`&title[..26]\` which panics on any title with a multi-byte UTF-8 character at the 26-byte boundary. Hits this dogfood title: *"Human review degradation — reviewer trusts AI without verification"* (em-dash at bytes 25-27). Replaced with \`chars().take(26).collect::<String>()\` + ellipsis.

### 3. \`.github/actions/compliance/action.yml\` — new \`single-page\` input

Adds \`single-page: true\` (default) as a new action input. Compliance reports want single-page by default; the multi-page mirror remains opt-in. Also flips \`offline: 'false' → 'true'\` as default — auditors typically open bundles disconnected from the internet.

## Result (rivet's own dogfood)

| | v0.9.0 (current) | After this PR |
|---|---|---|
| **Size** | 842 MB | **1.4 MB** (600× smaller) |
| **Shape** | Static mirror of \`rivet serve\` (index/coverage/help/validate/matrix/graph + per-schema pages + AADL viewer JS) | Single self-contained \`index.html\` with 9 inline sections |
| **External resources** | Google Fonts + WASM viewers | Zero (verified with \`grep -c "https://fonts\\."\`) |
| **Browser** | Requires HTTP server to serve relative paths | Opens directly via \`file://\` |

Inline sections in the new bundle:
\`index\`, \`requirements\`, \`documents\`, \`stpa\`, \`eu-ai-act\`, \`coverage\`, \`matrix\`, \`validation\`, \`graph\`.

## Test plan

- [x] Local: \`./target/release/rivet export --format html --single-page --offline --output /tmp/c\` → 1.4 MB \`index.html\`, 9 \`<section id="...">\` blocks, 0 external resources
- [x] \`cargo test -p rivet-core --lib export::\` → 42/42 pass (UTF-8 boundary fix doesn't break existing tests)
- [x] Multi-page path (no \`--single-page\` flag) unchanged — short-circuit only fires when \`single_page\` is true
- [ ] Next release will produce a small, audit-readable \`compliance-report.tar.gz\` instead of an 842 MB blob

## Trailer

\`Fixes: REQ-010\` (export contract integrity) · \`Refs: REQ-007\` (CLI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)