### PR TITLE
ci(mutants): drop --jobs 4 → --jobs 2 to fit 32G lean-mem cgroup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,21 @@ jobs:
         # "x3 baseline" rule — anything slower than that is reported as
         # `timeout` (counts as caught) rather than `missed`. With 30s
         # cap and 16-way sharding, each shard finishes in ~12-20 min.
-        run: cargo mutants -p ${{ matrix.crate }} --shard ${{ matrix.shard }} --timeout 30 --jobs 4 --output mutants-out -- --lib || true
+        #
+        # `--jobs 2` (was 4): smithy operator flagged on 2026-05-18 that
+        # lean-mem runners were hitting their 32G cgroup ceiling
+        # (runner3 31.0G/32G with 996MB headroom, ~3GB swap). Each
+        # cargo-mutants worker compiles a fresh target dir and runs the
+        # full test suite — at 4-way parallel that's ~8G per worker on
+        # a 32G runner, which is at or above cargo-rustc's compile peak
+        # for rivet-core's larger crates and triggers the same swap-
+        # death-spiral pattern the cgroup bump was meant to break.
+        # Halving concurrency gives ~16G per worker, comfortable for
+        # the compile peak with headroom for the test suite. Trade-off:
+        # each shard takes ~2x as long (was 12-20 min, now 20-40 min),
+        # but the lean-mem pool stops needing emergency cgroup-ceiling
+        # bumps every quarter.
+        run: cargo mutants -p ${{ matrix.crate }} --shard ${{ matrix.shard }} --timeout 30 --jobs 2 --output mutants-out -- --lib || true
       - name: Check surviving mutants
         run: |
           MISSED=0


### PR DESCRIPTION
## Summary

Smithy operator's 2026-05-18 status showed lean-mem runners approaching the 32G cgroup ceiling **again**, ~16 hours after their 24G→32G bump:

\`\`\`
runner3   31.0G/32G  (996MB headroom)  swap 2.1G  peak 2.8G
runner4   30.4G/32G  (1.5G headroom)   swap 2.1G  peak 2.3G
\`\`\`

Same death-spiral pattern that triggered the prior emergency bump. Their note: *"the 32G bump is also approaching its ceiling — the next escalation tier is the workflow-side fix"*.

## What changes

`cargo-mutants --jobs 4` → `--jobs 2` in the mutants step.

Each cargo-mutants worker compiles a fresh target dir and runs the full test suite. At 4-way parallel on a 32G cgroup that's ~8G/worker which is at-or-above rivet-core's compile peak — triggers the same swap-death-spiral pattern the cgroup bump was meant to break. 2-way gives ~16G/worker with comfortable headroom.

**Trade-off**: each shard takes ~2× as long (was 12-20 min, now 20-40 min). Net effect on the lean-mem queue is similar because we stop OOM-cycling mutants that previously had to be retried. Smithy operator confirmed: *"the durable answer is on the workflow side: lower cargo-mutants --jobs concurrency, or split mutation testing into smaller shards."*

## Composes with

- **#299** — independent: that issue decouples \`playwright\`/\`kani\`/\`rocq\` from \`needs: [test]\` to reduce blast radius when the rust-cpu pool stalls. This PR addresses the lean-mem side.

## Test plan

- [ ] Next mutants run lands under the lean-mem 32G ceiling with >4G headroom per worker.
- [ ] Shard completion times move from 12-20 min to 20-40 min as predicted.
- [ ] No regression in caught/missed mutant counts (concurrency change doesn't affect mutation semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)