### PR TITLE
refactor(model): Artifact status helpers — replace case-fold boilerplate

### DIFF
--- a/rivet-core/src/model.rs
+++ b/rivet-core/src/model.rs
@@ -164,6 +164,44 @@ impl Artifact {
     pub fn baseline(&self) -> Option<&str> {
         self.fields.get("baseline").and_then(|v| v.as_str())
     }
+
+    /// Case-insensitive comparison of the artifact's status to the
+    /// given lifecycle marker. Returns `false` when `status` is `None`.
+    ///
+    /// Replaces the long-form
+    /// `artifact.status.as_deref().map(str::to_lowercase).as_deref() == Some("draft")`
+    /// pattern that appeared at every status-aware site. Status remains
+    /// `Option<String>` at the schema level (projects use custom
+    /// lifecycle markers); this method only encapsulates the casing /
+    /// nul-safety dance.
+    #[inline]
+    pub fn status_is(&self, lifecycle: &str) -> bool {
+        self.status
+            .as_deref()
+            .is_some_and(|s| s.eq_ignore_ascii_case(lifecycle))
+    }
+
+    /// Convenience: `true` iff the artifact's status is `draft`
+    /// (case-insensitive). The most common status check in the codebase
+    /// (every traceability rule's draft-downgrade goes through this).
+    #[inline]
+    pub fn is_draft(&self) -> bool {
+        self.status_is("draft")
+    }
+
+    /// Convenience: `true` iff the artifact's status is `approved`
+    /// (case-insensitive).
+    #[inline]
+    pub fn is_approved(&self) -> bool {
+        self.status_is("approved")
+    }
+
+    /// Convenience: `true` iff the artifact's status is `released`
+    /// (case-insensitive).
+    #[inline]
+    pub fn is_released(&self) -> bool {
+        self.status_is("released")
+    }
 }
 
 #[cfg(test)]
@@ -193,6 +231,51 @@ mod tests {
         a.fields
             .insert("baseline".into(), serde_yaml::Value::Bool(true));
         assert_eq!(a.baseline(), None);
+    }
+
+    #[test]
+    fn status_is_case_insensitive() {
+        let mut a = minimal_artifact("A-1", "req");
+        a.status = Some("Draft".into());
+        assert!(a.status_is("draft"), "case-insensitive match");
+        assert!(a.status_is("DRAFT"));
+        assert!(a.status_is("Draft"));
+        assert!(!a.status_is("approved"));
+    }
+
+    #[test]
+    fn status_is_returns_false_for_none() {
+        let mut a = minimal_artifact("A-1", "req");
+        a.status = None;
+        assert!(!a.is_draft());
+        assert!(!a.is_approved());
+        assert!(!a.is_released());
+        assert!(!a.status_is("anything"));
+    }
+
+    #[test]
+    fn is_draft_and_is_approved_and_is_released_match_known_values() {
+        let mut a = minimal_artifact("A-1", "req");
+        a.status = Some("draft".into());
+        assert!(a.is_draft());
+        assert!(!a.is_approved());
+
+        a.status = Some("APPROVED".into());
+        assert!(a.is_approved());
+        assert!(!a.is_draft());
+
+        a.status = Some("released".into());
+        assert!(a.is_released());
+    }
+
+    #[test]
+    fn status_is_handles_custom_lifecycle_markers() {
+        let mut a = minimal_artifact("A-1", "req");
+        a.status = Some("needs-review".into());
+        assert!(a.status_is("needs-review"));
+        assert!(a.status_is("Needs-Review"));
+        assert!(!a.is_draft());
+        assert!(!a.is_approved());
     }
 
     #[test]

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -408,9 +408,7 @@ fn evaluate_validation_rules(store: &Store, schema: &Schema, graph: &LinkGraph) 
             if holds {
                 continue;
             }
-            let severity = if rule.draft_downgrade
-                && artifact.status.as_deref().map(str::to_lowercase).as_deref() == Some("draft")
-            {
+            let severity = if rule.draft_downgrade && artifact.is_draft() {
                 Severity::Info
             } else {
                 rule.severity
@@ -749,12 +747,11 @@ pub fn validate_structural_with_externals(
 
             // Draft artifacts get downgraded to Info for traceability rule violations.
             // Active and approved artifacts receive full error-level enforcement.
-            let effective_severity =
-                if artifact.status.as_deref().map(str::to_lowercase).as_deref() == Some("draft") {
-                    Severity::Info
-                } else {
-                    rule.severity
-                };
+            let effective_severity = if artifact.is_draft() {
+                Severity::Info
+            } else {
+                rule.severity
+            };
 
             // Forward link check.
             //


### PR DESCRIPTION
## Summary

Every status-aware site in \`validate.rs\` did the same ten-token incantation:

\`\`\`rust
artifact.status.as_deref().map(str::to_lowercase).as_deref() == Some("draft")
\`\`\`

Two such sites today (phase-7 traceability-rule draft-downgrade + phase-9 validation-rule draft-downgrade), and every future status-aware piece of code would have replicated it. Each redundant case-fold also allocates a \`String\` per check.

## The fix

Four methods on \`Artifact\`:

- \`status_is(&self, lifecycle: &str) -> bool\` — case-insensitive comparison via \`eq_ignore_ascii_case\` (no allocation). Returns \`false\` when \`status\` is \`None\`.
- \`is_draft(&self) -> bool\` — convenience for the most common check.
- \`is_approved(&self) -> bool\`, \`is_released(&self) -> bool\` — convenience for the other two lifecycle markers commonly tested.

The schema-level type of \`status\` stays \`Option<String>\`. Projects use custom lifecycle markers (\`needs-review\`, \`triaged\`, \`released-with-caveats\`); a closed typed enum would break those. Only the boilerplate at *check* sites goes away.

## Sites updated

| File | Site | Before | After |
|---|---|---|---|
| \`validate.rs:411\` | Phase-9 draft-downgrade | \`artifact.status.as_deref().map(str::to_lowercase).as_deref() == Some("draft")\` | \`artifact.is_draft()\` |
| \`validate.rs:752\` | Phase-7 draft-downgrade | (same boilerplate) | \`artifact.is_draft()\` |

## Test plan

- [x] 4 new regression tests in \`model::tests\`:
  - \`status_is_case_insensitive\` — \`Draft\` / \`DRAFT\` / \`draft\` all match
  - \`status_is_returns_false_for_none\` — all helpers return \`false\` on \`None\`
  - \`is_draft_and_is_approved_and_is_released_match_known_values\`
  - \`status_is_handles_custom_lifecycle_markers\` — \`needs-review\` matches itself, \`is_draft\` returns false
- [x] \`cargo test -p rivet-core --lib\` → 974 pass / 39 model tests pass
- [x] No behaviour change at the validate sites (same case-folding semantics)
- [ ] CI run on this PR

## Trailer

Refs: REQ-004 (validation), REQ-010 (model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)