### PR TITLE
Wave 2: five P1 cross-git fixes (REQ-063/064/068/075/076)

### DIFF
--- a/artifacts/v042-artifacts.yaml
+++ b/artifacts/v042-artifacts.yaml
@@ -390,7 +390,7 @@ artifacts:
       timestamp: 2026-04-22T20:25:20Z
   # ── Requirements ────────────────────────────────────────────────────
 
-  - id: REQ-060
+  - id: REQ-077
     type: requirement
     title: Every embed option must validate before the embed renders
     status: approved

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -353,6 +353,15 @@ enum Command {
         /// were skipped.
         #[arg(long = "check-remote-sources")]
         check_remote_sources: bool,
+
+        /// Promote `orphan-artifact` warnings (an artifact with no
+        /// inbound and no outbound links, disconnected from the
+        /// traceability graph) to errors. Orphans are reported as
+        /// Warnings by default; use this in CI to enforce "every
+        /// artifact must be linked into the graph". Mirrors
+        /// `--strict-cited-sources`.
+        #[arg(long = "strict-orphans")]
+        strict_orphans: bool,
     },
 
     /// Show a single artifact by ID
@@ -1863,6 +1872,7 @@ fn run(cli: Cli) -> Result<bool> {
             strict_cited_sources,
             strict_cited_source_stale,
             check_remote_sources,
+            strict_orphans,
         } => cmd_validate(
             &cli,
             format,
@@ -1878,6 +1888,7 @@ fn run(cli: Cli) -> Result<bool> {
             *strict_cited_sources,
             *strict_cited_source_stale,
             *check_remote_sources,
+            *strict_orphans,
         ),
         Command::List {
             r#type,
@@ -4541,6 +4552,7 @@ fn cmd_validate(
     strict_cited_sources: bool,
     strict_cited_source_stale: bool,
     check_remote_sources: bool,
+    strict_orphans: bool,
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let fail_on_threshold = parse_fail_on(fail_on)?;
@@ -4566,15 +4578,24 @@ fn cmd_validate(
     //   * NotArtifactFile  — legitimate non-artifact YAML living under the
     //                        source path, e.g. `bindings.yaml` (F2b)
     //                        -> silently skipped, no diagnostic.
+    //
+    // REQ-075: the same load-report channel additionally detects two
+    // artifacts that declare the same `id`. `Store::upsert` is keyed by ID
+    // and last-write-wins, so by the time `validate::validate` runs only
+    // the survivor exists. Duplicate IDs are gathered here, at load time,
+    // across every source — a collision can straddle two source paths —
+    // and emitted as `duplicate-artifact-id` Error diagnostics below.
     let mut parse_error_skips: Vec<rivet_core::SkippedFile> = Vec::new();
+    let mut loaded_for_dup_check: Vec<rivet_core::model::Artifact> = Vec::new();
     for source in &config.sources {
-        match rivet_core::load_artifacts_with_skips(source, &cli.project, &schema) {
-            Ok((_artifacts, skips)) => {
-                for skip in skips {
+        match rivet_core::load_artifacts_with_report(source, &cli.project, &schema) {
+            Ok(report) => {
+                for skip in report.skipped {
                     if skip.kind == rivet_core::SkipKind::ParseError {
                         parse_error_skips.push(skip);
                     }
                 }
+                loaded_for_dup_check.extend(report.artifacts);
             }
             Err(e) => {
                 // A hard load error here is already surfaced by
@@ -4583,6 +4604,10 @@ fn cmd_validate(
             }
         }
     }
+    // Detect duplicate IDs across the union of all sources. The per-source
+    // reports above only see one source each; a project-wide pass catches
+    // an ID claimed in source A and again in source B.
+    let duplicate_ids = rivet_core::detect_duplicate_ids_for_validate(&loaded_for_dup_check);
 
     // Apply baseline scoping if requested
     let (store, graph) = if let Some(bl) = baseline_name {
@@ -4853,6 +4878,65 @@ fn cmd_validate(
             ),
         );
         diag.source_file = Some(skip.path.clone());
+        diagnostics.push(diag);
+    }
+
+    // REQ-075 / F2: two artifacts declaring the same `id` collapse
+    // silently — `Store::upsert` is last-write-wins, so `validate` only
+    // ever sees the survivor. Detection happened at load time above; emit
+    // one Error diagnostic per collision naming both source files and the
+    // colliding ID.
+    for dup in &duplicate_ids {
+        let first = dup
+            .first_file
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "<unknown source>".to_string());
+        let second = dup
+            .second_file
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "<unknown source>".to_string());
+        let mut diag = validate::Diagnostic::new(
+            Severity::Error,
+            Some(dup.id.clone()),
+            "duplicate-artifact-id",
+            format!(
+                "artifact id '{}' is declared more than once: {} and {} \
+                 — the second definition silently overwrites the first",
+                dup.id, first, second
+            ),
+        );
+        diag.source_file = dup.second_file.clone();
+        diagnostics.push(diag);
+    }
+
+    // REQ-076: surface orphan artifacts (no inbound and no outbound links,
+    // disconnected from the traceability graph) through the `validate`
+    // diagnostic channel. This reuses `LinkGraph::orphans` — the exact
+    // computation behind `rivet stats`'s "Orphan artifacts (no links): N".
+    //
+    // Severity is Warning by default and Error under `--strict-orphans`,
+    // mirroring the `cited-source-drift` / `--strict-cited-sources`
+    // pattern. Warning-by-default is required: the rivet repo itself
+    // carries orphans, so a hard-error default would break its own
+    // dogfood `validate` (REQ-062's F2b lesson applied to severity).
+    let orphan_severity = if strict_orphans {
+        Severity::Error
+    } else {
+        Severity::Warning
+    };
+    for orphan_id in graph.orphans(&store) {
+        let mut diag = validate::Diagnostic::new(
+            orphan_severity,
+            Some(orphan_id.clone()),
+            "orphan-artifact",
+            format!(
+                "artifact '{orphan_id}' is an orphan: it has no inbound or \
+                 outbound links and is disconnected from the traceability graph"
+            ),
+        );
+        diag.source_file = store.get(orphan_id).and_then(|a| a.source_file.clone());
         diagnostics.push(diag);
     }
 
@@ -5618,8 +5702,46 @@ fn cmd_stats(
     // counts line up with the visible artifact set when --filter or
     // --baseline is in effect. Externals-aware so the numbers match the
     // post-#245 `rivet validate` output.
-    let diagnostics =
+    let mut diagnostics =
         validate::validate_with_externals(&store, &ctx.schema, &graph, &ctx.external_schemas);
+    // REQ-076: `rivet validate` emits one `orphan-artifact` Warning per
+    // orphan. Mirror that here so the `warnings` count stays consistent
+    // with `rivet validate` (see `stats_json_counts_match_validate`).
+    // `--strict-orphans` is a `validate`-only flag, so stats always uses
+    // the default Warning severity.
+    for orphan_id in &stats.orphans {
+        diagnostics.push(validate::Diagnostic::new(
+            Severity::Warning,
+            Some(orphan_id.clone()),
+            "orphan-artifact",
+            format!(
+                "artifact '{orphan_id}' is an orphan: it has no inbound or \
+                 outbound links and is disconnected from the traceability graph"
+            ),
+        ));
+    }
+    // REQ-075: `rivet validate` emits one `duplicate-artifact-id` Error
+    // per ID claimed by more than one artifact. Re-load every source and
+    // run the same load-time duplicate scan so the `errors` count stays
+    // consistent with `rivet validate` (see `stats_json_counts_match_validate`).
+    {
+        let mut loaded: Vec<rivet_core::model::Artifact> = Vec::new();
+        for source in &ctx.config.sources {
+            if let Ok(report) =
+                rivet_core::load_artifacts_with_report(source, &cli.project, &ctx.schema)
+            {
+                loaded.extend(report.artifacts);
+            }
+        }
+        for dup in rivet_core::detect_duplicate_ids_for_validate(&loaded) {
+            diagnostics.push(validate::Diagnostic::new(
+                Severity::Error,
+                Some(dup.id.clone()),
+                "duplicate-artifact-id",
+                format!("artifact id '{}' is declared more than once", dup.id),
+            ));
+        }
+    }
     let errors = diagnostics
         .iter()
         .filter(|d| d.severity == Severity::Error)
@@ -8092,6 +8214,7 @@ fn cmd_diff(
                     strict_cited_sources: false,
                     strict_cited_source_stale: false,
                     check_remote_sources: false,
+                    strict_orphans: false,
                 },
             };
             let head_cli = Cli {
@@ -8113,6 +8236,7 @@ fn cmd_diff(
                     strict_cited_sources: false,
                     strict_cited_source_stale: false,
                     check_remote_sources: false,
+                    strict_orphans: false,
                 },
             };
             let bc = ProjectContext::load(&base_cli)?;

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1283,6 +1283,15 @@ enum SupplierAction {
         /// Output format: "text" (default) or "json".
         #[arg(short, long, default_value = "text")]
         format: String,
+        /// Accept supplier byte drift: when the new payload's sha256
+        /// contradicts the hash recorded on a prior pull (cache
+        /// manifest) or the anchor's stamped `cited-source.sha256`,
+        /// `pull` normally refuses. With `--accept-drift` the auditor
+        /// explicitly authorizes the new bytes — the cache is
+        /// overwritten and the anchor's `cited-source` stamp +
+        /// `last-synced` are refreshed. REQ-068.
+        #[arg(long)]
+        accept_drift: bool,
     },
 }
 
@@ -2014,7 +2023,11 @@ fn run(cli: Cli) -> Result<bool> {
         Command::Supplier { action } => match action {
             SupplierAction::List { format } => cmd_supplier_list(&cli, format),
             SupplierAction::Check { format } => cmd_supplier_check(&cli, format),
-            SupplierAction::Pull { anchor, format } => cmd_supplier_pull(&cli, anchor, format),
+            SupplierAction::Pull {
+                anchor,
+                format,
+                accept_drift,
+            } => cmd_supplier_pull(&cli, anchor, format, *accept_drift),
         },
         Command::Baseline { action } => match action {
             BaselineAction::Verify { name, strict } => cmd_baseline_verify(&cli, name, *strict),
@@ -6174,7 +6187,16 @@ fn cmd_supplier_check(cli: &Cli, format: &str) -> Result<bool> {
 /// the [`FederationProvenance`] block is written alongside so the
 /// auditor can reconstruct the source. Read-only on the supplier
 /// side; idempotent on the cache side.
-fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str) -> Result<bool> {
+///
+/// REQ-068: `pull` is the *authorisation* point for supplier bytes.
+/// When the new payload's sha256 contradicts a previously recorded
+/// hash — either the anchor's stamped `cited-source.sha256` or the
+/// `source-hash` from a prior cache manifest — the pull refuses
+/// (exit non-zero) and names both hashes plus the supplier identity.
+/// The auditor authorises the new bytes with `--accept-drift`, which
+/// overwrites the cache and refreshes the stamp + `last-synced`. A
+/// first pull (no prior stamp, no prior manifest) is unaffected.
+fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str, accept_drift: bool) -> Result<bool> {
     use rivet_core::cited_source as cs;
     use rivet_core::model::FederationProvenance;
 
@@ -6194,6 +6216,9 @@ fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str) -> Result<bool> {
             anchor.artifact_type
         );
     }
+    // The anchor's source YAML — needed to re-stamp `cited-source`
+    // (sha256 + last-checked) when an auditor accepts a byte drift.
+    let anchor_source_file = anchor.source_file.clone();
 
     // Read `cited-source` — required for a pull.
     let cited_raw = anchor.fields.get("cited-source").ok_or_else(|| {
@@ -6223,10 +6248,9 @@ fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str) -> Result<bool> {
         _ => cs::resolve_file_uri(&cited.uri, &project_root),
     };
 
-    // Read the bytes once; compute hash; cross-check stamped sha256
-    // if present. We refuse to write a cache entry whose stamped
-    // hash doesn't match the wire payload (auditor-grade: a drift
-    // would silently let the cache lie about what was delivered).
+    // Read the bytes once; compute the wire hash. Drift detection
+    // (REQ-068) happens below, once the prior recorded hash and the
+    // supplier identity are known so the error can name both.
     let bytes = std::fs::read(&source_path).with_context(|| {
         format!(
             "reading source for '{anchor_id}': {}",
@@ -6234,16 +6258,6 @@ fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str) -> Result<bool> {
         )
     })?;
     let source_hash = cs::sha256_hex(&bytes);
-    if let Some(stamped) = &cited.sha256 {
-        if !stamped.eq_ignore_ascii_case(&source_hash) {
-            anyhow::bail!(
-                "anchor '{anchor_id}' cited-source sha256 drift: \
-                 stamped {stamped} but file hashes to {source_hash}. \
-                 Refusing to write a poisoned cache entry. Re-stamp the \
-                 anchor and retry."
-            );
-        }
-    }
     // For ReqIF, also verify well-formedness — caches a bad payload otherwise.
     if matches!(cited.kind, cs::CitedSourceKind::Reqif) {
         rivet_core::reqif::parse_reqif(
@@ -6297,6 +6311,57 @@ fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str) -> Result<bool> {
     let payload_path = cache_root.join(&payload_name);
     let manifest_path = cache_root.join(format!("{anchor_id}.manifest.yaml"));
 
+    // ── REQ-068: drift detection ─────────────────────────────────────
+    // `pull` is the authorisation point for supplier bytes. Establish
+    // the prior recorded hash from the strongest available record:
+    //   1. The prior cache manifest's `federation.source-hash` — the
+    //      authoritative record of what was last pulled into the cache.
+    //   2. The anchor's stamped `cited-source.sha256` — the fallback
+    //      when no manifest exists yet (e.g. a hand-stamped anchor).
+    // If a prior hash exists and contradicts the new wire hash, the
+    // supplier has changed bytes since the last pull. Refuse unless
+    // `--accept-drift` explicitly authorises the new revision.
+    let prior_manifest_hash: Option<String> = std::fs::read_to_string(&manifest_path)
+        .ok()
+        .and_then(|m| serde_yaml::from_str::<serde_yaml::Value>(&m).ok())
+        .and_then(|v| {
+            v.get("federation")
+                .and_then(|f| f.get("source-hash"))
+                .and_then(|h| h.as_str())
+                .map(str::to_string)
+        });
+    let prior_recorded_hash: Option<(&str, String)> = prior_manifest_hash
+        .as_deref()
+        .map(|h| ("prior cache manifest", h.to_string()))
+        .or_else(|| {
+            cited
+                .sha256
+                .as_deref()
+                .map(|h| ("anchor cited-source.sha256", h.to_string()))
+        });
+    let drift_detected = prior_recorded_hash
+        .as_ref()
+        .is_some_and(|(_, prior)| !prior.eq_ignore_ascii_case(&source_hash));
+    if drift_detected && !accept_drift {
+        let (prior_src, prior_hash) = prior_recorded_hash.as_ref().unwrap();
+        anyhow::bail!(
+            "DRIFT: supplier bytes for anchor '{anchor_id}' changed since the last pull.\n  \
+             supplier:   {org} / {contract}\n  \
+             prior sha256 ({prior_src}): {prior_hash}\n  \
+             new sha256 (wire payload):   {source_hash}\n  \
+             source: {source}\n\
+             Refusing to overwrite the supplier cache. A `pull` that silently \
+             accepted these bytes would grant the supplier authority to revise \
+             the delivered artifact with no audit trail. If this revision is \
+             intentional, an auditor must re-run with `--accept-drift` to \
+             authorise it explicitly.",
+            source = source_path.display(),
+        );
+    }
+    // `accept_drift_applied` is true only when an auditor authorised an
+    // actual byte change — used to refresh the anchor stamp + last-synced.
+    let accept_drift_applied = drift_detected && accept_drift;
+
     // Idempotency: if the existing payload already has the same hash,
     // we still refresh the manifest's `fetched-at` so re-runs leave a
     // trail in the file mtime but don't churn the bytes.
@@ -6347,6 +6412,29 @@ fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str) -> Result<bool> {
     std::fs::write(&manifest_path, manifest)
         .with_context(|| format!("writing manifest: {}", manifest_path.display()))?;
 
+    // REQ-068: when an auditor accepted a byte drift, re-stamp the
+    // anchor so the source-of-record reflects the authorised revision.
+    // This refreshes `cited-source.sha256` to the new hash and
+    // `cited-source.last-checked` (the anchor's `last-synced` mark) to
+    // the fetch time — equivalent to a manual re-stamp.
+    let mut anchor_restamped = false;
+    if accept_drift_applied {
+        let target = anchor_source_file.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "anchor '{anchor_id}' has no known source file — cannot \
+                 re-stamp after --accept-drift"
+            )
+        })?;
+        anchor_restamped =
+            cs::update_cited_source_in_file(&target, anchor_id, &source_hash, &fetched_at)
+                .with_context(|| {
+                    format!(
+                        "re-stamping anchor '{anchor_id}' cited-source in {}",
+                        target.display()
+                    )
+                })?;
+    }
+
     if format == "json" {
         let output = serde_json::json!({
             "command": "supplier pull",
@@ -6360,6 +6448,8 @@ fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str) -> Result<bool> {
             "cache_payload": payload_path.display().to_string(),
             "cache_manifest": manifest_path.display().to_string(),
             "bytes_unchanged": bytes_unchanged,
+            "drift_accepted": accept_drift_applied,
+            "anchor_restamped": anchor_restamped,
         });
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
     } else {
@@ -6372,6 +6462,12 @@ fn cmd_supplier_pull(cli: &Cli, anchor_id: &str, format: &str) -> Result<bool> {
         println!("  fetched-at:     {fetched_at}");
         if bytes_unchanged {
             println!("  (payload bytes unchanged — manifest refreshed only)");
+        }
+        if accept_drift_applied {
+            println!(
+                "  DRIFT ACCEPTED: supplier bytes changed; cache overwritten \
+                 and anchor cited-source re-stamped to {source_hash}."
+            );
         }
     }
     Ok(true)

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -4207,6 +4207,148 @@ fn supplier_pull_idempotent_on_re_run() {
     );
 }
 
+/// REQ-068 regression: `rivet supplier pull` is the authorisation
+/// point for supplier bytes. After a first pull stamps the cache with
+/// sha256 X, mutating the supplier file so it hashes to Y must make a
+/// flagless re-pull refuse — exit non-zero with an error naming both
+/// X and Y plus the supplier identity (org + contract), and leaving
+/// the cache untouched. Re-running with `--accept-drift` is the
+/// explicit auditor authorisation path: it exits 0 and overwrites the
+/// cache with the new bytes.
+///
+/// Verifies: REQ-068
+#[test]
+fn supplier_pull_refuses_on_sha256_drift_without_accept_flag() {
+    use sha2::{Digest, Sha256};
+
+    let payload_v1 = b"-- supplier payload v1 --";
+    let (tmp, payload_path) = supplier_pull_project_with_file(payload_v1, true);
+    let project = tmp.path().to_str().unwrap().to_string();
+
+    // First pull: establishes the cache + manifest stamped to hash X.
+    let first = Command::new(rivet_bin())
+        .args([
+            "--project",
+            &project,
+            "supplier",
+            "pull",
+            "ANCHOR-ACME-001",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("first pull");
+    assert!(
+        first.status.success(),
+        "first pull must succeed. stderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let cache = tmp
+        .path()
+        .join(".rivet")
+        .join("supplier-cache")
+        .join("acme-electronics")
+        .join("PO-4711");
+    let cached_payload = cache.join("ANCHOR-ACME-001.bin");
+    assert_eq!(
+        std::fs::read(&cached_payload).unwrap(),
+        payload_v1,
+        "first pull caches v1 bytes"
+    );
+
+    let mut h1 = Sha256::new();
+    h1.update(payload_v1);
+    let hash_x = format!("{:x}", h1.finalize());
+
+    // Mutate the supplier file so its bytes now hash to Y != X.
+    let payload_v2 = b"-- supplier payload v2 (revised by supplier) --";
+    std::fs::write(&payload_path, payload_v2).expect("mutate supplier file");
+    let mut h2 = Sha256::new();
+    h2.update(payload_v2);
+    let hash_y = format!("{:x}", h2.finalize());
+    assert_ne!(hash_x, hash_y, "sanity: the mutation must change the hash");
+
+    // Flagless re-pull: must refuse and name both hashes + identity.
+    let drift = Command::new(rivet_bin())
+        .args(["--project", &project, "supplier", "pull", "ANCHOR-ACME-001"])
+        .output()
+        .expect("drift pull");
+    assert!(
+        !drift.status.success(),
+        "pull on sha256 drift must exit non-zero without --accept-drift"
+    );
+    let stderr = String::from_utf8_lossy(&drift.stderr);
+    assert!(
+        stderr.contains(&hash_x),
+        "drift error must name the prior sha256 X ({hash_x}), got: {stderr}"
+    );
+    assert!(
+        stderr.contains(&hash_y),
+        "drift error must name the new sha256 Y ({hash_y}), got: {stderr}"
+    );
+    assert!(
+        stderr.contains("acme-electronics") && stderr.contains("PO-4711"),
+        "drift error must name the supplier identity (org + contract), got: {stderr}"
+    );
+    // The refusal must NOT overwrite the cache.
+    assert_eq!(
+        std::fs::read(&cached_payload).unwrap(),
+        payload_v1,
+        "a refused drift pull must leave the cache untouched"
+    );
+
+    // `--accept-drift`: explicit auditor authorisation → exit 0,
+    // cache overwritten with the new bytes.
+    let accepted = Command::new(rivet_bin())
+        .args([
+            "--project",
+            &project,
+            "supplier",
+            "pull",
+            "ANCHOR-ACME-001",
+            "--accept-drift",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("accept-drift pull");
+    assert!(
+        accepted.status.success(),
+        "pull --accept-drift must exit 0. stderr: {}",
+        String::from_utf8_lossy(&accepted.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_slice(&accepted.stdout).expect("valid json on accept-drift pull");
+    assert_eq!(v["drift_accepted"], serde_json::Value::Bool(true));
+    assert_eq!(v["source_hash"], hash_y);
+    assert_eq!(
+        std::fs::read(&cached_payload).unwrap(),
+        payload_v2,
+        "accept-drift pull must overwrite the cache with the new bytes"
+    );
+
+    // The anchor must be re-stamped to Y so a subsequent re-pull of
+    // the SAME bytes is idempotent (not a fresh drift).
+    let re_pull = Command::new(rivet_bin())
+        .args([
+            "--project",
+            &project,
+            "supplier",
+            "pull",
+            "ANCHOR-ACME-001",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("idempotent re-pull after accept-drift");
+    assert!(
+        re_pull.status.success(),
+        "re-pull of identical accepted bytes must exit 0. stderr: {}",
+        String::from_utf8_lossy(&re_pull.stderr)
+    );
+}
+
 /// `kind: reqif` end-to-end: minimal well-formed ReqIF in the
 /// project, anchored cited-source, hash agrees → cache layout
 /// shows `.reqif` extension and `source-tool: reqif-1.2`.

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -634,6 +634,253 @@ fn validate_accepts_derives_from_external_structured_target() {
     );
 }
 
+/// REQ-075 / F2: two artifacts that declare the same `id` collapse
+/// silently — `Store::upsert` is last-write-wins, so by the time
+/// `validate::validate` runs only one survives and the validator is
+/// structurally blind to the collision. `rivet validate` must detect the
+/// duplicate at LOAD time and emit a `duplicate-artifact-id` Error
+/// diagnostic naming both source files. Verified for both the two-files
+/// case and the twice-in-one-file case.
+///
+/// rivet: verifies REQ-075
+#[test]
+fn validate_detects_duplicate_artifact_ids() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dir.to_str().unwrap()])
+        .output()
+        .expect("failed to execute rivet init");
+    assert!(
+        init.status.success(),
+        "rivet init must exit 0. stderr: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // Two artifact files that both declare `id: REQ-DUP`. `upsert` keeps
+    // only one; the load-time duplicate check must still see both.
+    std::fs::write(
+        dir.join("artifacts").join("file-a.yaml"),
+        "artifacts:\n  - id: REQ-DUP\n    type: requirement\n    \
+         title: First definition\n    status: draft\n    \
+         fields:\n      priority: must\n      category: functional\n",
+    )
+    .expect("write file-a.yaml");
+    std::fs::write(
+        dir.join("artifacts").join("file-b.yaml"),
+        "artifacts:\n  - id: REQ-DUP\n    type: requirement\n    \
+         title: Second definition\n    status: draft\n    \
+         fields:\n      priority: must\n      category: functional\n",
+    )
+    .expect("write file-b.yaml");
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute rivet validate");
+
+    assert!(
+        !out.status.success(),
+        "validate must exit non-zero when an artifact id is duplicated"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("validate JSON must be valid");
+    assert_eq!(
+        parsed.get("result").and_then(|v| v.as_str()),
+        Some("FAIL"),
+        "result must be FAIL; got: {parsed}"
+    );
+    assert!(
+        parsed.get("errors").and_then(|v| v.as_u64()).unwrap_or(0) >= 1,
+        "errors must be >= 1; got: {parsed}"
+    );
+    let diags = parsed
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics array");
+    let dup = diags
+        .iter()
+        .find(|d| d.get("rule").and_then(|r| r.as_str()) == Some("duplicate-artifact-id"))
+        .unwrap_or_else(|| {
+            panic!("expected a diagnostic with rule 'duplicate-artifact-id'; got: {parsed}")
+        });
+    let msg = dup
+        .get("message")
+        .and_then(|m| m.as_str())
+        .expect("duplicate diagnostic must have a message");
+    assert!(
+        msg.contains("REQ-DUP"),
+        "the duplicate-artifact-id message must name the colliding id; got: {msg}"
+    );
+    assert!(
+        msg.contains("file-a.yaml") && msg.contains("file-b.yaml"),
+        "the duplicate-artifact-id message must name both source files; got: {msg}"
+    );
+
+    // The same ID twice within a SINGLE file's `artifacts:` list.
+    let tmp2 = tempfile::tempdir().expect("create temp dir 2");
+    let dir2 = tmp2.path();
+    let init2 = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dir2.to_str().unwrap()])
+        .output()
+        .expect("failed to execute rivet init (2)");
+    assert!(init2.status.success(), "rivet init (2) must exit 0");
+    std::fs::write(
+        dir2.join("artifacts").join("requirements.yaml"),
+        "artifacts:\n  - id: REQ-DUP\n    type: requirement\n    \
+         title: First\n    status: draft\n    \
+         fields:\n      priority: must\n      category: functional\n  \
+         - id: REQ-DUP\n    type: requirement\n    \
+         title: Second\n    status: draft\n    \
+         fields:\n      priority: must\n      category: functional\n",
+    )
+    .expect("write requirements.yaml with duplicate");
+
+    let out2 = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir2.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute rivet validate (2)");
+    assert!(
+        !out2.status.success(),
+        "validate must exit non-zero for two same-id entries in one file"
+    );
+    let parsed2: serde_json::Value =
+        serde_json::from_slice(&out2.stdout).expect("validate JSON (2) must be valid");
+    let diags2 = parsed2
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics array (2)");
+    assert!(
+        diags2
+            .iter()
+            .any(|d| d.get("rule").and_then(|r| r.as_str()) == Some("duplicate-artifact-id")),
+        "two same-id entries in one file must produce a duplicate-artifact-id diagnostic; \
+         got: {parsed2}"
+    );
+}
+
+/// REQ-076: an orphan artifact — no inbound and no outbound links,
+/// disconnected from the traceability graph — must be surfaced by
+/// `rivet validate` as an `orphan-artifact` diagnostic. Severity is
+/// Warning by default (so a project with orphans does not hard-fail),
+/// promotable to Error with `--strict-orphans`.
+///
+/// rivet: verifies REQ-076
+#[test]
+fn validate_reports_orphans_as_warnings() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dir.to_str().unwrap()])
+        .output()
+        .expect("failed to execute rivet init");
+    assert!(
+        init.status.success(),
+        "rivet init must exit 0. stderr: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // Replace the seeded artifacts with a single requirement that has no
+    // links of any kind — a textbook orphan.
+    std::fs::write(
+        dir.join("artifacts").join("requirements.yaml"),
+        "artifacts:\n  - id: REQ-ORPHAN\n    type: requirement\n    \
+         title: Disconnected requirement\n    status: draft\n    \
+         fields:\n      priority: must\n      category: functional\n",
+    )
+    .expect("write requirements.yaml");
+
+    // Default run: orphan surfaces as a Warning; the run still exits 0
+    // (orphans must not hard-fail by default).
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute rivet validate");
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("validate JSON must be valid");
+    let diags = parsed
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics array");
+    let orphan = diags
+        .iter()
+        .find(|d| {
+            d.get("rule").and_then(|r| r.as_str()) == Some("orphan-artifact")
+                && d.get("artifact_id").and_then(|a| a.as_str()) == Some("REQ-ORPHAN")
+        })
+        .unwrap_or_else(|| {
+            panic!("expected an orphan-artifact diagnostic for REQ-ORPHAN; got: {parsed}")
+        });
+    assert_eq!(
+        orphan.get("severity").and_then(|s| s.as_str()),
+        Some("warning"),
+        "orphan-artifact must default to severity 'warning'; got: {orphan}"
+    );
+
+    // `--strict-orphans` promotes the same diagnostic to Error and the
+    // run exits non-zero.
+    let strict = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+            "--strict-orphans",
+        ])
+        .output()
+        .expect("failed to execute rivet validate --strict-orphans");
+    assert!(
+        !strict.status.success(),
+        "validate --strict-orphans must exit non-zero when an orphan exists"
+    );
+    let parsed_strict: serde_json::Value =
+        serde_json::from_slice(&strict.stdout).expect("strict validate JSON must be valid");
+    assert_eq!(
+        parsed_strict.get("result").and_then(|v| v.as_str()),
+        Some("FAIL"),
+        "result must be FAIL under --strict-orphans; got: {parsed_strict}"
+    );
+    let strict_orphan = parsed_strict
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("strict diagnostics array")
+        .iter()
+        .find(|d| {
+            d.get("rule").and_then(|r| r.as_str()) == Some("orphan-artifact")
+                && d.get("artifact_id").and_then(|a| a.as_str()) == Some("REQ-ORPHAN")
+        })
+        .unwrap_or_else(|| {
+            panic!("expected an orphan-artifact diagnostic under --strict-orphans; got: {parsed_strict}")
+        });
+    assert_eq!(
+        strict_orphan.get("severity").and_then(|s| s.as_str()),
+        Some("error"),
+        "orphan-artifact must be severity 'error' under --strict-orphans; got: {strict_orphan}"
+    );
+}
+
+
 // ── rivet stats ─────────────────────────────────────────────────────────
 
 /// `rivet stats --format json` produces valid JSON with total count.

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -348,6 +348,71 @@ fn init_dev_preset() {
     );
 }
 
+/// Regression test for REQ-063: the four safety-critical industry-standard
+/// presets (`do-178c`, `en-50128`, `iec-61508`, `iec-62304`) must produce
+/// projects that `rivet validate` accepts.
+///
+/// Before the fix, `rivet init --preset iec-61508` exited 0 and wrote a
+/// `rivet.yaml` naming a schema that was neither embedded in the binary nor
+/// written to disk; the next `rivet validate` failed with
+/// `Schema error: schema '<name>' not found on disk or as embedded schema`.
+/// The fix embeds the four schemas in the binary alongside the working five.
+///
+/// This test is itself a mechanical oracle: it drives the real `rivet`
+/// binary end-to-end (`init` then `validate`) and asserts both exit 0,
+/// mirroring the `init_stpa_preset` pattern.
+#[test]
+fn init_safety_critical_presets_produce_validating_projects() {
+    for preset in ["do-178c", "en-50128", "iec-61508", "iec-62304"] {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let dir = tmp.path();
+
+        // init must exit 0
+        let init_out = Command::new(rivet_bin())
+            .args(["init", "--preset", preset, "--dir", dir.to_str().unwrap()])
+            .output()
+            .expect("failed to execute rivet init");
+        assert!(
+            init_out.status.success(),
+            "rivet init --preset {preset} must exit 0. stderr:\n{}",
+            String::from_utf8_lossy(&init_out.stderr)
+        );
+
+        // rivet.yaml must reference the preset's schema
+        let config_path = dir.join("rivet.yaml");
+        assert!(
+            config_path.exists(),
+            "rivet.yaml must be created for {preset}"
+        );
+
+        // validate the freshly-initialized project — must exit 0 with no errors
+        let validate_out = Command::new(rivet_bin())
+            .args([
+                "--project",
+                dir.to_str().unwrap(),
+                "validate",
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("failed to execute rivet validate");
+        assert!(
+            validate_out.status.success(),
+            "rivet validate must exit 0 for preset {preset}. stderr:\n{}",
+            String::from_utf8_lossy(&validate_out.stderr)
+        );
+
+        let stdout = String::from_utf8_lossy(&validate_out.stdout);
+        let parsed: serde_json::Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("validate JSON must be valid for {preset}: {e}"));
+        let errors = parsed.get("errors").and_then(|v| v.as_u64()).unwrap_or(999);
+        assert_eq!(
+            errors, 0,
+            "freshly-initialized {preset} project must have 0 validation errors, got {errors}"
+        );
+    }
+}
+
 // ── rivet validate ──────────────────────────────────────────────────────
 
 /// `rivet validate --format json` produces valid JSON with "command":"validate".

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -880,7 +880,6 @@ fn validate_reports_orphans_as_warnings() {
     );
 }
 
-
 // ── rivet stats ─────────────────────────────────────────────────────────
 
 /// `rivet stats --format json` produces valid JSON with total count.

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -560,6 +560,80 @@ fn validate_surfaces_parse_error_on_malformed_artifact_file() {
     );
 }
 
+/// REQ-064: a `derives-from-external` link (the cross-org variant of
+/// `derives-from`, terminating at an `external-anchor`) must satisfy a
+/// required `derives-from` link-field. Before the fix the cardinality
+/// check counted only exact `derives-from` links, so a sw-req that
+/// derived from an external anchor failed with a spurious
+/// `link 'derives-from' requires at least 1 target, found 0` Error.
+///
+/// rivet: verifies REQ-064
+#[test]
+fn validate_accepts_derives_from_external_structured_target() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "aspice", "--dir", dir.to_str().unwrap()])
+        .output()
+        .expect("rivet init");
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    std::fs::write(
+        dir.join("artifacts").join("ext.yaml"),
+        "artifacts:\n\
+         \x20 - id: ANCHOR-X\n\
+         \x20   type: external-anchor\n\
+         \x20   title: ACME anchor\n\
+         \x20   status: approved\n\
+         \x20   fields:\n\
+         \x20     source-of-truth: {org: acme, contract: PO-1, doc-id: D-1}\n\
+         \x20     expected-derived-types: [sw-req]\n\
+         \x20     received-status: received-other\n\
+         \x20 - id: SWREQ-X\n\
+         \x20   type: sw-req\n\
+         \x20   title: Derives from an external anchor\n\
+         \x20   status: draft\n\
+         \x20   fields: {req-type: functional, priority: must}\n\
+         \x20   links:\n\
+         \x20     - type: derives-from-external\n\
+         \x20       target: {org: acme, contract: PO-1, doc-id: D-1, anchor: ANCHOR-X}\n",
+    )
+    .expect("write ext.yaml");
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("rivet validate");
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("validate JSON must be valid");
+    let diags = parsed
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics array");
+    let spurious = diags.iter().any(|d| {
+        d.get("artifact_id").and_then(|a| a.as_str()) == Some("SWREQ-X")
+            && d.get("rule").and_then(|r| r.as_str()) == Some("cardinality")
+            && d.get("message")
+                .and_then(|m| m.as_str())
+                .is_some_and(|m| m.contains("requires at least 1 target"))
+    });
+    assert!(
+        !spurious,
+        "a derives-from-external link must satisfy the derives-from \
+         link-field cardinality; got: {parsed}"
+    );
+}
+
 // ── rivet stats ─────────────────────────────────────────────────────────
 
 /// `rivet stats --format json` produces valid JSON with total count.

--- a/rivet-core/src/embedded.rs
+++ b/rivet-core/src/embedded.rs
@@ -32,6 +32,10 @@ pub const SCHEMA_ISO_PAS_8800: &str = include_str!("../../schemas/iso-pas-8800.y
 pub const SCHEMA_SOTIF: &str = include_str!("../../schemas/sotif.yaml");
 pub const SCHEMA_SUPPLY_CHAIN: &str = include_str!("../../schemas/supply-chain.yaml");
 pub const SCHEMA_VV_COVERAGE: &str = include_str!("../../schemas/vv-coverage.yaml");
+pub const SCHEMA_DO_178C: &str = include_str!("../../schemas/do-178c.yaml");
+pub const SCHEMA_EN_50128: &str = include_str!("../../schemas/en-50128.yaml");
+pub const SCHEMA_IEC_61508: &str = include_str!("../../schemas/iec-61508.yaml");
+pub const SCHEMA_IEC_62304: &str = include_str!("../../schemas/iec-62304.yaml");
 
 // ── Embedded migration recipes ──────────────────────────────────────────
 
@@ -81,6 +85,10 @@ pub const SCHEMA_NAMES: &[&str] = &[
     "sotif",
     "supply-chain",
     "vv-coverage",
+    "do-178c",
+    "en-50128",
+    "iec-61508",
+    "iec-62304",
 ];
 
 /// Metadata for a built-in bridge schema.
@@ -152,6 +160,10 @@ pub fn embedded_schema(name: &str) -> Option<&'static str> {
         "sotif" => Some(SCHEMA_SOTIF),
         "supply-chain" => Some(SCHEMA_SUPPLY_CHAIN),
         "vv-coverage" => Some(SCHEMA_VV_COVERAGE),
+        "do-178c" => Some(SCHEMA_DO_178C),
+        "en-50128" => Some(SCHEMA_EN_50128),
+        "iec-61508" => Some(SCHEMA_IEC_61508),
+        "iec-62304" => Some(SCHEMA_IEC_62304),
         _ => None,
     }
 }

--- a/rivet-core/src/lib.rs
+++ b/rivet-core/src/lib.rs
@@ -276,6 +276,46 @@ pub fn load_artifacts(
     }
 }
 
+/// A second artifact in a load that claims an `id` already taken by an
+/// artifact loaded earlier from the same project.
+///
+/// `Store::upsert` is keyed by ID and last-write-wins, so two artifacts
+/// declaring the same `id` collapse silently — by the time
+/// `validate::validate` runs only the survivor exists, and the validator
+/// is structurally blind to the collision (REQ-075, F2 family). This type
+/// captures the collision at LOAD time, where both copies are still
+/// visible, so callers (notably `rivet validate`) can surface it as an
+/// Error diagnostic naming both files.
+///
+/// Cross-repo `prefix:ID` references are namespaced and loaded through a
+/// separate path; they never appear here. Only two *local* artifacts
+/// colliding produce a `DuplicateId`.
+#[derive(Debug, Clone)]
+pub struct DuplicateId {
+    /// The artifact ID claimed by two artifacts.
+    pub id: String,
+    /// Source file of the artifact that claimed the ID first (the one
+    /// that would be overwritten by `upsert`).
+    pub first_file: Option<PathBuf>,
+    /// Source file of the later artifact that collided. When two
+    /// artifacts in a single file share an ID this equals `first_file`.
+    pub second_file: Option<PathBuf>,
+}
+
+/// The full result of loading one or more sources: the loaded artifacts
+/// plus the load-time anomalies that `load_artifacts` alone would discard
+/// — files skipped during a directory import ([`SkippedFile`], REQ-062)
+/// and duplicate artifact IDs ([`DuplicateId`], REQ-075).
+#[derive(Debug, Default)]
+pub struct LoadReport {
+    /// The artifacts loaded from the source(s).
+    pub artifacts: Vec<model::Artifact>,
+    /// YAML files that were not loaded as artifacts, classified by reason.
+    pub skipped: Vec<SkippedFile>,
+    /// Artifact IDs claimed by more than one artifact.
+    pub duplicates: Vec<DuplicateId>,
+}
+
 /// Like [`load_artifacts`], but additionally reports YAML files that were
 /// skipped during a `generic`/`generic-yaml` directory import.
 ///
@@ -299,7 +339,40 @@ pub fn load_artifacts_with_skips(
     schema: &schema::Schema,
 ) -> Result<(Vec<model::Artifact>, Vec<SkippedFile>), Error> {
     let artifacts = load_artifacts(source, base_dir, schema)?;
-    let skips = match source.format.as_str() {
+    let skips = scan_source_skips(source, base_dir);
+    Ok((artifacts, skips))
+}
+
+/// Like [`load_artifacts_with_skips`], but also detects duplicate artifact
+/// IDs across the loaded artifacts (REQ-075).
+///
+/// This extends the REQ-062 load-report channel with duplicate detection.
+/// Detection happens here, at LOAD time, because once the artifacts are
+/// `upsert`ed into a `Store` only the last writer for each ID survives —
+/// `validate::validate` can never see the collision.
+///
+/// Like [`load_artifacts_with_skips`], this is a separate entrypoint so
+/// `load_artifacts`'s signature stays semver-stable.
+pub fn load_artifacts_with_report(
+    source: &model::SourceConfig,
+    base_dir: &Path,
+    schema: &schema::Schema,
+) -> Result<LoadReport, Error> {
+    let artifacts = load_artifacts(source, base_dir, schema)?;
+    let skipped = scan_source_skips(source, base_dir);
+    let duplicates = detect_duplicate_ids(&artifacts);
+    Ok(LoadReport {
+        artifacts,
+        skipped,
+        duplicates,
+    })
+}
+
+/// Re-walk a `generic`/`generic-yaml` source directory and classify the
+/// `.yaml`/`.yml` files that failed to import. For non-`generic` formats
+/// (or single-file sources) the result is always empty.
+fn scan_source_skips(source: &model::SourceConfig, base_dir: &Path) -> Vec<SkippedFile> {
+    match source.format.as_str() {
         "generic" | "generic-yaml" => {
             let path = base_dir.join(&source.path);
             if path.is_dir() {
@@ -309,8 +382,45 @@ pub fn load_artifacts_with_skips(
             }
         }
         _ => Vec::new(),
-    };
-    Ok((artifacts, skips))
+    }
+}
+
+/// Scan a loaded artifact list for IDs claimed by more than one artifact.
+///
+/// Public entrypoint for callers (notably `rivet validate`) that load
+/// every source first and need a single project-wide duplicate pass: a
+/// collision can straddle two source paths, which per-source
+/// [`load_artifacts_with_report`] calls would each miss. Detection happens
+/// here, before the artifacts are `upsert`ed into a `Store`, because
+/// `upsert` is keyed by ID and last-write-wins (REQ-075).
+pub fn detect_duplicate_ids_for_validate(artifacts: &[model::Artifact]) -> Vec<DuplicateId> {
+    detect_duplicate_ids(artifacts)
+}
+
+/// Scan a loaded artifact list for IDs claimed by more than one artifact.
+///
+/// The first artifact to claim an ID is remembered; every later artifact
+/// with the same ID yields one [`DuplicateId`] pairing the first file with
+/// the colliding file. Two collisions on the same ID produce two entries.
+fn detect_duplicate_ids(artifacts: &[model::Artifact]) -> Vec<DuplicateId> {
+    let mut seen: std::collections::HashMap<&str, Option<PathBuf>> =
+        std::collections::HashMap::new();
+    let mut duplicates = Vec::new();
+    for a in artifacts {
+        match seen.get(a.id.as_str()) {
+            Some(first_file) => {
+                duplicates.push(DuplicateId {
+                    id: a.id.clone(),
+                    first_file: first_file.clone(),
+                    second_file: a.source_file.clone(),
+                });
+            }
+            None => {
+                seen.insert(a.id.as_str(), a.source_file.clone());
+            }
+        }
+    }
+    duplicates
 }
 
 /// Import artifacts from a source using schema-driven rowan extraction.
@@ -367,3 +477,7 @@ pub mod providers;
 /// Re-export of the skipped-file classification types so the CLI can name
 /// them without reaching into the `formats::generic` module path.
 pub use formats::generic::{SkipKind, SkippedFile};
+
+// `DuplicateId` and `LoadReport` are declared in this module directly;
+// they are part of the same load-report channel as `SkippedFile` and are
+// already public (no re-export needed).

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -500,6 +500,25 @@ fn render_validation_message(
         .replace("{rule}", &rule.id)
 }
 
+/// Does a link of type `actual` satisfy a link-field that requires
+/// `required`?
+///
+/// A `<base>-external` link is the cross-organizational variant of the
+/// `<base>` link — e.g. `derives-from-external` for `derives-from`. It
+/// terminates at an `external-anchor` rather than an in-house artifact,
+/// but the derivation still happened; it just crossed an org boundary.
+/// So `derives-from-external` satisfies a required `derives-from`
+/// link-field. The cardinality count uses this; the target-type check
+/// deliberately does NOT — the `*-external` link legitimately points at
+/// an `external-anchor`, which is not in the base field's target types
+/// (REQ-064).
+fn link_satisfies_field(actual: &str, required: &str) -> bool {
+    actual == required
+        || actual
+            .strip_suffix("-external")
+            .is_some_and(|base| base == required)
+}
+
 /// Structural validation only (phases 1-7).
 ///
 /// Validates types, required fields, allowed values, link cardinality,
@@ -721,7 +740,7 @@ pub fn validate_structural_with_externals_and_variant(
             let count = artifact
                 .links
                 .iter()
-                .filter(|l| l.link_type == link_field.link_type)
+                .filter(|l| link_satisfies_field(&l.link_type, &link_field.link_type))
                 .count();
 
             match link_field.cardinality {

--- a/schemas/iec-61508.yaml
+++ b/schemas/iec-61508.yaml
@@ -303,7 +303,11 @@ traceability-rules:
     from-types: [validation]
     severity: error
 
-  # Independent assessment for SIL 3-4
+  # Independent assessment (required for SIL 3-4)
+  # Note: IEC 61508-1 clause 8.2.15 scopes the independent assessment
+  # to SIL 3-4 safety concepts. SIL-level filtering is a project-level
+  # concern documented in the assessment itself; this rule checks that
+  # an assessment artifact exists and references the safety concept.
   - name: safety-concept-has-assessment
     description: >
       SIL 3-4 safety concepts must have an independent safety assessment.
@@ -312,6 +316,3 @@ traceability-rules:
     required-backlink: assesses
     from-types: [safety-assessment]
     severity: error
-    condition:
-      field: sil-target
-      values: [SIL-3, SIL-4]

--- a/schemas/iec-62304.yaml
+++ b/schemas/iec-62304.yaml
@@ -213,36 +213,28 @@ traceability-rules:
     severity: error
 
   # Unit verification coverage
-  - name: sw-unit-has-verification-classA
-    description: Every software unit should be verified (Class A — warning)
-    source-type: sw-unit
-    required-backlink: verifies
-    from-types: [sw-unit-verification]
-    severity: warning
-    condition:
-      field: sw-class
-      values: [A]
-
-  - name: sw-unit-has-verification-classBC
-    description: Every software unit must be verified (Class B/C — error)
+  # Note: IEC 62304 scales the rigour of unit verification by software
+  # safety class (5.5.3 / 5.5.5) — Class A is advisory while Class B/C
+  # is mandatory. Per-class filtering is a project-level concern
+  # documented in the unit and its dev plan; this rule checks that a
+  # unit-verification artifact exists for every software unit.
+  - name: sw-unit-has-verification
+    description: Every software unit must be verified by a unit-verification artifact
     source-type: sw-unit
     required-backlink: verifies
     from-types: [sw-unit-verification]
     severity: error
-    condition:
-      field: sw-class
-      values: [B, C]
 
-  # Integration testing for Class C
+  # Integration testing
+  # Note: IEC 62304 5.6 makes integration testing mandatory for Class C
+  # software. Per-class filtering is a project-level concern; this rule
+  # checks that an integration-test artifact references the item.
   - name: sw-arch-item-has-integration-test
-    description: Every architecture item must be integration-tested (Class C)
+    description: Every architecture item must be integration-tested
     source-type: sw-arch-item
     required-backlink: verifies
     from-types: [sw-integration-test]
     severity: error
-    condition:
-      field: sw-class
-      values: [C]
 
   # Release completeness
   - name: sw-release-has-system-tests


### PR DESCRIPTION
## Summary

Wave 2 of the cross-git investigation follow-ups (FEAT-135) — five P1
code fixes, each closing an F2-family finding (a silent failure under a
green `rivet validate`). Integrated from four parallel work units.

| REQ | Fix |
|---|---|
| **REQ-063** | `rivet init --preset {do-178c,en-50128,iec-61508,iec-62304}` no longer produces an unvalidatable project — the four safety-critical schemas are now embedded in the binary alongside the working five. (Two also carried an unparseable `condition:` field; brought in line with the `en-50128` pattern.) |
| **REQ-064** | A `derives-from-external` link now satisfies a required `derives-from` link-field. The S4 finding was misdiagnosed as a parse failure; the link parses fine — the validator's cardinality check counted only exact matches. New `link_satisfies_field` helper. |
| **REQ-068** | `rivet supplier pull` refuses on sha256 drift (exit non-zero, names both hashes + supplier) instead of silently overwriting the cache; `--accept-drift` is the explicit auditor override. |
| **REQ-075** | Duplicate artifact IDs are detected at load time — a `duplicate-artifact-id` Error naming both source files — instead of `Store::upsert` silently keeping last-write-wins. |
| **REQ-076** | Orphan artifacts surface in `rivet validate` (`orphan-artifact`, Warning by default; `--strict-orphans` promotes to Error) — previously visible only in `rivet stats`. |

## Notable: REQ-075 immediately found a real bug

The new duplicate detection surfaced a genuine pre-existing collision in
rivet's own `artifacts/`: `REQ-060` was declared twice (two unrelated
requirements). Resolved by renaming the v042 entry to `REQ-077` (zero
inbound links, zero doc mentions — the safe one). Without this, `rivet
validate` on the rivet repo itself would now FAIL.

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --workspace` — **0 failures** across the full suite.
- [x] New regression tests: `init_safety_critical_presets_produce_validating_projects`, `validate_accepts_derives_from_external_structured_target`, `supplier_pull_refuses_on_sha256_drift_without_accept_flag`, `validate_detects_duplicate_artifact_ids`, `validate_reports_orphans_as_warnings`.
- [x] `test_dogfood_validate` + `stats_json_counts_match_validate` — still green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0.

Implements: REQ-004, REQ-007, REQ-010
Verifies: REQ-063, REQ-064, REQ-068, REQ-075, REQ-076
Refs: FEAT-135

🤖 Generated with [Claude Code](https://claude.com/claude-code)