### PR TITLE
ci(release): make build-test-evidence non-blocking (round 2) (#293)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,9 +165,18 @@ jobs:
           path: ${{ steps.report.outputs.archive-path }}
 
   # ── Test evidence bundle ──────────────────────────────────────────────
+  # Non-blocking: this job pulls in the spar wasm32-wasip2 build, which
+  # transitively requires the highs-sys C++ solver. WASI cross-compile of
+  # highs-sys has been flaky (CMake Threads::Threads target unavailable in
+  # the WASI sysroot — see v0.10.0 release run 25966236046). Until that
+  # upstream issue is resolved (tracked separately), this job must NOT
+  # block `create-release` from publishing the binaries that DID build.
+  # Test evidence is a desirable add-on, not a required gate; cargo test
+  # already ran on the merge commit before the tag was pushed.
   build-test-evidence:
     name: Build test evidence
     runs-on: ubuntu-latest
+    continue-on-error: true  # NB: doesn't block create-release; see note above.
     steps:
       - uses: actions/checkout@v6
 
@@ -307,9 +316,14 @@ jobs:
           path: vscode-rivet/*.vsix
 
   # ── Create GitHub Release ─────────────────────────────────────────────
+  # Note: build-test-evidence is intentionally NOT in `needs` — that job
+  # depends on a flaky WASI cross-compile (spar → highs-sys) and a failure
+  # there must not block publication of the cross-platform binaries. If
+  # the test-evidence tarball does build, it will be available as a
+  # workflow artifact and can be attached to the release manually.
   create-release:
     name: Create GitHub Release
-    needs: [build-binaries, build-compliance, build-test-evidence, build-vsix, docs-check]
+    needs: [build-binaries, build-compliance, build-vsix, docs-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

v0.10.0 release workflow built all binaries successfully but \`Create GitHub Release\` was skipped because \`build-test-evidence\` failed on the spar→highs-sys WASI cross-compile (transitive CMake \`Threads::Threads\` issue). I manually republished v0.10.0 from the workflow artifacts.

To prevent the hand-republish on every future tag push, this PR:

- Makes \`build-test-evidence\` \`continue-on-error: true\`. The job still runs and uploads when it succeeds.
- Removes \`build-test-evidence\` from \`create-release.needs\`. The Collect-assets step uses a permissive \`find\` that tolerates the missing tarball.

The root-cause investigation is tracked in #293 — once that lands, this commit can be reverted.

## History
- #272 originally introduced \`continue-on-error\` for the same reason.
- #274 reverted it, integrating wasi-sdk in the expectation that highs-sys would build.
- v0.10.0 proved wasi-sdk 25.0 still doesn't supply the \`Threads::Threads\` CMake target on WASI.

## Test plan

- [ ] Next tag push (v0.11+) publishes the release page without manual intervention.
- [ ] If \`build-test-evidence\` succeeds, the tarball appears in the release as before.
- [ ] If it fails, the release still publishes; the workflow shows yellow not red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)