### PR TITLE
ci: decouple playwright/kani/rocq from needs:[test] (#299)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,10 @@ jobs:
   # ── Playwright E2E ────────────────────────────────────────────────────
   playwright:
     name: Playwright E2E
-    needs: [test]
+    # Decoupled from `test` (#299): Playwright runs the release binary
+    # end-to-end and is independent of cargo-test passing. Keeping it
+    # gated on `test` blocked an ubuntu-latest job behind self-hosted
+    # rust-cpu saturation (2026-05-17 incident).
     # Stays on ubuntu-latest: `npx playwright install --with-deps` runs
     # `apt-get install` (sudo needed) and pulls in Chromium + a slate
     # of system libraries. Smithy runners have no sudo.
@@ -508,7 +511,10 @@ jobs:
   # PR-sized subset completes in <20 min.
   kani:
     name: Kani Proofs
-    needs: [test]
+    # Decoupled from `test` (#299): Kani harnesses are bounded model
+    # checks against rivet-core; they don't read cargo-test status.
+    # Keeping the gate blocked an ubuntu-latest job behind self-hosted
+    # rust-cpu saturation (2026-05-17 incident).
     # Stays on ubuntu-latest: kani-verifier bundles CBMC (~100 MB),
     # not pre-installed on smithy. Move once toolchains role ships kani.
     runs-on: ubuntu-latest
@@ -591,7 +597,10 @@ jobs:
   # port. TODO: flip to hard gate after the Rocq 9 port PR.
   rocq:
     name: Rocq Proofs
-    needs: [test]
+    # Decoupled from `test` (#299): Rocq theorem proving runs against
+    # vendored .v files; it doesn't read cargo-test status. Keeping
+    # the gate blocked an ubuntu-latest job behind self-hosted rust-cpu
+    # saturation (2026-05-17 incident).
     # Stays on ubuntu-latest: Rocq (Coq) install is heavy and
     # not pre-provisioned on smithy. Migrate once toolchains role ships it.
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #299.

## Summary

Phase 1 of the CI fan-out de-coupling proposed in #299. When the self-hosted `rust-cpu` pool saturates (rivet-core mutation testing held it for ~4 hours on 2026-05-17, smithy commit `70401cd`), the entire downstream CI tree blocks because eight jobs chain off `test`. Three of those — `playwright`, `kani`, `rocq` — have their own ubuntu-latest runner capacity available and are independent of cargo-test status.

## Acceptance criteria from #299

- [x] **Remove `needs: [test]` from `playwright`.** `.github/workflows/ci.yml` line ~117. Replaced with a 4-line comment explaining the decoupling and back-referencing #299. Playwright runs the release binary end-to-end via `npx`; cargo-test status is not a precondition.
- [x] **Remove `needs: [test]` from `kani`.** Line ~511. Kani harnesses are bounded model checks against `rivet-core` source; they do not read cargo-test status.
- [x] **Remove `needs: [test]` from `rocq`.** Line ~594. Rocq theorem proving runs against vendored `.v` files; it does not read cargo-test status.
- [x] **Keep `needs: [test]` on `coverage`.** Verified at the remaining `grep` line — coverage re-runs the same suite under `llvm-cov` so the dependency is legitimate.
- [x] **Keep `needs: [test]` on `mutants`.** Verified at the remaining `grep` line — `mutants` (lean-mem) mutation testing intentionally gates on a clean `test` baseline.
- [x] **`verus` deferred to Phase 2.** Verus still gates on `test`; no change in this PR per the issue's "Defer verus to Phase 2" line.

After the change, only five `needs: [test]` references remain in `ci.yml`: `vscode-extension` (Phase 2 audit), `coverage` (kept), `mutants` (kept), `verus` (deferred), `release-results` (Phase 2 fan-in concern).

## Out of scope (Phase 2, not in this PR)

- Auditing `vscode-extension`'s dep on `test`.
- Reconsidering the 5-way `release-results` fan-in.
- Lowering `cargo-mutants --jobs` or sharding the rivet-core mutation suite.

## Test plan

- [x] `grep -n "needs:" .github/workflows/ci.yml` — only the five expected references remain (`vscode-extension`, `coverage`, `mutants`, `verus`, `release-results`).
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — workflow is still valid YAML.
- [x] yamllint config (default + project overrides at `.yamllint.yml`): comment lines ≤120 chars, 4-space comment indentation matching surrounding context, no flow-style maps.
- [ ] First post-merge CI run on `main` shows `playwright`, `kani`, `rocq` starting in parallel with `test` rather than queuing behind it. (Validated only after merge — that's the gate the issue describes.)

## Commit traceability

`ci` type is exempt from artifact trailers per `CLAUDE.md` ("Exempt types (no trailer needed): chore, style, ci, docs, build."). No `Implements:` / `Refs:` lines required.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HxueTb3QAoFVqMh1khuTAa)_