### PR TITLE
fix(validate): surface skipped artifact files as Errors (REQ-062, P0)

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -4544,6 +4544,33 @@ fn cmd_validate(
         ..
     } = ctx;
 
+    // REQ-062 / F2: `load_artifacts` swallows per-file YAML parse failures
+    // to a stderr `log::warn!`, so a malformed artifact file produced a
+    // green `Result: PASS` over an effectively-empty load. Re-walk every
+    // `generic`/`generic-yaml` source and collect the files that failed to
+    // import, classified into:
+    //   * ParseError       — a malformed artifact file (F2a) -> Error diag.
+    //   * NotArtifactFile  — legitimate non-artifact YAML living under the
+    //                        source path, e.g. `bindings.yaml` (F2b)
+    //                        -> silently skipped, no diagnostic.
+    let mut parse_error_skips: Vec<rivet_core::SkippedFile> = Vec::new();
+    for source in &config.sources {
+        match rivet_core::load_artifacts_with_skips(source, &cli.project, &schema) {
+            Ok((_artifacts, skips)) => {
+                for skip in skips {
+                    if skip.kind == rivet_core::SkipKind::ParseError {
+                        parse_error_skips.push(skip);
+                    }
+                }
+            }
+            Err(e) => {
+                // A hard load error here is already surfaced by
+                // `ProjectContext::load`; don't double-report.
+                log::warn!("could not re-scan source '{}' for skips: {e}", source.path);
+            }
+        }
+    }
+
     // Apply baseline scoping if requested
     let (store, graph) = if let Some(bl) = baseline_name {
         if let Some(ref baselines) = config.baselines {
@@ -4796,6 +4823,26 @@ fn cmd_validate(
     );
     diagnostics.extend(cited_source_diags);
 
+    // REQ-062 / F2a: surface malformed artifact files as Error diagnostics.
+    // These would otherwise be invisible (swallowed to a stderr log line by
+    // `load_artifacts`), letting `rivet validate` report PASS over a file
+    // that never loaded. They flow into `errors`, the text/JSON output, and
+    // the exit code like any other Error.
+    for skip in &parse_error_skips {
+        let mut diag = validate::Diagnostic::new(
+            Severity::Error,
+            None,
+            "artifact-parse-error",
+            format!(
+                "artifact file {} failed to parse: {}",
+                skip.path.display(),
+                skip.reason
+            ),
+        );
+        diag.source_file = Some(skip.path.clone());
+        diagnostics.push(diag);
+    }
+
     // Cross-repo link validation (skipped with --skip-external-validation)
     let mut cross_repo_broken: Vec<rivet_core::externals::BrokenRef> = Vec::new();
     let mut backlinks: Vec<rivet_core::externals::CrossRepoBacklink> = Vec::new();
@@ -4884,6 +4931,7 @@ fn cmd_validate(
                 serde_json::json!({
                     "severity": format!("{:?}", d.severity).to_lowercase(),
                     "artifact_id": d.artifact_id,
+                    "rule": d.rule,
                     "message": d.message,
                 })
             })

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -393,6 +393,108 @@ fn validate_json() {
     );
 }
 
+/// REQ-062 / F2: `rivet validate` must surface a malformed artifact file
+/// as an Error diagnostic — not swallow it to a stderr log line under a
+/// green PASS. A file with top-level `id:`/`type:` (an artifact written
+/// without the `artifacts:` wrapper) must fail validation. A legitimate
+/// non-artifact file (`bindings.yaml`) must NOT add an error (F2b).
+///
+/// rivet: verifies REQ-062
+#[test]
+fn validate_surfaces_parse_error_on_malformed_artifact_file() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dir.to_str().unwrap()])
+        .output()
+        .expect("failed to execute rivet init");
+    assert!(
+        init.status.success(),
+        "rivet init must exit 0. stderr: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // F2a: an artifact written WITHOUT the required `artifacts:` wrapper.
+    std::fs::write(
+        dir.join("artifacts").join("malformed.yaml"),
+        "id: REQ-OOPS\ntype: requirement\ntitle: Forgot the artifacts wrapper\n",
+    )
+    .expect("write malformed.yaml");
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute rivet validate");
+
+    assert!(
+        !out.status.success(),
+        "validate must exit non-zero when an artifact file fails to parse"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("validate JSON must be valid");
+    assert_eq!(
+        parsed.get("result").and_then(|v| v.as_str()),
+        Some("FAIL"),
+        "result must be FAIL; got: {parsed}"
+    );
+    assert!(
+        parsed.get("errors").and_then(|v| v.as_u64()).unwrap_or(0) >= 1,
+        "errors must be >= 1; got: {parsed}"
+    );
+    let diags = parsed
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics array");
+    let parse_err = diags
+        .iter()
+        .find(|d| d.get("rule").and_then(|r| r.as_str()) == Some("artifact-parse-error"));
+    let parse_err = parse_err.unwrap_or_else(|| {
+        panic!("expected a diagnostic with rule 'artifact-parse-error'; got: {parsed}")
+    });
+    assert!(
+        parse_err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .is_some_and(|m| m.contains("malformed.yaml")),
+        "the artifact-parse-error message must name the malformed file; got: {parse_err}"
+    );
+
+    // F2b: a legitimate non-artifact file under the same source path must
+    // NOT contribute an error. Capture the error count, add bindings.yaml,
+    // and assert the count does not grow.
+    let errors_before = parsed.get("errors").and_then(|v| v.as_u64()).unwrap_or(0);
+    std::fs::write(
+        dir.join("artifacts").join("bindings.yaml"),
+        "bindings:\n  - feature: core\n    artifact: REQ-001\n",
+    )
+    .expect("write bindings.yaml");
+
+    let out2 = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute rivet validate (2)");
+    let parsed2: serde_json::Value =
+        serde_json::from_slice(&out2.stdout).expect("validate JSON (2) must be valid");
+    assert_eq!(
+        parsed2.get("errors").and_then(|v| v.as_u64()).unwrap_or(0),
+        errors_before,
+        "a legitimate non-artifact file (bindings.yaml) must not add an error; got: {parsed2}"
+    );
+}
+
 // ── rivet stats ─────────────────────────────────────────────────────────
 
 /// `rivet stats --format json` produces valid JSON with total count.

--- a/rivet-core/src/formats/generic.rs
+++ b/rivet-core/src/formats/generic.rs
@@ -57,7 +57,7 @@
 )]
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Maximum allowed YAML file size (10 MB). Files exceeding this limit are
 /// rejected before parsing to mitigate resource-exhaustion attacks (SSC-6).
@@ -233,10 +233,143 @@ fn import_generic_directory(dir: &Path) -> Result<Vec<Artifact>, Error> {
     Ok(artifacts)
 }
 
+/// Why a YAML file under a `generic`/`generic-yaml` source path was not
+/// loaded as an artifact list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipKind {
+    /// The file looks like it was *meant* to be an artifact file but is
+    /// malformed (not valid YAML, a broken `artifacts:` list, or an
+    /// artifact written without the `artifacts:` wrapper). This is a
+    /// user-facing error (F2a).
+    ParseError,
+    /// The file is legitimate non-artifact YAML that happens to live under
+    /// the `artifacts/` source path (e.g. `bindings.yaml`,
+    /// `feature-model.yaml`, `variants/*.yaml`). It is skipped silently
+    /// with no diagnostic (F2b).
+    NotArtifactFile,
+}
+
+/// A YAML file that `import_generic_file` declined to load, together with
+/// the classification of *why* (see [`SkipKind`]).
+#[derive(Debug, Clone)]
+pub struct SkippedFile {
+    /// Path to the file that failed to import.
+    pub path: PathBuf,
+    /// Human-readable reason (the underlying parse/IO error message).
+    pub reason: String,
+    /// Whether this is a malformed artifact file (`ParseError`) or
+    /// legitimate non-artifact YAML (`NotArtifactFile`).
+    pub kind: SkipKind,
+}
+
+/// Classify a `.yaml`/`.yml` file that failed `import_generic_file`.
+///
+/// Re-parses the raw content as a generic `serde_yaml::Value` and applies
+/// the REQ-062 classification rule:
+///
+/// 1. Not valid YAML at all -> [`SkipKind::ParseError`] (F2a).
+/// 2. Top-level mapping has an `artifacts` key -> [`SkipKind::ParseError`]
+///    (a malformed artifacts list).
+/// 3. Top-level mapping has BOTH `id` and `type` keys ->
+///    [`SkipKind::ParseError`] (an artifact written without the
+///    `artifacts:` wrapper — the exact F2a reproducer).
+/// 4. Anything else -> [`SkipKind::NotArtifactFile`] (F2b — skip silently).
+fn classify_skip(content: &str) -> SkipKind {
+    let value: serde_yaml::Value = match serde_yaml::from_str(content) {
+        Ok(v) => v,
+        // Case 1: not valid YAML at all.
+        Err(_) => return SkipKind::ParseError,
+    };
+    if let serde_yaml::Value::Mapping(map) = value {
+        let has_key = |k: &str| map.contains_key(serde_yaml::Value::String(k.to_string()));
+        // Case 2: a top-level `artifacts:` key means this was intended as
+        // an artifact-list file; if `import_generic_file` rejected it, the
+        // list itself is malformed.
+        if has_key("artifacts") {
+            return SkipKind::ParseError;
+        }
+        // Case 3: both `id` and `type` at top level — an artifact written
+        // without the required `artifacts:` wrapper.
+        if has_key("id") && has_key("type") {
+            return SkipKind::ParseError;
+        }
+    }
+    // Case 4: legitimate non-artifact YAML (mapping without the artifact
+    // signals, a list, or a scalar).
+    SkipKind::NotArtifactFile
+}
+
+/// Recursively collect `.yaml`/`.yml` file paths under `dir`, mirroring the
+/// directory walk in [`import_generic_directory`].
+fn collect_yaml_paths(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path
+            .extension()
+            .is_some_and(|ext| ext == "yaml" || ext == "yml")
+        {
+            out.push(path);
+        } else if path.is_dir() {
+            collect_yaml_paths(&path, out);
+        }
+    }
+}
+
+/// Walk `dir` exactly like [`import_generic_directory`] and report every
+/// `.yaml`/`.yml` file that fails `import_generic_file`, classified per the
+/// REQ-062 rule (see [`classify_skip`]).
+///
+/// Well-formed artifact files produce no entry. The returned vec is the
+/// missing diagnostic signal: without it, malformed artifact files were
+/// swallowed to a stderr `log::warn!` and `rivet validate` reported a green
+/// PASS over an empty load.
+pub fn scan_skipped_files(dir: &Path) -> Vec<SkippedFile> {
+    let mut paths = Vec::new();
+    collect_yaml_paths(dir, &mut paths);
+    let mut skipped = Vec::new();
+    for path in paths {
+        match import_generic_file(&path) {
+            Ok(_) => {}
+            Err(e) => {
+                let reason = e.to_string();
+                let kind = match std::fs::read_to_string(&path) {
+                    Ok(content) => classify_skip(&content),
+                    // Couldn't even read the file (IO error / non-UTF-8) —
+                    // treat as a parse error so it surfaces.
+                    Err(_) => SkipKind::ParseError,
+                };
+                skipped.push(SkippedFile { path, reason, kind });
+            }
+        }
+    }
+    skipped
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
+
+    /// REQ-062 / F2: genuinely corrupt YAML (not even parseable) is a
+    /// ParseError; a bare list / scalar with no artifact signal is not.
+    /// Complements `scan_skipped_files_classifies_malformed_vs_non_artifact`
+    /// which covers the directory-walk + the `id`+`type` and `bindings`
+    /// cases.
+    ///
+    /// rivet: verifies REQ-062
+    #[test]
+    fn classify_skip_treats_corrupt_yaml_as_parse_error() {
+        assert_eq!(classify_skip("{[unbalanced: yaml"), SkipKind::ParseError);
+        // A bare list / scalar with no artifact signal is not an error.
+        assert_eq!(
+            classify_skip("- just\n- a\n- list\n"),
+            SkipKind::NotArtifactFile
+        );
+    }
 
     #[test]
     fn rejects_oversized_yaml_file() {
@@ -311,6 +444,64 @@ Artifacts:
             result.is_err(),
             "parse must fail on wrong-case top-level key 'Artifacts'; got Ok({:?})",
             result.as_ref().ok()
+        );
+    }
+
+    /// `scan_skipped_files` must distinguish a malformed artifact file
+    /// (F2a — top-level `id:`/`type:` without the `artifacts:` wrapper)
+    /// from legitimate non-artifact YAML (F2b — a `bindings:` file), and
+    /// must produce no entry at all for a well-formed `artifacts:` file.
+    ///
+    /// rivet: implements REQ-004 verifies REQ-062
+    #[test]
+    fn scan_skipped_files_classifies_malformed_vs_non_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // F2a: an artifact written WITHOUT the `artifacts:` wrapper.
+        let malformed = dir.path().join("malformed.yaml");
+        std::fs::write(
+            &malformed,
+            "id: REQ-001\ntype: requirement\ntitle: Orphan artifact\n",
+        )
+        .unwrap();
+
+        // F2b: legitimate non-artifact YAML living under the source path.
+        let bindings = dir.path().join("bindings.yaml");
+        std::fs::write(&bindings, "bindings:\n  - core\n  - dashboard\n").unwrap();
+
+        // Well-formed artifact file — must produce no skip entry.
+        let good = dir.path().join("requirements.yaml");
+        std::fs::write(
+            &good,
+            "artifacts:\n  - id: REQ-002\n    type: requirement\n    title: Valid\n",
+        )
+        .unwrap();
+
+        let skipped = scan_skipped_files(dir.path());
+
+        let malformed_entry = skipped
+            .iter()
+            .find(|s| s.path == malformed)
+            .expect("malformed.yaml must be reported as skipped");
+        assert_eq!(
+            malformed_entry.kind,
+            SkipKind::ParseError,
+            "an artifact without the `artifacts:` wrapper is F2a (ParseError)"
+        );
+
+        let bindings_entry = skipped
+            .iter()
+            .find(|s| s.path == bindings)
+            .expect("bindings.yaml must be reported as skipped");
+        assert_eq!(
+            bindings_entry.kind,
+            SkipKind::NotArtifactFile,
+            "a `bindings:` file is legitimate non-artifact YAML (F2b)"
+        );
+
+        assert!(
+            !skipped.iter().any(|s| s.path == good),
+            "a well-formed `artifacts:` file must produce no skip entry"
         );
     }
 }

--- a/rivet-core/src/lib.rs
+++ b/rivet-core/src/lib.rs
@@ -276,6 +276,43 @@ pub fn load_artifacts(
     }
 }
 
+/// Like [`load_artifacts`], but additionally reports YAML files that were
+/// skipped during a `generic`/`generic-yaml` directory import.
+///
+/// `load_artifacts` swallows per-file parse failures to a `log::warn!` line
+/// (see `formats::generic::import_generic_directory`), which means a
+/// malformed artifact file produces a green PASS over an empty load
+/// (REQ-062 / F2). This entrypoint re-walks the source directory via
+/// [`formats::generic::scan_skipped_files`] and returns the classified
+/// [`SkippedFile`]s alongside the artifacts so callers (notably
+/// `rivet validate`) can surface malformed files as Error diagnostics
+/// while still silently skipping legitimate non-artifact YAML.
+///
+/// For non-`generic` formats the skips vec is always empty — those
+/// adapters fail loudly rather than skipping files.
+///
+/// This is a separate function (not a signature change to `load_artifacts`)
+/// to keep the `rivet-core` public API semver-compatible.
+pub fn load_artifacts_with_skips(
+    source: &model::SourceConfig,
+    base_dir: &Path,
+    schema: &schema::Schema,
+) -> Result<(Vec<model::Artifact>, Vec<SkippedFile>), Error> {
+    let artifacts = load_artifacts(source, base_dir, schema)?;
+    let skips = match source.format.as_str() {
+        "generic" | "generic-yaml" => {
+            let path = base_dir.join(&source.path);
+            if path.is_dir() {
+                formats::generic::scan_skipped_files(&path)
+            } else {
+                Vec::new()
+            }
+        }
+        _ => Vec::new(),
+    };
+    Ok((artifacts, skips))
+}
+
 /// Import artifacts from a source using schema-driven rowan extraction.
 fn import_with_schema(
     source: &adapter::AdapterSource,
@@ -326,3 +363,7 @@ fn import_with_schema(
 }
 
 pub mod providers;
+
+/// Re-export of the skipped-file classification types so the CLI can name
+/// them without reaching into the `formats::generic` module path.
+pub use formats::generic::{SkipKind, SkippedFile};


### PR DESCRIPTION
## Summary

Wave 1 / PR-A of the cross-git investigation follow-ups (#304 →
FEAT-135). Closes the **P0** finding REQ-062.

`rivet validate` reported `Result: PASS (0 warnings)` when artifact
files failed to parse — the skip was swallowed to a stderr
`log::warn!` and never reached the diagnostics. A user who wrote an
artifact file with the wrong shape got a green PASS over an empty
load. The cross-git investigation called this the canonical
Cederqvist cliff; running `rivet validate` on rivet's *own* repo
reproduced it.

## The F2a / F2b distinction

Not every YAML file under a `generic-yaml` source path is an artifact
file — `artifacts/bindings.yaml`, `feature-model.yaml`, and
`variants/*.yaml` legitimately live there. Promoting every skip to an
error would break rivet's own `validate`. New `classify_skip`:

| Input | Verdict |
|---|---|
| not valid YAML | `ParseError` (F2a) |
| top-level `artifacts:` key (malformed list) | `ParseError` (F2a) |
| top-level `id` **and** `type` (artifact missing the `artifacts:` wrapper) | `ParseError` (F2a) |
| anything else | `NotArtifactFile` (F2b — silent skip) |

## Non-breaking plumbing

`load_artifacts`'s signature is unchanged (rivet-core has a semver
gate). New `load_artifacts_with_skips` returns `(Vec<Artifact>,
Vec<SkippedFile>)`. `cmd_validate` collects `ParseError` skips and
emits one `artifact-parse-error` Error diagnostic per skip — flowing
into `errors`, the text/JSON output, and the exit code. The validate
`--format json` diagnostic serializer also gained a `rule` field
(REQ-062's acceptance requires `rule` to be visible to a JSON
consumer).

## Test plan

- [x] `rivet-core`: `scan_skipped_files_classifies_malformed_vs_non_artifact`, `classify_skip_treats_corrupt_yaml_as_parse_error`
- [x] `rivet-cli`: `validate_surfaces_parse_error_on_malformed_artifact_file` — oracle-gated: one good + one malformed artifact file → exit non-zero, `result: FAIL`, `errors >= 1`, an `artifact-parse-error` diagnostic naming the file; plus an F2b assertion that `bindings.yaml` adds no error.
- [x] `test_dogfood_validate` — the F2b regression guard. rivet's own `bindings.yaml`/`feature-model.yaml`/`variants/*.yaml` must not error.
- [x] `stats_json_counts_match_validate` — still green.
- [x] `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` (exit 0).

## REQ-062 acceptance — met

Each criterion in `artifacts/cross-git-investigation.yaml` REQ-062's `Acceptance:` block is exercised by the integration test above.

Implements: REQ-004
Verifies: REQ-062
Refs: FEAT-135

🤖 Generated with [Claude Code](https://claude.com/claude-code)