### PR TITLE
docs+schema: external-anchor cited-source field + README link + MSRV fix (REQ-066/070)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ This is not an audit-after-the-fact tool. The point is that the agent
 *authors* against the typed schema while the oracle is firing — so the
 evidence is born compliant instead of being reverse-engineered later.
 
+> **Before you build Rivet into a process, read [What Rivet is
+> not](docs/rivet-is-not.md).** It enumerates — in the register of an
+> ISO 26262-10 SEooC Safety Manual — the boundaries of Rivet's
+> competence and the obligations that remain the integrator's, not the
+> tool's. It is shorter than this README; reading it first saves a
+> day's debugging.
+
 ## Install
 
 ```bash

--- a/docs/srs.md
+++ b/docs/srs.md
@@ -82,7 +82,7 @@ audit, deny, vet, coverage).
 
 [[REQ-009]] ties test results to GitHub releases as evidence artifacts.
 
-[[REQ-011]] pins Rust edition 2024 with MSRV 1.85.
+[[REQ-011]] pins Rust edition 2024 with MSRV 1.89.
 
 ### 3.7 V-Model Traceability Flow
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -134,7 +134,7 @@ a qualification gate:
 | `deny`         | `cargo deny`        | License violations, duplicate deps     |
 | `vet`          | `cargo vet`         | Supply chain verification              |
 | `coverage`     | `cargo llvm-cov`    | Code coverage metrics                  |
-| `msrv`         | MSRV 1.85 check     | Backward compatibility ([[REQ-011]])   |
+| `msrv`         | MSRV 1.89 check     | Backward compatibility ([[REQ-011]])   |
 
 ## 9. Requirement-to-Test Mapping
 

--- a/schemas/common.yaml
+++ b/schemas/common.yaml
@@ -353,6 +353,18 @@ artifact-types:
         description: >
           Optional contract / PO / DIA reference for traceability into
           the legal artefact (ISO 26262-8 §5 DIA, ASPICE SUP.10).
+      - name: cited-source
+        type: mapping
+        required: false
+        description: >
+          Optional sha256-stamped reference to the upstream document this
+          anchor delegates to. The mapping carries `uri`, `kind` (file |
+          reqif | url | github | oslc | polarion), `sha256`, and
+          `last-checked`. `rivet supplier pull` fetches it into the
+          local supplier cache; `rivet validate` checks drift. Declared
+          here so the field that makes `external-anchor` functional for
+          federation is no longer an undefined-field INFO at validate
+          time (REQ-066). See `rivet docs schema-cited-sources`.
     link-fields: []
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wave 1 / PR-B of the cross-git investigation follow-ups (FEAT-135).
Three small, low-risk fixes bundled — no code changes.

- **REQ-066** — `external-anchor` schema declares `cited-source`. The
  artifact type built for federation didn't declare the field that
  makes it functional, so every `external-anchor` with a
  `cited-source` emitted a spurious `field 'cited-source' is not
  defined` INFO. One field added to `schemas/common.yaml`.
- **REQ-070** — README links `docs/rivet-is-not.md` above the first
  user-action heading (`## Install`), per the First-Time User
  persona's "put it in the README, not three clicks deep."
- **MSRV doc fix** (from `DOC-DOCS-AUDIT-2026-05-19`) — `srs.md` and
  `verification.md` said MSRV 1.85; `Cargo.toml` pins 1.89.

## Test plan

- [x] An `external-anchor` carrying a `cited-source` no longer emits the undefined-field INFO at `rivet validate`.
- [x] `rivet docs check` — PASS (57 files, 0 violations).
- [x] Binary rebuilds clean with the schema change.

Implements: REQ-010
Verifies: REQ-066
Refs: FEAT-135, REQ-070

🤖 Generated with [Claude Code](https://claude.com/claude-code)