### PR TITLE
release(v0.11.1): Mythos silent-failure hunt — REQ-078..082

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,8 +583,16 @@ jobs:
       # DeterminateSystems installer which supports a daemonless
       # single-user mode that does not need sudo.
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        # Pinned by SHA + `determinate: false`. The action's `determinate`
+        # input default flipped false->true between v17 and v22, so the
+        # former `@main` pin started installing Determinate Nix, whose
+        # `determinate-nixd` daemon ignores `init: none` and fails on
+        # no-sudo / NoNewPrivileges runners (missing daemon socket,
+        # root-owned store lock). `determinate: false` restores the plain
+        # upstream daemonless install this job was written for.
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
+          determinate: false
           init: none
           extra-conf: |
             experimental-features = nix-command flakes
@@ -631,8 +639,16 @@ jobs:
       # Same NoNewPrivileges constraint as the verus job above — use the
       # DeterminateSystems installer which works without sudo.
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        # Pinned by SHA + `determinate: false`. The action's `determinate`
+        # input default flipped false->true between v17 and v22, so the
+        # former `@main` pin started installing Determinate Nix, whose
+        # `determinate-nixd` daemon ignores `init: none` and fails on
+        # no-sudo / NoNewPrivileges runners (missing daemon socket,
+        # root-owned store lock). `determinate: false` restores the plain
+        # upstream daemonless install this job was written for.
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
+          determinate: false
           init: none
           extra-conf: |
             experimental-features = nix-command flakes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@
 
 ## [Unreleased]
 
+## [0.11.1] — 2026-05-21
+
+Theme: **the Mythos silent-failure hunt**. A `scripts/mythos/`
+slop-hunt re-run after v0.11.0 — adjusted with a new degraded-input
+oracle (`discover-silent-failure.md`) targeting the F2 silent-failure
+class the cross-git investigation surfaced — swept the ingest/parse
+subsystems the FEAT-135 waves did not cover. Four discovery agents
+returned four confirmed findings; in every case the subsystem already
+contained a sibling check doing the right thing and one code path that
+forgot to. Filed as REQ-078..REQ-081 (`artifacts/mythos-silent-failure-findings.yaml`).
+A fifth fix, REQ-082, addresses a user-reported v0.11.0 regression.
+Patch-shaped: every change is a localized fix, no new flags, no schema
+change.
+
+### Fixed
+
+- **`rivet commits` silently treated malformed artifact trailers as
+  benign orphans** — a one-keystroke typo (`Implements: REQ-O1`) or a
+  typo'd trailer key (`Implments:`) produced an empty `artifact_refs`,
+  classified `Orphan` (warning, exit 0). Malformed references are now
+  flagged as broken, asymmetric with the existing `BrokenRef` check
+  for well-formed-but-unknown IDs (REQ-078).
+- **ReqIF import silently typed a SPEC-OBJECT `unknown`** when its
+  `<TYPE>` was missing or referenced an undeclared SPEC-OBJECT-TYPE —
+  `parse_reqif` returned `Ok`. It now rejects the import naming the
+  offending SPEC-OBJECT, matching the sibling dangling-SPEC-RELATION
+  check (REQ-079).
+- **Schema migration skipped the enum value-check on field-map-renamed
+  fields** — a source value out of the target field's `allowed_values`
+  enum produced zero conflicts and migrated `COMPLETE`. The renamed
+  path now hits the same conflict path as the non-renamed path
+  (REQ-080).
+- **`needs.json` import accepted duplicate artifact IDs** — two
+  sphinx-needs entries sharing one inner `id` both imported, exit 0.
+  The importer now rejects the collision, reusing REQ-075's
+  `detect_duplicate_ids` so the uniqueness rule has one definition
+  (REQ-081).
+- **`rivet validate` counted linked external repos' own schema
+  violations against the consumer** — after `rivet sync`, a consumer
+  project reported thousands of errors all originating from loaded
+  external repos' artifacts, contradicting REQ-065 / AoU-X1. External
+  (`prefix:`-qualified) artifacts now stay in the store ONLY so the
+  consumer's `prefix:ID` cross-links resolve; every per-artifact
+  validation pass skips them. The supplier's diagnostics remain opt-in
+  via `--with-externals-validate` (REQ-082). User-reported.
+
 ## [0.11.0] — 2026-05-21
 
 Theme: **the cross-git investigation**. A 2026-05-19 investigation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/artifacts/mythos-silent-failure-findings.yaml
+++ b/artifacts/mythos-silent-failure-findings.yaml
@@ -1,0 +1,224 @@
+# Mythos silent-failure hunt — findings (2026-05-21)
+#
+# A Mythos-style slop hunt (scripts/mythos/discover-silent-failure.md, the
+# degraded-input oracle) run after v0.11.0, hunting the F2 silent-failure
+# class — code that reports success over an input it should reject — in
+# the ingest/parse subsystems the cross-git investigation (FEAT-135) did
+# not cover. Four discovery agents, four confirmed findings, every one
+# FIX_SIZE: SMALL. Each subsystem already contained a sibling check that
+# does the right thing; the bug is always one code path that forgot to.
+#
+# Shipped as v0.11.1 (patch — all localized, no new flags/schema).
+
+artifacts:
+
+  - id: REQ-078
+    type: requirement
+    title: "rivet commits must flag malformed/typo'd artifact trailers, not silently treat them as orphans"
+    status: draft
+    description: |
+      `parse_commit_message` (rivet-core/src/commits.rs) returns an empty
+      `artifact_refs` for a trailer whose ID is malformed — e.g.
+      `Implements: REQ-O1` (capital letter O, a one-keystroke typo for
+      REQ-001). `analyze_commits` then routes the commit through
+      `CommitClass::Orphan` (a warning), so `rivet commits` exits 0 and
+      the CI gate passes. The author plainly intended a link; the tool
+      silently downgrades a broken link to a benign orphan.
+
+      In-file precedent: a well-formed but unknown ID (`REQ-99999`) IS
+      correctly classified `BrokenRef` (error, non-zero exit). The gap is
+      asymmetric — a clearly-wrong link is treated MORE leniently than a
+      merely-stale one.
+
+      Acceptance:
+        - In a temp git repo, make a commit `Implements: REQ-O1`. Run
+          `rivet commits` — verify exit non-zero and a broken/malformed
+          reference reported (not a silent orphan).
+        - A typo'd trailer KEY (`Implments: REQ-001`) is likewise
+          flagged, not dropped.
+        - A well-formed valid trailer still classifies as `linked`.
+        - Regression test in `rivet-core/src/commits.rs` tests.
+    tags: [commits, silent-failure, f2-family, mythos, p2]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.11.1-track
+    links:
+      - type: derives-from
+        target: FEAT-135
+
+  - id: REQ-079
+    type: requirement
+    title: "ReqIF import must reject a SPEC-OBJECT with missing/dangling TYPE, not silently type it 'unknown'"
+    status: draft
+    description: |
+      `parse_reqif` (rivet-core/src/reqif.rs, ~line 711) resolves a
+      SPEC-OBJECT's type with `.unwrap_or("unknown")`: a SPEC-OBJECT with
+      no `<TYPE>` element, or a `SPEC-OBJECT-TYPE-REF` pointing at an
+      undeclared type, silently becomes `artifact_type: "unknown"` and
+      `parse_reqif` returns `Ok` — no error, no `log::warn!`, no
+      diagnostic. ReqIF 1.2's XSD makes `SPEC-OBJECT/TYPE` mandatory;
+      `docs/design/polarion-reqif-fidelity.md` lists `artifact_type` as
+      LOSSLESS — it never sanctions an unknown-type fallback.
+
+      Sibling precedent in the SAME function (~lines 919-973): dangling
+      `SPEC-RELATION` source/target refs are collected and the import is
+      rejected (`"ReqIF import rejected N dangling SPEC-RELATION ..."`).
+      The dangling-TYPE-ref case is the un-fixed twin.
+
+      Acceptance:
+        - Parse a ReqIF where a SPEC-OBJECT has no `<TYPE>` — verify
+          `parse_reqif` returns `Err`, naming the SPEC-OBJECT identifier.
+        - Same for a SPEC-OBJECT whose TYPE references an undeclared
+          SPEC-OBJECT-TYPE.
+        - A well-formed ReqIF still imports cleanly.
+        - Folds in the lesser sibling at ~line 928 (unresolved
+          SPEC-RELATION-TYPE-REF silently `unwrap_or("traces-to")`).
+        - Regression test in `rivet-core/src/reqif.rs` tests.
+    tags: [reqif, import, silent-failure, f2-family, mythos, p2]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.11.1-track
+    links:
+      - type: derives-from
+        target: FEAT-135
+
+  - id: REQ-080
+    type: requirement
+    title: "Schema migration must run the enum value-check on field-map-renamed fields, not skip it"
+    status: draft
+    description: |
+      `diff_artifacts` (rivet-core/src/migrate.rs, ~lines 461-475): when a
+      field is renamed via the recipe's `field_map`, the code pushes a
+      `FieldRename` change and `continue`s — skipping the
+      `allowed_values` enum check at ~lines 483-504, which is only
+      reachable for non-renamed fields. So a source value that is
+      out-of-enum for the TARGET field (e.g. `prio: 7` renamed into an
+      enum `priority` field constrained to {must,should,could,wont})
+      produces ZERO conflicts, `has_conflicts()` is false, and the
+      migration completes `COMPLETE` (exit 0) with `priority: 7` written
+      against the enum.
+
+      `rivet docs schema-migrate` explicitly defines a `conflict` as
+      "field needs value-mapping (`priority: 5` -> enum)" — the renamed
+      path should hit the conflict path, not bypass it. The non-renamed
+      path already does this correctly (sibling precedent in-function).
+
+      Acceptance:
+        - Run `diff_artifacts` (or `rivet migrate`) with a recipe that
+          field-map-renames `prio` -> `priority` and a source artifact
+          `prio: 7` (out of the target enum). Verify a
+          `FieldValueConflict` / `Conflict`-class change is emitted and
+          `has_conflicts()` is true.
+        - An in-enum renamed value still migrates as a clean mechanical
+          rename.
+        - Folds in the neighbour: `apply_to_file` returning
+          `Ok(original)` with no diagnostic on a file lacking the
+          top-level `artifacts:` key.
+        - Regression test in `rivet-core/src/migrate.rs` tests.
+    tags: [migrate, silent-failure, f2-family, mythos, p2]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.11.1-track
+    links:
+      - type: derives-from
+        target: FEAT-135
+
+  - id: REQ-081
+    type: requirement
+    title: "needs.json import must reject duplicate artifact IDs, not return Ok with colliding artifacts"
+    status: draft
+    description: |
+      `import_needs_json` (rivet-core/src/formats/needs_json.rs) builds a
+      `Vec<Artifact>` from the sphinx-needs `needs` map. Two needs that
+      carry the identical inner `id` field produce two artifacts both
+      claiming that ID; `import_needs_json` returns `Ok` with both, the
+      CLI prints `Imported 2 artifacts` and exits 0. The CLI's REQ-050
+      link check builds a `HashSet` of IDs, which silently DEDUPS the
+      collision instead of flagging it.
+
+      Artifact IDs must be unique — the exact invariant REQ-075's
+      `detect_duplicate_ids` enforces for project loads. The importer is
+      the unguarded entry point for the same violation.
+
+      Acceptance:
+        - Call `import_needs_json` on a needs.json with two needs sharing
+          one inner `id`. Verify it returns `Err` (Adapter error) naming
+          the colliding ID.
+        - A needs.json with all-distinct IDs still imports cleanly.
+        - Folds in the neighbour: `convert_need` mapping a missing `type`
+          field to the literal `"unknown"` with no diagnostic.
+        - Reuse `detect_duplicate_ids_for_validate` (pub, REQ-075) so the
+          rule has one definition.
+        - Regression test in `rivet-core/src/formats/needs_json.rs`.
+    tags: [needs-json, import, duplicate-id, silent-failure, f2-family, mythos, p2]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.11.1-track
+    links:
+      - type: derives-from
+        target: FEAT-135
+      - type: traces-to
+        target: REQ-075
+
+  - id: REQ-082
+    type: requirement
+    title: "rivet validate must not count linked external repos' own schema violations against the consumer"
+    status: draft
+    description: |
+      User-reported against v0.11.0 (2026-05-21). After `rivet sync`,
+      `rivet validate` on a consumer project reports thousands of errors
+      (~5800 in the reporter's case) — `link-target-type`, `cardinality`,
+      schema validation-rule violations — ALL originating from the
+      loaded external repos' own artifacts. The consumer's own artifacts
+      produce zero errors. `rm -rf .rivet/repos && rivet validate` → PASS.
+
+      Root cause: `ProjectContext::load` (rivet-cli/src/main.rs ~12616)
+      `store.upsert`s every external artifact (ID-prefixed `prefix:ID`)
+      into the SAME store that `cmd_validate` hands to
+      `validate::validate`. The external artifacts therefore receive the
+      consumer's full per-artifact validation — type, fields, cardinality,
+      link-target-type, lifecycle, validation-rules. A supplier project
+      that is not itself error-free pushes its internal violations into
+      the consumer's `errors` total and fails the consumer's gate.
+
+      This directly contradicts REQ-065 / AoU-X1: "the consumer's PASS
+      does not otherwise reflect the supplier's validation state." The
+      old issue-#245 intent ("type-check prefixed artifacts against their
+      own schema") is superseded by the deliberate AoU-X1 design — the
+      supplier's diagnostics are opt-in via `--with-externals-validate`,
+      never part of the consumer's default gate.
+
+      Fix: external (prefixed) artifacts stay in the store ONLY so
+      `prefix:ID` cross-links resolve (the broken-ref check needs them).
+      `validate::validate`, the lifecycle pass, and the orphan pass must
+      run over the consumer's OWN artifacts only — those whose ID is not
+      `prefix:`-qualified. The graph stays built from the full store so
+      cross-links still resolve. `--with-externals-validate` (REQ-065)
+      remains the way to see the supplier's own diagnostics, separately.
+
+      Acceptance:
+        - Consumer project with an `externals:` entry whose external
+          project contains real schema violations. `rivet sync` then
+          `rivet validate` (no flags): verify the consumer's `errors`
+          total counts ONLY the consumer's own artifacts — the
+          external's violations do not appear and do not cause FAIL.
+        - `prefix:ID` cross-links from the consumer still resolve (a
+          consumer artifact linking `prefix:REAL-ID` is not a broken
+          ref; linking `prefix:NONEXISTENT` still is).
+        - `rivet validate --with-externals-validate` still surfaces the
+          external's diagnostics under `cross_repo_diagnostics`.
+        - Regression test in `rivet-cli/tests/cli_commands.rs`.
+    tags: [validate, cross-repo, externals, silent-failure-inverse, p1]
+    fields:
+      priority: must
+      category: functional
+      baseline: v0.11.1-track
+    links:
+      - type: derives-from
+        target: FEAT-135
+      - type: traces-to
+        target: REQ-065

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -5845,6 +5845,11 @@ fn cmd_stats(
             ));
         }
     }
+    // REQ-082: drop diagnostics keyed to external (`prefix:ID`) artifacts —
+    // a linked external repo's own violations are the supplier's gate, not
+    // the consumer's. Mirrors the identical filter in `cmd_validate` so the
+    // `errors`/`warnings` counts stay consistent (stats_json_counts_match_validate).
+    diagnostics.retain(|d| !d.artifact_id.as_deref().is_some_and(|id| id.contains(':')));
     let errors = diagnostics
         .iter()
         .filter(|d| d.severity == Severity::Error)

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -10124,9 +10124,39 @@ fn cmd_commit_msg_check(cli: &Cli, file: &std::path::Path) -> Result<bool> {
 
     // Parse artifact trailers
     let trailer_map: &BTreeMap<String, String> = &commits_cfg.trailers;
-    let (artifact_refs, _) =
+    let parsed =
         rivet_core::commits::parse_commit_message(message, trailer_map, &commits_cfg.skip_trailer);
 
+    // Malformed or typo'd trailers are hard errors (REQ-078): a botched
+    // artifact-ID token or a mistyped trailer key must not slip through
+    // as a silent orphan.
+    if !parsed.malformed_refs.is_empty() {
+        eprintln!("error: commit message has malformed artifact trailers:");
+        for m in &parsed.malformed_refs {
+            match m.kind {
+                rivet_core::commits::MalformedKind::Id => {
+                    eprintln!(
+                        "  '{}' under '{}:' is not a valid artifact ID",
+                        m.token, m.context
+                    );
+                }
+                rivet_core::commits::MalformedKind::Key => {
+                    eprintln!(
+                        "  '{}:' is not a known trailer key (did you mean '{}:'?)",
+                        m.token, m.context
+                    );
+                }
+            }
+        }
+        eprintln!();
+        eprintln!(
+            "Fix the trailer, or add '{}' to skip.",
+            commits_cfg.skip_trailer
+        );
+        return Ok(false);
+    }
+
+    let artifact_refs = &parsed.artifact_refs;
     let all_ids: Vec<String> = artifact_refs.values().flatten().cloned().collect();
 
     if all_ids.is_empty() {
@@ -10313,10 +10343,17 @@ fn cmd_commits(
             } else {
                 &br.hash
             };
-            println!(
-                "  {short} {}: unknown ID '{}' (trailer: {})",
-                br.subject, br.missing_id, br.link_type
-            );
+            if br.malformed {
+                println!(
+                    "  {short} {}: malformed trailer '{}' ({})",
+                    br.subject, br.missing_id, br.link_type
+                );
+            } else {
+                println!(
+                    "  {short} {}: unknown ID '{}' (trailer: {})",
+                    br.subject, br.missing_id, br.link_type
+                );
+            }
         }
     }
 
@@ -10363,12 +10400,18 @@ fn cmd_commits(
 }
 
 fn cmd_commits_json(analysis: &rivet_core::commits::CommitAnalysis, strict: bool) -> Result<bool> {
+    let malformed_count = analysis
+        .broken_refs
+        .iter()
+        .filter(|br| br.malformed)
+        .count();
     let json = serde_json::json!({
         "summary": {
             "linked": analysis.linked.len(),
             "orphans": analysis.orphans.len(),
             "exempt": analysis.exempt.len(),
             "broken_refs": analysis.broken_refs.len(),
+            "malformed_refs": malformed_count,
         },
         "broken_refs": analysis.broken_refs.iter().map(|br| {
             serde_json::json!({
@@ -10376,6 +10419,7 @@ fn cmd_commits_json(analysis: &rivet_core::commits::CommitAnalysis, strict: bool
                 "subject": br.subject,
                 "missing_id": br.missing_id,
                 "link_type": br.link_type,
+                "malformed": br.malformed,
             })
         }).collect::<Vec<_>>(),
         "orphans": analysis.orphans.iter().map(|c| {

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -4941,6 +4941,12 @@ fn cmd_validate(
         Severity::Warning
     };
     for orphan_id in graph.orphans(&store) {
+        // REQ-082: an external (prefixed) artifact appearing orphaned in
+        // the consumer's graph is the supplier's concern, not a finding
+        // against the consumer.
+        if orphan_id.contains(':') {
+            continue;
+        }
         let mut diag = validate::Diagnostic::new(
             orphan_severity,
             Some(orphan_id.clone()),
@@ -5050,10 +5056,28 @@ fn cmd_validate(
         }
     }
 
-    // Lifecycle completeness check
-    let all_artifacts: Vec<_> = store.iter().cloned().collect();
+    // Lifecycle completeness check — consumer's own artifacts only;
+    // external (prefixed) artifacts are the supplier's gate (REQ-082).
+    let all_artifacts: Vec<_> = store
+        .iter()
+        .filter(|a| !a.id.contains(':'))
+        .cloned()
+        .collect();
     let lifecycle_gaps =
         rivet_core::lifecycle::check_lifecycle_completeness(&all_artifacts, &schema, &graph);
+
+    // REQ-082: external (prefixed `prefix:ID`) artifacts are loaded into
+    // the store only so the consumer's `prefix:ID` cross-links resolve.
+    // Their own schema / rule / conditional-rule / traceability
+    // violations are the SUPPLIER's gate — surfaced opt-in via
+    // `--with-externals-validate` (REQ-065 / AoU-X1) — never counted
+    // against the consumer's default run. Drop every diagnostic keyed to
+    // a prefixed external ID, whichever validation pass produced it
+    // (structural, conditional, traceability, salsa or direct). A broken
+    // cross-link FROM a consumer artifact is keyed to the consumer's own
+    // ID and is correctly kept; `artifact-parse-error` diagnostics carry
+    // no artifact_id and are kept.
+    diagnostics.retain(|d| !d.artifact_id.as_deref().is_some_and(|id| id.contains(':')));
 
     let errors = diagnostics
         .iter()

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1018,6 +1018,113 @@ fn validate_with_externals_validate_surfaces_supplier_diagnostics() {
     );
 }
 
+/// REQ-082: a linked external repo's OWN schema violations must not be
+/// counted against the consumer's default `rivet validate`. External
+/// (`prefix:ID`) artifacts are in the store only so cross-links resolve;
+/// validating the supplier's project is opt-in (`--with-externals-validate`).
+///
+/// rivet: verifies REQ-082
+#[test]
+fn validate_does_not_count_external_repo_violations() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let supplier = root.path().join("supplier");
+    let consumer = root.path().join("consumer");
+    std::fs::create_dir_all(&supplier).unwrap();
+    std::fs::create_dir_all(&consumer).unwrap();
+
+    // Supplier: a dev project carrying a real schema violation
+    // (out-of-enum priority) — the kind of error that, before REQ-082,
+    // flooded the consumer's error total after `rivet sync`.
+    let init_s = Command::new(rivet_bin())
+        .args([
+            "init",
+            "--preset",
+            "dev",
+            "--dir",
+            supplier.to_str().unwrap(),
+        ])
+        .output()
+        .expect("init supplier");
+    assert!(
+        init_s.status.success(),
+        "init supplier: {}",
+        String::from_utf8_lossy(&init_s.stderr)
+    );
+    std::fs::write(
+        supplier.join("artifacts").join("bad.yaml"),
+        "artifacts:\n\
+         \x20 - id: REQ-SUPPLIER-BAD\n    type: requirement\n\
+         \x20   title: Supplier req with an invalid priority\n\
+         \x20   status: approved\n\
+         \x20   fields: {priority: TotallyInvalid, category: functional}\n",
+    )
+    .expect("write supplier bad.yaml");
+
+    let init_c = Command::new(rivet_bin())
+        .args([
+            "init",
+            "--preset",
+            "dev",
+            "--dir",
+            consumer.to_str().unwrap(),
+        ])
+        .output()
+        .expect("init consumer");
+    assert!(
+        init_c.status.success(),
+        "init consumer: {}",
+        String::from_utf8_lossy(&init_c.stderr)
+    );
+    std::fs::write(
+        consumer.join("rivet.yaml"),
+        format!(
+            "project:\n  name: consumer\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+             externals:\n  sup:\n    path: {}\n    prefix: sup\n\
+             sources:\n  - path: artifacts\n    format: generic-yaml\n",
+            supplier.display()
+        ),
+    )
+    .expect("write consumer rivet.yaml");
+    let sync = Command::new(rivet_bin())
+        .args(["--project", consumer.to_str().unwrap(), "sync"])
+        .output()
+        .expect("rivet sync");
+    assert!(
+        sync.status.success(),
+        "sync: {}",
+        String::from_utf8_lossy(&sync.stderr)
+    );
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            consumer.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("validate");
+    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).expect("validate JSON");
+    let diags = parsed
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics array");
+    let external_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| {
+            d.get("artifact_id")
+                .and_then(|a| a.as_str())
+                .is_some_and(|id| id.starts_with("sup:"))
+        })
+        .collect();
+    assert!(
+        external_diags.is_empty(),
+        "the consumer's validate must not carry diagnostics for the \
+         external repo's own artifacts; got: {external_diags:?}"
+    );
+}
+
 // ── rivet stats ─────────────────────────────────────────────────────────
 
 /// `rivet stats --format json` produces valid JSON with total count.

--- a/rivet-core/src/commits.rs
+++ b/rivet-core/src/commits.rs
@@ -50,6 +50,49 @@ use crate::error::Error;
 // Data types
 // ---------------------------------------------------------------------------
 
+/// A malformed artifact reference found in a commit trailer.
+///
+/// This covers two distinct authoring mistakes that previously went
+/// silently undetected (REQ-078):
+///
+///   * `MalformedKind::Id` — a trailer *value* token that clearly
+///     attempts an artifact ID (it contains a `-` and at least one
+///     ASCII digit) but does not satisfy [`is_artifact_id`], e.g.
+///     `Implements: REQ-O1` (capital letter O for a zero).
+///   * `MalformedKind::Key` — a trailer *key* that is within
+///     edit-distance 1 of a configured trailer key but is not an exact
+///     match, e.g. `Implments:` for `Implements:`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MalformedRef {
+    /// What kind of malformed reference this is.
+    pub kind: MalformedKind,
+    /// The offending token, exactly as it appeared in the commit.
+    pub token: String,
+    /// Context: for an `Id` this is the trailer key the token appeared
+    /// under; for a `Key` this is the configured key it most resembles.
+    pub context: String,
+}
+
+/// The category of a [`MalformedRef`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MalformedKind {
+    /// A trailer value that looks like a botched artifact ID.
+    Id,
+    /// A trailer key that looks like a botched (mistyped) trailer key.
+    Key,
+}
+
+/// The result of parsing a single commit message for traceability data.
+#[derive(Debug, Clone, Default)]
+pub struct CommitParse {
+    /// Artifact IDs extracted from trailers, keyed by link type.
+    pub artifact_refs: BTreeMap<String, Vec<String>>,
+    /// Trailer tokens that look like botched artifact references.
+    pub malformed_refs: Vec<MalformedRef>,
+    /// Whether the skip trailer was present.
+    pub has_skip_trailer: bool,
+}
+
 /// A parsed git commit with extracted metadata.
 #[derive(Debug, Clone)]
 pub struct ParsedCommit {
@@ -67,6 +110,8 @@ pub struct ParsedCommit {
     pub commit_type: Option<String>,
     /// Artifact IDs extracted from trailers, keyed by link type.
     pub artifact_refs: BTreeMap<String, Vec<String>>,
+    /// Trailer tokens that look like botched artifact references.
+    pub malformed_refs: Vec<MalformedRef>,
     /// Files changed by this commit.
     pub changed_files: Vec<String>,
     /// Whether the skip trailer was present.
@@ -78,7 +123,8 @@ pub struct ParsedCommit {
 pub enum CommitClass {
     /// All referenced artifact IDs exist in the store.
     Linked,
-    /// At least one referenced artifact ID does not exist.
+    /// At least one referenced artifact ID does not exist, or a trailer
+    /// contains a malformed/typo'd reference.
     BrokenRef,
     /// No artifact references at all (and not exempt).
     Orphan,
@@ -95,6 +141,9 @@ pub struct BrokenRef {
     pub missing_id: String,
     /// The link type / trailer key under which it was referenced.
     pub link_type: String,
+    /// True when the reference is malformed (a botched ID/key) rather
+    /// than merely well-formed-but-unknown.
+    pub malformed: bool,
 }
 
 /// Full analysis of a set of commits against a known artifact set.
@@ -229,8 +278,25 @@ pub fn expand_artifact_range(reference: &str) -> Vec<String> {
 /// "REQ-001", "FEAT-42", "DD-007".  Multiple IDs can appear separated
 /// by commas or whitespace.  Range syntax like "FEAT-052..056" is
 /// expanded into individual IDs.
+///
+/// Malformed tokens are silently dropped; use [`extract_artifact_refs`]
+/// when malformed references must also be surfaced.
 pub fn extract_artifact_ids(value: &str) -> Vec<String> {
+    extract_artifact_refs(value).0
+}
+
+/// Extract artifact IDs *and* malformed reference tokens from a trailer
+/// value.
+///
+/// Returns `(valid_ids, malformed_tokens)`. A token is considered a
+/// malformed reference — a botched artifact-ID *attempt* rather than
+/// ordinary prose — when it contains a hyphen and at least one ASCII
+/// digit yet does not satisfy [`is_artifact_id`]. This catches typos
+/// like `REQ-O1` (capital letter O for a zero) while leaving plain
+/// words such as `hot-fix` or numbers like `42` untouched.
+pub fn extract_artifact_refs(value: &str) -> (Vec<String>, Vec<String>) {
     let mut ids = Vec::new();
+    let mut malformed = Vec::new();
     // Split on commas and whitespace
     for token in value.split(|c: char| c == ',' || c.is_ascii_whitespace()) {
         let token = token.trim();
@@ -242,10 +308,22 @@ pub fn extract_artifact_ids(value: &str) -> Vec<String> {
         for id in &expanded {
             if is_artifact_id(id) {
                 ids.push(id.clone());
+            } else if looks_like_artifact_id_attempt(id) {
+                malformed.push(id.clone());
             }
         }
     }
-    ids
+    (ids, malformed)
+}
+
+/// Heuristic: does this token *look like* a (botched) artifact ID?
+///
+/// True when the token contains a hyphen and at least one ASCII digit
+/// but is not itself a valid artifact ID. This deliberately excludes
+/// ordinary hyphenated prose (no digit) and bare numbers (no hyphen),
+/// so `rivet commits` flags genuine typos without choking on free text.
+fn looks_like_artifact_id_attempt(token: &str) -> bool {
+    !is_artifact_id(token) && token.contains('-') && token.chars().any(|c| c.is_ascii_digit())
 }
 
 /// Check whether a string looks like an artifact ID.
@@ -268,8 +346,36 @@ fn is_artifact_id(s: &str) -> bool {
     }
 }
 
-/// Parse a full commit message: extract trailer-based artifact references
-/// and detect the skip trailer.
+/// Compute the Levenshtein edit distance between two strings.
+///
+/// Used to detect trailer keys that are one keystroke away from a
+/// configured key (`Implments:` vs `Implements:`).
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a_len = a.chars().count();
+    let b_len = b.chars().count();
+    if a_len == 0 {
+        return b_len;
+    }
+    if b_len == 0 {
+        return a_len;
+    }
+
+    let mut prev: Vec<usize> = (0..=b_len).collect();
+    let mut curr = vec![0_usize; b_len + 1];
+
+    for (i, ca) in a.chars().enumerate() {
+        curr[0] = i + 1;
+        for (j, cb) in b.chars().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b_len]
+}
+
+/// Parse a full commit message: extract trailer-based artifact references,
+/// detect malformed/typo'd references, and detect the skip trailer.
 ///
 /// `trailer_map` maps trailer keys (e.g. "Implements") to link types
 /// (e.g. "implements").  `skip_trailer` is the full "Key: value" string
@@ -278,28 +384,62 @@ pub fn parse_commit_message(
     message: &str,
     trailer_map: &BTreeMap<String, String>,
     skip_trailer: &str,
-) -> (BTreeMap<String, Vec<String>>, bool) {
+) -> CommitParse {
     let raw_trailers = parse_trailers(message);
     let mut artifact_refs: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut malformed_refs: Vec<MalformedRef> = Vec::new();
 
     for (trailer_key, link_type) in trailer_map {
         if let Some(values) = raw_trailers.get(trailer_key) {
             for value in values {
-                let ids = extract_artifact_ids(value);
+                let (ids, malformed) = extract_artifact_refs(value);
                 if !ids.is_empty() {
                     artifact_refs
                         .entry(link_type.clone())
                         .or_default()
                         .extend(ids);
                 }
+                for token in malformed {
+                    malformed_refs.push(MalformedRef {
+                        kind: MalformedKind::Id,
+                        token,
+                        context: trailer_key.clone(),
+                    });
+                }
             }
         }
     }
 
-    // Check for skip trailer
-    let has_skip = message.lines().any(|line| line.trim() == skip_trailer);
+    // Detect typo'd trailer KEYS: a key not in `trailer_map` that is
+    // within edit-distance 1 of a configured key. The skip-trailer key
+    // is also a legitimate target so it does not get flagged.
+    let skip_key = skip_trailer.split_once(':').map(|(k, _)| k.trim());
+    for raw_key in raw_trailers.keys() {
+        if trailer_map.contains_key(raw_key) || skip_key == Some(raw_key.as_str()) {
+            continue;
+        }
+        if let Some(closest) = trailer_map
+            .keys()
+            .filter(|cfg| levenshtein(raw_key, cfg) == 1)
+            // Prefer a longer configured key on ties for a stable hint.
+            .max_by_key(|cfg| cfg.len())
+        {
+            malformed_refs.push(MalformedRef {
+                kind: MalformedKind::Key,
+                token: raw_key.clone(),
+                context: closest.clone(),
+            });
+        }
+    }
 
-    (artifact_refs, has_skip)
+    // Check for skip trailer
+    let has_skip_trailer = message.lines().any(|line| line.trim() == skip_trailer);
+
+    CommitParse {
+        artifact_refs,
+        malformed_refs,
+        has_skip_trailer,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -352,8 +492,7 @@ pub fn parse_git_log_entry(
         format!("{}\n\n{}", subject, body)
     };
 
-    let (artifact_refs, has_skip_trailer) =
-        parse_commit_message(&full_message, trailer_map, skip_trailer);
+    let parsed = parse_commit_message(&full_message, trailer_map, skip_trailer);
 
     Some(ParsedCommit {
         hash,
@@ -362,9 +501,10 @@ pub fn parse_git_log_entry(
         author,
         date,
         commit_type,
-        artifact_refs,
+        artifact_refs: parsed.artifact_refs,
+        malformed_refs: parsed.malformed_refs,
         changed_files,
-        has_skip_trailer,
+        has_skip_trailer: parsed.has_skip_trailer,
     })
 }
 
@@ -412,11 +552,20 @@ pub fn git_log_commits(
 // Classification and analysis (Task 4)
 // ---------------------------------------------------------------------------
 
-/// Classify a commit based on its artifact references against the set of known IDs.
+/// Classify a commit based on its artifact references against the set of
+/// known IDs.
+///
+/// A commit with one or more malformed/typo'd references (`has_malformed`)
+/// is always [`CommitClass::BrokenRef`] — a clearly-botched link must
+/// never be downgraded to a benign [`CommitClass::Orphan`] (REQ-078).
 pub fn classify_commit_refs(
     artifact_refs: &BTreeMap<String, Vec<String>>,
     known_ids: &HashSet<String>,
+    has_malformed: bool,
 ) -> CommitClass {
+    if has_malformed {
+        return CommitClass::BrokenRef;
+    }
     let all_ids: Vec<&String> = artifact_refs.values().flatten().collect();
     if all_ids.is_empty() {
         return CommitClass::Orphan;
@@ -484,7 +633,8 @@ pub fn analyze_commits(
         }
 
         // 3. Classify by artifact references
-        let class = classify_commit_refs(&commit.artifact_refs, known_ids);
+        let has_malformed = !commit.malformed_refs.is_empty();
+        let class = classify_commit_refs(&commit.artifact_refs, known_ids, has_malformed);
         match class {
             CommitClass::Linked => {
                 // Record coverage
@@ -496,7 +646,7 @@ pub fn analyze_commits(
                 linked.push(commit);
             }
             CommitClass::BrokenRef => {
-                // Collect broken refs
+                // Collect well-formed-but-unknown broken refs.
                 for (link_type, ids) in &commit.artifact_refs {
                     for id in ids {
                         if !known_ids.contains(id) {
@@ -505,13 +655,33 @@ pub fn analyze_commits(
                                 subject: commit.subject.clone(),
                                 missing_id: id.clone(),
                                 link_type: link_type.clone(),
+                                malformed: false,
                             });
                         } else {
                             artifact_coverage.insert(id.clone());
                         }
                     }
                 }
-                // Still count partially linked commits in the linked set
+                // Collect malformed/typo'd references (REQ-078): a
+                // botched ID token or a mistyped trailer key. These are
+                // hard errors, never silent orphans.
+                for m in &commit.malformed_refs {
+                    let (missing_id, link_type) = match m.kind {
+                        MalformedKind::Id => (m.token.clone(), m.context.clone()),
+                        MalformedKind::Key => (
+                            m.token.clone(),
+                            format!("typo'd trailer key (did you mean '{}'?)", m.context),
+                        ),
+                    };
+                    broken_refs_list.push(BrokenRef {
+                        hash: commit.hash.clone(),
+                        subject: commit.subject.clone(),
+                        missing_id,
+                        link_type,
+                        malformed: true,
+                    });
+                }
+                // Still count partially linked commits in the linked set.
                 linked.push(commit);
             }
             CommitClass::Orphan => {
@@ -648,10 +818,13 @@ mod tests {
         trailer_map.insert("Implements".into(), "implements".into());
         trailer_map.insert("Fixes".into(), "fixes".into());
 
-        let (refs, skip) = parse_commit_message(msg, &trailer_map, "Trace: skip");
-        assert!(!skip);
-        assert_eq!(refs.get("implements").unwrap(), &vec!["REQ-001", "REQ-002"]);
-        assert_eq!(refs.get("fixes").unwrap(), &vec!["DD-003"]);
+        let parsed = parse_commit_message(msg, &trailer_map, "Trace: skip");
+        assert!(!parsed.has_skip_trailer);
+        assert_eq!(
+            parsed.artifact_refs.get("implements").unwrap(),
+            &vec!["REQ-001", "REQ-002"]
+        );
+        assert_eq!(parsed.artifact_refs.get("fixes").unwrap(), &vec!["DD-003"]);
     }
 
     // rivet: verifies REQ-017
@@ -659,9 +832,9 @@ mod tests {
     fn parse_message_with_skip() {
         let msg = "chore: update deps\n\nTrace: skip";
         let trailer_map = BTreeMap::new();
-        let (refs, skip) = parse_commit_message(msg, &trailer_map, "Trace: skip");
-        assert!(skip);
-        assert!(refs.is_empty());
+        let parsed = parse_commit_message(msg, &trailer_map, "Trace: skip");
+        assert!(parsed.has_skip_trailer);
+        assert!(parsed.artifact_refs.is_empty());
     }
 
     // rivet: verifies REQ-017
@@ -670,9 +843,9 @@ mod tests {
         let msg = "fix: quick patch";
         let mut trailer_map = BTreeMap::new();
         trailer_map.insert("Implements".into(), "implements".into());
-        let (refs, skip) = parse_commit_message(msg, &trailer_map, "Trace: skip");
-        assert!(!skip);
-        assert!(refs.is_empty());
+        let parsed = parse_commit_message(msg, &trailer_map, "Trace: skip");
+        assert!(!parsed.has_skip_trailer);
+        assert!(parsed.artifact_refs.is_empty());
     }
 
     // -- parse_git_log_entry --
@@ -715,7 +888,10 @@ mod tests {
         let mut refs = BTreeMap::new();
         refs.insert("implements".into(), vec!["REQ-001".into()]);
         let known: HashSet<String> = ["REQ-001".into()].into();
-        assert_eq!(classify_commit_refs(&refs, &known), CommitClass::Linked);
+        assert_eq!(
+            classify_commit_refs(&refs, &known, false),
+            CommitClass::Linked
+        );
     }
 
     // rivet: verifies REQ-017
@@ -724,7 +900,10 @@ mod tests {
         let mut refs = BTreeMap::new();
         refs.insert("implements".into(), vec!["REQ-999".into()]);
         let known: HashSet<String> = ["REQ-001".into()].into();
-        assert_eq!(classify_commit_refs(&refs, &known), CommitClass::BrokenRef);
+        assert_eq!(
+            classify_commit_refs(&refs, &known, false),
+            CommitClass::BrokenRef
+        );
     }
 
     // rivet: verifies REQ-017
@@ -732,7 +911,10 @@ mod tests {
     fn classify_orphan() {
         let refs = BTreeMap::new();
         let known: HashSet<String> = ["REQ-001".into()].into();
-        assert_eq!(classify_commit_refs(&refs, &known), CommitClass::Orphan);
+        assert_eq!(
+            classify_commit_refs(&refs, &known, false),
+            CommitClass::Orphan
+        );
     }
 
     // -- is_exempt --
@@ -748,6 +930,7 @@ mod tests {
             date: "2025-01-01".into(),
             commit_type: Some("chore".into()),
             artifact_refs: BTreeMap::new(),
+            malformed_refs: Vec::new(),
             changed_files: Vec::new(),
             has_skip_trailer: false,
         };
@@ -766,6 +949,7 @@ mod tests {
             date: "2025-01-01".into(),
             commit_type: Some("feat".into()),
             artifact_refs: BTreeMap::new(),
+            malformed_refs: Vec::new(),
             changed_files: Vec::new(),
             has_skip_trailer: true,
         };
@@ -783,6 +967,7 @@ mod tests {
             date: "2025-01-01".into(),
             commit_type: Some("feat".into()),
             artifact_refs: BTreeMap::new(),
+            malformed_refs: Vec::new(),
             changed_files: Vec::new(),
             has_skip_trailer: false,
         };
@@ -845,6 +1030,7 @@ mod tests {
                 date: "2025-01-01".into(),
                 commit_type: Some("feat".into()),
                 artifact_refs: linked_refs,
+                malformed_refs: Vec::new(),
                 changed_files: vec!["src/parser.rs".into()],
                 has_skip_trailer: false,
             },
@@ -857,6 +1043,7 @@ mod tests {
                 date: "2025-01-02".into(),
                 commit_type: Some("chore".into()),
                 artifact_refs: BTreeMap::new(),
+                malformed_refs: Vec::new(),
                 changed_files: vec!["Cargo.toml".into()],
                 has_skip_trailer: false,
             },
@@ -869,6 +1056,7 @@ mod tests {
                 date: "2025-01-03".into(),
                 commit_type: Some("feat".into()),
                 artifact_refs: BTreeMap::new(),
+                malformed_refs: Vec::new(),
                 changed_files: vec!["src/hack.rs".into()],
                 has_skip_trailer: false,
             },
@@ -881,6 +1069,7 @@ mod tests {
                 date: "2025-01-04".into(),
                 commit_type: Some("feat".into()),
                 artifact_refs: broken_refs,
+                malformed_refs: Vec::new(),
                 changed_files: vec!["src/fix.rs".into()],
                 has_skip_trailer: false,
             },
@@ -893,6 +1082,7 @@ mod tests {
                 date: "2025-01-05".into(),
                 commit_type: Some("feat".into()),
                 artifact_refs: BTreeMap::new(),
+                malformed_refs: Vec::new(),
                 changed_files: vec!["docs/guide.md".into()],
                 has_skip_trailer: false,
             },
@@ -1102,11 +1292,178 @@ mod tests {
         let mut trailer_map = BTreeMap::new();
         trailer_map.insert("Implements".into(), "implements".into());
 
-        let (refs, _skip) = parse_commit_message(msg, &trailer_map, "Trace: skip");
-        let impl_ids = refs.get("implements").unwrap();
+        let parsed = parse_commit_message(msg, &trailer_map, "Trace: skip");
+        let impl_ids = parsed.artifact_refs.get("implements").unwrap();
         assert_eq!(
             impl_ids,
             &vec!["FEAT-052", "FEAT-053", "FEAT-054", "FEAT-055", "FEAT-056"]
         );
+    }
+
+    // ── REQ-078: malformed/typo'd trailers must not pass as orphans ──────
+    //
+    // The bug: `Implements: REQ-O1` (capital letter O) yielded an empty
+    // `artifact_refs`, so the commit was classified `Orphan` (a warning,
+    // exit 0) instead of `BrokenRef` (an error, non-zero exit). A
+    // well-formed-but-unknown ID (`REQ-99999`) was already caught — the
+    // malformed case was the un-fixed asymmetry.
+
+    fn impl_trailer_map() -> BTreeMap<String, String> {
+        let mut m = BTreeMap::new();
+        m.insert("Implements".into(), "implements".into());
+        m.insert("Fixes".into(), "fixes".into());
+        m
+    }
+
+    // rivet: verifies REQ-078
+    #[test]
+    fn malformed_id_token_is_detected_not_dropped() {
+        // `REQ-O1` — capital letter O for a zero — looks like an artifact
+        // ID attempt but is not valid: it must surface as a malformed ref.
+        let (ids, malformed) = extract_artifact_refs("REQ-O1");
+        assert!(ids.is_empty(), "REQ-O1 must not be a valid artifact ID");
+        assert_eq!(malformed, vec!["REQ-O1"]);
+    }
+
+    // rivet: verifies REQ-078
+    #[test]
+    fn ordinary_prose_is_not_flagged_as_malformed() {
+        // A hyphenated word with no digit, and a bare number, are not
+        // artifact-ID attempts — `rivet commits` must not choke on prose.
+        let (ids, malformed) = extract_artifact_refs("hot-fix for issue 42");
+        assert!(ids.is_empty());
+        assert!(
+            malformed.is_empty(),
+            "prose must not be flagged as malformed: {malformed:?}"
+        );
+    }
+
+    // rivet: verifies REQ-078
+    #[test]
+    fn typod_id_classifies_as_broken_ref_not_orphan() {
+        // End-to-end: a commit whose only trailer is `Implements: REQ-O1`
+        // must classify as BrokenRef, never Orphan.
+        let trailer_map = impl_trailer_map();
+        let parsed = parse_commit_message(
+            "feat: add thing\n\nImplements: REQ-O1",
+            &trailer_map,
+            "Trace: skip",
+        );
+        assert!(
+            parsed.artifact_refs.is_empty(),
+            "the malformed token must not become a valid ref"
+        );
+        assert_eq!(parsed.malformed_refs.len(), 1);
+        assert_eq!(parsed.malformed_refs[0].kind, MalformedKind::Id);
+        assert_eq!(parsed.malformed_refs[0].token, "REQ-O1");
+
+        let known: HashSet<String> = ["REQ-001".into()].into();
+        // has_malformed = true → BrokenRef even with empty artifact_refs.
+        assert_eq!(
+            classify_commit_refs(&parsed.artifact_refs, &known, true),
+            CommitClass::BrokenRef,
+        );
+    }
+
+    // rivet: verifies REQ-078
+    #[test]
+    fn typod_trailer_key_is_flagged() {
+        // `Implments:` is edit-distance 1 from the configured `Implements:`
+        // key — it must be flagged, not silently dropped.
+        let trailer_map = impl_trailer_map();
+        let parsed = parse_commit_message(
+            "feat: add thing\n\nImplments: REQ-001",
+            &trailer_map,
+            "Trace: skip",
+        );
+        // The value never reaches `artifact_refs` because the key is wrong.
+        assert!(parsed.artifact_refs.is_empty());
+        assert_eq!(parsed.malformed_refs.len(), 1);
+        assert_eq!(parsed.malformed_refs[0].kind, MalformedKind::Key);
+        assert_eq!(parsed.malformed_refs[0].token, "Implments");
+        assert_eq!(parsed.malformed_refs[0].context, "Implements");
+    }
+
+    // rivet: verifies REQ-078
+    #[test]
+    fn unrelated_trailer_key_is_not_flagged_as_typo() {
+        // A genuinely unrelated trailer key (`Co-Authored-By:`,
+        // `Signed-off-by:` style) is far from every configured key and
+        // must not be mistaken for a typo.
+        let trailer_map = impl_trailer_map();
+        let parsed = parse_commit_message(
+            "feat: add thing\n\nImplements: REQ-001\nReviewed-By: Someone",
+            &trailer_map,
+            "Trace: skip",
+        );
+        assert!(
+            parsed.malformed_refs.is_empty(),
+            "unrelated key wrongly flagged: {:?}",
+            parsed.malformed_refs
+        );
+    }
+
+    // rivet: verifies REQ-078
+    #[test]
+    fn well_formed_valid_trailer_still_classifies_as_linked() {
+        // The control case: a correct trailer must keep working — no
+        // malformed refs, classifies Linked against a known store.
+        let trailer_map = impl_trailer_map();
+        let parsed = parse_commit_message(
+            "feat: add thing\n\nImplements: REQ-001",
+            &trailer_map,
+            "Trace: skip",
+        );
+        assert!(parsed.malformed_refs.is_empty());
+        assert_eq!(
+            parsed.artifact_refs.get("implements").unwrap(),
+            &vec!["REQ-001"]
+        );
+
+        let known: HashSet<String> = ["REQ-001".into()].into();
+        assert_eq!(
+            classify_commit_refs(&parsed.artifact_refs, &known, false),
+            CommitClass::Linked,
+        );
+    }
+
+    // rivet: verifies REQ-078
+    #[test]
+    fn analyze_commits_reports_malformed_ref_as_broken() {
+        // Full pipeline: a `feat` commit touching a traced path with a
+        // malformed trailer must land in `broken_refs` (error), NOT in
+        // `orphans` (warning) — so `rivet commits` exits non-zero.
+        let known_ids: HashSet<String> = ["REQ-001".into()].into();
+        let commit = ParsedCommit {
+            hash: "deadbeef".into(),
+            subject: "feat: add thing".into(),
+            body: String::new(),
+            author: "Alice".into(),
+            date: "2025-01-01".into(),
+            commit_type: Some("feat".into()),
+            artifact_refs: BTreeMap::new(),
+            malformed_refs: vec![MalformedRef {
+                kind: MalformedKind::Id,
+                token: "REQ-O1".into(),
+                context: "Implements".into(),
+            }],
+            changed_files: vec!["src/lib.rs".into()],
+            has_skip_trailer: false,
+        };
+        let analysis = analyze_commits(
+            vec![commit],
+            &known_ids,
+            &["chore".into()],
+            &["src/".into()],
+            &[],
+            &BTreeMap::new(),
+        );
+        assert!(
+            analysis.orphans.is_empty(),
+            "malformed commit must not be a silent orphan"
+        );
+        assert_eq!(analysis.broken_refs.len(), 1);
+        assert!(analysis.broken_refs[0].malformed);
+        assert_eq!(analysis.broken_refs[0].missing_id, "REQ-O1");
     }
 }

--- a/rivet-core/src/formats/needs_json.rs
+++ b/rivet-core/src/formats/needs_json.rs
@@ -188,6 +188,26 @@ fn import_needs_json_inner(
 
     let link_type = config.default_link_type.as_deref().unwrap_or("satisfies");
 
+    // Reject needs missing the `type` field. sphinx-needs always emits a
+    // `type`; a need lacking it is degraded input. `convert_need` would
+    // otherwise silently substitute the literal `"unknown"` type, producing
+    // an artifact that does not match any schema (REQ-081). Reported as the
+    // sphinx-needs map keys, which name the offending entries.
+    let mut typeless: Vec<&str> = version
+        .needs
+        .iter()
+        .filter(|(_, item)| item.need_type.is_none())
+        .map(|(key, _)| key.as_str())
+        .collect();
+    if !typeless.is_empty() {
+        typeless.sort_unstable();
+        return Err(Error::Adapter(format!(
+            "needs.json: {} need(s) missing the required `type` field: {}",
+            typeless.len(),
+            typeless.join(", ")
+        )));
+    }
+
     let mut artifacts: Vec<Artifact> = version
         .needs
         .values()
@@ -196,6 +216,23 @@ fn import_needs_json_inner(
 
     // Deterministic output order.
     artifacts.sort_by(|a, b| a.id.cmp(&b.id));
+
+    // Artifact IDs must be unique. Two sphinx-needs entries carrying the
+    // same inner `id` (or whose IDs collide after `id-transform`) would
+    // otherwise produce two artifacts both claiming one ID, and the import
+    // would return `Ok` with the silent collision (REQ-081). Reuse the
+    // REQ-075 duplicate rule so the invariant has a single definition.
+    let duplicates = crate::detect_duplicate_ids_for_validate(&artifacts);
+    if !duplicates.is_empty() {
+        let mut ids: Vec<&str> = duplicates.iter().map(|d| d.id.as_str()).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        return Err(Error::Adapter(format!(
+            "needs.json: {} artifact ID(s) claimed by more than one need: {}",
+            ids.len(),
+            ids.join(", ")
+        )));
+    }
 
     Ok(artifacts)
 }
@@ -299,6 +336,11 @@ fn convert_need(
     source: Option<&Path>,
 ) -> Artifact {
     let id = transform_id(&item.id, &config.id_transform);
+    // `import_needs_json_inner` rejects needs with no `type` before any
+    // `convert_need` call, so `need_type` is always `Some` here. The
+    // `"unknown"` fallback is a defensive belt-and-braces value and is
+    // not reachable through the public `import_needs_json` entry point
+    // (REQ-081).
     let artifact_type = map_type(
         item.need_type.as_deref().unwrap_or("unknown"),
         &config.type_mapping,
@@ -607,5 +649,90 @@ mod tests {
         let arts = import_needs_json(json, &Default::default()).unwrap();
         assert_eq!(arts.len(), 1);
         assert_eq!(arts[0].id, "req--x");
+    }
+
+    // ----- Test: duplicate artifact IDs rejected (REQ-081) --------------
+
+    // rivet: verifies REQ-081
+    #[test]
+    fn duplicate_inner_id_returns_error() {
+        // Two distinct needs map keys, but the inner `id` is identical, so
+        // both convert to the same artifact ID. The import must reject this
+        // rather than return `Ok` with a silent collision (REQ-081).
+        let json = minimal_needs_json(
+            r#"
+            "key_a": {
+                "id": "req__shared",
+                "type": "req",
+                "title": "First claimant"
+            },
+            "key_b": {
+                "id": "req__shared",
+                "type": "req",
+                "title": "Second claimant"
+            }
+            "#,
+        );
+        let result = import_needs_json(&json, &Default::default());
+        assert!(result.is_err(), "expected Err for colliding IDs");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("req--shared"),
+            "error should name the colliding ID: {err}"
+        );
+        assert!(
+            err.contains("more than one need"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    // rivet: verifies REQ-081
+    #[test]
+    fn distinct_ids_import_cleanly() {
+        // All-distinct IDs must still import without error (REQ-081).
+        let json = minimal_needs_json(
+            r#"
+            "req__one": {
+                "id": "req__one",
+                "type": "req",
+                "title": "One"
+            },
+            "req__two": {
+                "id": "req__two",
+                "type": "req",
+                "title": "Two"
+            }
+            "#,
+        );
+        let arts = import_needs_json(&json, &Default::default()).unwrap();
+        assert_eq!(arts.len(), 2);
+        assert_eq!(arts[0].id, "req--one");
+        assert_eq!(arts[1].id, "req--two");
+    }
+
+    // ----- Test: missing `type` field rejected (REQ-081) ----------------
+
+    // rivet: verifies REQ-081
+    #[test]
+    fn missing_type_returns_error() {
+        // sphinx-needs always emits `type`; a need lacking it is degraded
+        // input and must be flagged rather than silently typed "unknown"
+        // (REQ-081).
+        let json = minimal_needs_json(
+            r#"
+            "req__no_type": {
+                "id": "req__no_type",
+                "title": "No type field"
+            }
+            "#,
+        );
+        let result = import_needs_json(&json, &Default::default());
+        assert!(result.is_err(), "expected Err for need missing `type`");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("req__no_type"),
+            "error should name the offending need key: {err}"
+        );
+        assert!(err.contains("type"), "unexpected error message: {err}");
     }
 }

--- a/rivet-core/src/migrate.rs
+++ b/rivet-core/src/migrate.rs
@@ -366,6 +366,39 @@ impl RewriteMap {
     }
 }
 
+/// Check whether `field_value`, written against `target_field_name` on
+/// `target_def`, satisfies that field's `allowed_values` enum.
+///
+/// Returns `Some(ChangeKind::FieldValueConflict)` when the target field
+/// is enum-constrained and the value is out of the enum; `None`
+/// otherwise (field absent, not enum-constrained, or in-enum).
+///
+/// Shared by both the identity-named and the field-map-renamed paths in
+/// [`diff_artifacts`] so an out-of-enum value is flagged as a conflict
+/// regardless of whether the recipe renamed the field.
+fn enum_conflict_for(
+    target_def: &crate::schema::ArtifactTypeDef,
+    target_field_name: &str,
+    field_value: &serde_yaml::Value,
+    target_type_name: &str,
+) -> Option<ChangeKind> {
+    let target_field = target_def
+        .fields
+        .iter()
+        .find(|f| f.name == target_field_name)?;
+    let allowed = target_field.allowed_values.as_ref()?;
+    let current_value = yaml_value_as_display(field_value);
+    if allowed.iter().any(|v| v == &current_value) {
+        return None;
+    }
+    Some(ChangeKind::FieldValueConflict {
+        in_type: target_type_name.to_string(),
+        field: target_field_name.to_string(),
+        from_value: current_value,
+        target_constraint: format!("[{}]", allowed.join("|")),
+    })
+}
+
 /// Compute a [`RewriteMap`] from a recipe + the source artifacts.
 ///
 /// `target_schema` is consulted (when `Some`) to detect unmapped fields
@@ -471,6 +504,24 @@ pub fn diff_artifacts(
                         },
                     });
                 }
+                // The renamed value still has to satisfy the TARGET
+                // field's `allowed_values` enum. Without this check a
+                // value that is out-of-enum for the renamed-into field
+                // (e.g. `prio: 7` -> enum `priority`) would slip through
+                // as a clean mechanical rename. Run the same enum check
+                // the identity-named path below runs.
+                if let Some(target_def) = target_type_def {
+                    if let Some(change) =
+                        enum_conflict_for(target_def, target_name, field_value, &target_type_name)
+                    {
+                        changes.push(PlannedChange {
+                            artifact_id: artifact.id.clone(),
+                            source_file: source_file.clone(),
+                            action: ActionClass::Conflict,
+                            change,
+                        });
+                    }
+                }
                 continue;
             }
             // No explicit mapping. If we have a target schema, check
@@ -482,25 +533,15 @@ pub fn diff_artifacts(
             // unmapped-fields policy.
             if let Some(target_def) = target_type_def {
                 if target_field_names.contains(field_name) {
-                    if let Some(target_field) =
-                        target_def.fields.iter().find(|f| f.name == *field_name)
+                    if let Some(change) =
+                        enum_conflict_for(target_def, field_name, field_value, &target_type_name)
                     {
-                        if let Some(allowed) = &target_field.allowed_values {
-                            let current_value = yaml_value_as_display(field_value);
-                            if !allowed.iter().any(|v| v == &current_value) {
-                                changes.push(PlannedChange {
-                                    artifact_id: artifact.id.clone(),
-                                    source_file: source_file.clone(),
-                                    action: ActionClass::Conflict,
-                                    change: ChangeKind::FieldValueConflict {
-                                        in_type: target_type_name.clone(),
-                                        field: field_name.clone(),
-                                        from_value: current_value,
-                                        target_constraint: format!("[{}]", allowed.join("|")),
-                                    },
-                                });
-                            }
-                        }
+                        changes.push(PlannedChange {
+                            artifact_id: artifact.id.clone(),
+                            source_file: source_file.clone(),
+                            action: ActionClass::Conflict,
+                            change,
+                        });
                     }
                 } else {
                     let action = match recipe.policies.unmapped_fields {
@@ -573,8 +614,15 @@ pub fn apply_to_file(
         .and_then(|v| v.as_sequence_mut());
 
     let Some(artifacts) = artifacts else {
-        // No `artifacts:` key — nothing to do. Return original.
-        return Ok(original.to_string());
+        // No top-level `artifacts:` sequence — the recipe is pointed at a
+        // wrong-shaped file. Returning `Ok(original)` here would report
+        // success having migrated nothing (a silent failure); surface it
+        // as an error instead.
+        return Err(Error::Schema(format!(
+            "file has no top-level `artifacts:` sequence; \
+             cannot apply migration (expected a Rivet artifact YAML, found {})",
+            describe_yaml_shape(&doc)
+        )));
     };
 
     let type_map: BTreeMap<&str, &TypeRewrite> = recipe
@@ -776,6 +824,20 @@ pub fn yaml_value_as_display(v: &serde_yaml::Value) -> String {
             .unwrap_or_default()
             .trim_end()
             .to_string(),
+    }
+}
+
+/// Describe the top-level shape of a parsed YAML document, for
+/// diagnostics when a file does not have the expected `artifacts:`
+/// sequence.
+fn describe_yaml_shape(doc: &serde_yaml::Value) -> &'static str {
+    match doc {
+        serde_yaml::Value::Mapping(_) => "a mapping without an `artifacts` key",
+        serde_yaml::Value::Sequence(_) => "a bare sequence",
+        serde_yaml::Value::Null => "an empty document",
+        serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_) => "a scalar",
+        serde_yaml::Value::String(_) => "a string",
+        serde_yaml::Value::Tagged(_) => "a tagged value",
     }
 }
 
@@ -1635,6 +1697,158 @@ mod tests {
             assert_eq!(from_value, "5");
             assert!(target_constraint.contains("must"));
         }
+    }
+
+    /// Build a target schema where `sw-req` has an enum `priority`
+    /// field constrained to {must,should,could,wont}.
+    fn enum_priority_target() -> Schema {
+        let mut target = Schema {
+            artifact_types: std::collections::HashMap::new(),
+            link_types: std::collections::HashMap::new(),
+            inverse_map: std::collections::HashMap::new(),
+            traceability_rules: vec![],
+            conditional_rules: vec![],
+            validation_rules: vec![],
+        };
+        let sw_req = crate::schema::ArtifactTypeDef {
+            name: "sw-req".into(),
+            description: "".into(),
+            fields: vec![crate::schema::FieldDef {
+                name: "priority".into(),
+                field_type: "enum".into(),
+                required: false,
+                description: None,
+                allowed_values: Some(vec![
+                    "must".into(),
+                    "should".into(),
+                    "could".into(),
+                    "wont".into(),
+                ]),
+            }],
+            link_fields: vec![],
+            aspice_process: None,
+            common_mistakes: vec![],
+            example: None,
+            yaml_section: None,
+            yaml_sections: vec![],
+            yaml_section_suffix: None,
+            shorthand_links: BTreeMap::new(),
+        };
+        target.artifact_types.insert("sw-req".into(), sw_req);
+        target
+    }
+
+    /// A recipe whose `requirement -> sw-req` rewrite renames the field
+    /// `prio` to the enum-constrained target field `priority`.
+    fn recipe_renaming_prio_to_priority() -> MigrationRecipe {
+        let mut recipe = dev_to_aspice();
+        let mut field_map = BTreeMap::new();
+        field_map.insert("prio".to_string(), "priority".to_string());
+        recipe.type_rewrites[0].field_map = field_map;
+        recipe
+    }
+
+    /// REQ-080: a field-map-renamed value that is out-of-enum for the
+    /// renamed-into TARGET field must emit a `FieldValueConflict` — the
+    /// renamed path must not bypass the enum check.
+    #[test]
+    fn diff_field_map_rename_emits_conflict_for_out_of_enum_value() {
+        let target = enum_priority_target();
+        let recipe = recipe_renaming_prio_to_priority();
+
+        let mut a = artifact("REQ-001", "requirement");
+        // `prio: 7` is out of the target `priority` enum.
+        a.fields.insert(
+            "prio".into(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(7)),
+        );
+
+        let map = diff_artifacts(&recipe, &[a], Some(&target));
+
+        // The mechanical rename is still emitted.
+        let renames: Vec<&PlannedChange> = map
+            .changes
+            .iter()
+            .filter(|c| matches!(c.change, ChangeKind::FieldRename { .. }))
+            .collect();
+        assert_eq!(renames.len(), 1, "rename still emitted: {:?}", map.changes);
+
+        // And the out-of-enum value is flagged as a conflict on the
+        // RENAMED target field name.
+        let confs: Vec<&PlannedChange> = map
+            .changes
+            .iter()
+            .filter(|c| matches!(c.change, ChangeKind::FieldValueConflict { .. }))
+            .collect();
+        assert_eq!(
+            confs.len(),
+            1,
+            "renamed out-of-enum value must conflict: {:?}",
+            map.changes
+        );
+        assert_eq!(confs[0].action, ActionClass::Conflict);
+        assert!(map.has_conflicts(), "has_conflicts() must be true");
+        if let ChangeKind::FieldValueConflict {
+            field,
+            from_value,
+            target_constraint,
+            ..
+        } = &confs[0].change
+        {
+            assert_eq!(field, "priority", "conflict names the TARGET field");
+            assert_eq!(from_value, "7");
+            assert!(target_constraint.contains("must"));
+        }
+    }
+
+    /// REQ-080: an in-enum field-map-renamed value stays a clean
+    /// mechanical rename — no conflict.
+    #[test]
+    fn diff_field_map_rename_in_enum_value_is_clean_mechanical() {
+        let target = enum_priority_target();
+        let recipe = recipe_renaming_prio_to_priority();
+
+        let mut a = artifact("REQ-001", "requirement");
+        // `prio: should` is in the target `priority` enum.
+        a.fields
+            .insert("prio".into(), serde_yaml::Value::String("should".into()));
+
+        let map = diff_artifacts(&recipe, &[a], Some(&target));
+
+        assert!(
+            !map.has_conflicts(),
+            "in-enum renamed value must not conflict: {:?}",
+            map.changes
+        );
+        let renames: Vec<&PlannedChange> = map
+            .changes
+            .iter()
+            .filter(|c| matches!(c.change, ChangeKind::FieldRename { .. }))
+            .collect();
+        assert_eq!(
+            renames.len(),
+            1,
+            "clean mechanical rename: {:?}",
+            map.changes
+        );
+        assert_eq!(renames[0].action, ActionClass::Mechanical);
+    }
+
+    /// REQ-080 neighbour: `apply_to_file` on a YAML file lacking the
+    /// top-level `artifacts:` key must surface an error rather than
+    /// silently returning `Ok(original)` having migrated nothing.
+    #[test]
+    fn apply_to_file_errors_on_file_without_artifacts_key() {
+        let recipe = dev_to_aspice();
+        // A wrong-shaped file: a mapping with no `artifacts` key.
+        let original = "schema:\n  version: 1\n";
+        let err = apply_to_file(original, &[], &recipe)
+            .expect_err("must not silently report success on a wrong-shaped file");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("artifacts"),
+            "diagnostic should mention the missing `artifacts:` key: {msg}"
+        );
     }
 
     #[test]

--- a/rivet-core/src/reqif.rs
+++ b/rivet-core/src/reqif.rs
@@ -706,18 +706,39 @@ pub fn parse_reqif(xml: &str, type_map: &HashMap<String, String>) -> Result<Vec<
     }
 
     // Parse SPEC-OBJECTS into Artifacts.
+    //
+    // ReqIF 1.2's XSD makes `SPEC-OBJECT/TYPE` mandatory, and
+    // `docs/design/polarion-reqif-fidelity.md` lists `artifact_type` as
+    // LOSSLESS — there is no sanctioned unknown-type fallback. A SPEC-OBJECT
+    // with no `<TYPE>` element, or a `SPEC-OBJECT-TYPE-REF` pointing at an
+    // undeclared SPEC-OBJECT-TYPE, is collected into `untyped`; the whole
+    // import is rejected (mirrors the dangling-SPEC-RELATION block below)
+    // rather than silently typing the artifact `"unknown"`.
     let mut artifacts: Vec<Artifact> = Vec::new();
+    let mut untyped: Vec<String> = Vec::new();
     for obj in &content.spec_objects.objects {
-        let artifact_type = obj
-            .object_type_ref
-            .as_ref()
-            .and_then(|r| {
-                object_type_names
+        let artifact_type = match &obj.object_type_ref {
+            Some(r) => {
+                match object_type_names
                     .get(r.spec_object_type_ref.as_str())
                     .copied()
-            })
-            .unwrap_or("unknown")
-            .to_string();
+                {
+                    Some(name) => name.to_string(),
+                    None => {
+                        untyped.push(format!(
+                            "SPEC-OBJECT {} -> type {}",
+                            obj.identifier, r.spec_object_type_ref
+                        ));
+                        // Placeholder; the import is rejected after the loop.
+                        "unknown".to_string()
+                    }
+                }
+            }
+            None => {
+                untyped.push(format!("SPEC-OBJECT {} has no TYPE", obj.identifier));
+                "unknown".to_string()
+            }
+        };
 
         let mut status: Option<String> = None;
         let mut tags: Vec<String> = Vec::new();
@@ -890,6 +911,14 @@ pub fn parse_reqif(xml: &str, type_map: &HashMap<String, String>) -> Result<Vec<
         artifacts.push(artifact);
     }
 
+    if !untyped.is_empty() {
+        return Err(Error::Adapter(format!(
+            "ReqIF import rejected {} SPEC-OBJECT(s) with missing/dangling TYPE: {}",
+            untyped.len(),
+            untyped.join("; ")
+        )));
+    }
+
     // Build UUID -> resolved ID map (for StrictDoc where IDENTIFIER is a UUID
     // but we use ReqIF.ForeignID as the artifact ID).
     let uuid_to_id: HashMap<String, String> = content
@@ -915,18 +944,33 @@ pub fn parse_reqif(xml: &str, type_map: &HashMap<String, String>) -> Result<Vec<
     // existing SpecObject is collected into `dangling`; the whole import is
     // rejected if any are seen, rather than silently creating phantom Links
     // that would show up as broken edges in the LinkGraph.
+    //
+    // The relation's TYPE gets the same treatment: a missing `<TYPE>` or a
+    // `SPEC-RELATION-TYPE-REF` pointing at an undeclared SPEC-RELATION-TYPE is
+    // collected into `dangling` instead of silently falling back to
+    // `"traces-to"`, which would mislabel the link role.
     let mut dangling: Vec<String> = Vec::new();
     for rel in &content.spec_relations.relations {
-        let link_type = rel
-            .relation_type_ref
-            .as_ref()
-            .and_then(|r| {
-                relation_type_names
-                    .get(r.spec_relation_type_ref.as_str())
-                    .copied()
-            })
-            .unwrap_or("traces-to")
-            .to_string();
+        let link_type = match &rel.relation_type_ref {
+            Some(r) => match relation_type_names
+                .get(r.spec_relation_type_ref.as_str())
+                .copied()
+            {
+                Some(name) => name.to_string(),
+                None => {
+                    dangling.push(format!(
+                        "SPEC-RELATION {} -> type {} (undeclared SPEC-RELATION-TYPE)",
+                        rel.identifier, r.spec_relation_type_ref
+                    ));
+                    // Placeholder; the import is rejected after the loop.
+                    "traces-to".to_string()
+                }
+            },
+            None => {
+                dangling.push(format!("SPEC-RELATION {} has no TYPE", rel.identifier));
+                "traces-to".to_string()
+            }
+        };
 
         // Resolve UUID references to artifact IDs
         let source_id = uuid_to_id
@@ -966,7 +1010,7 @@ pub fn parse_reqif(xml: &str, type_map: &HashMap<String, String>) -> Result<Vec<
 
     if !dangling.is_empty() {
         return Err(Error::Adapter(format!(
-            "ReqIF import rejected {} dangling SPEC-RELATION target(s): {}",
+            "ReqIF import rejected {} dangling SPEC-RELATION reference(s): {}",
             dangling.len(),
             dangling.join("; ")
         )));
@@ -2155,6 +2199,7 @@ mod tests {
       <DATATYPES/>
       <SPEC-TYPES>
         <SPEC-OBJECT-TYPE IDENTIFIER="SOT-req" LONG-NAME="requirement"/>
+        <SPEC-RELATION-TYPE IDENTIFIER="SRT-traces-to" LONG-NAME="traces-to"/>
       </SPEC-TYPES>
       <SPEC-OBJECTS>
         <SPEC-OBJECT IDENTIFIER="R-1" LONG-NAME="Existing">
@@ -2163,6 +2208,7 @@ mod tests {
       </SPEC-OBJECTS>
       <SPEC-RELATIONS>
         <SPEC-RELATION IDENTIFIER="REL-1">
+          <TYPE><SPEC-RELATION-TYPE-REF>SRT-traces-to</SPEC-RELATION-TYPE-REF></TYPE>
           <SOURCE><SPEC-OBJECT-REF>MISSING-SRC</SPEC-OBJECT-REF></SOURCE>
           <TARGET><SPEC-OBJECT-REF>R-1</SPEC-OBJECT-REF></TARGET>
         </SPEC-RELATION>
@@ -2172,6 +2218,183 @@ mod tests {
 </REQ-IF>"#;
         let err = parse_reqif(xml, &HashMap::new()).expect_err("dangling source rejected");
         assert!(err.to_string().contains("MISSING-SRC"));
+    }
+
+    /// A SPEC-OBJECT with no `<TYPE>` element must be rejected — ReqIF 1.2's
+    /// XSD makes `SPEC-OBJECT/TYPE` mandatory, so silently typing the
+    /// artifact `"unknown"` (the old `unwrap_or` fallback) is a data-loss bug.
+    // rivet: verifies REQ-079
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_spec_object_without_type_rejected() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd">
+  <THE-HEADER>
+    <REQ-IF-HEADER IDENTIFIER="missing-type"/>
+  </THE-HEADER>
+  <CORE-CONTENT>
+    <REQ-IF-CONTENT>
+      <DATATYPES/>
+      <SPEC-TYPES>
+        <SPEC-OBJECT-TYPE IDENTIFIER="SOT-req" LONG-NAME="requirement"/>
+      </SPEC-TYPES>
+      <SPEC-OBJECTS>
+        <SPEC-OBJECT IDENTIFIER="R-NOTYPE" LONG-NAME="Untyped req"/>
+      </SPEC-OBJECTS>
+      <SPEC-RELATIONS/>
+    </REQ-IF-CONTENT>
+  </CORE-CONTENT>
+</REQ-IF>"#;
+
+        let err = parse_reqif(xml, &HashMap::new())
+            .expect_err("SPEC-OBJECT without TYPE should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("R-NOTYPE"),
+            "error should name the untyped SPEC-OBJECT: {msg}"
+        );
+        assert!(
+            msg.contains("no TYPE"),
+            "error should explain the TYPE is missing: {msg}"
+        );
+    }
+
+    /// A SPEC-OBJECT whose `SPEC-OBJECT-TYPE-REF` points at an undeclared
+    /// SPEC-OBJECT-TYPE must be rejected, naming both the object and the
+    /// dangling type ref — not silently typed `"unknown"`.
+    // rivet: verifies REQ-079
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_spec_object_dangling_type_ref_rejected() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd">
+  <THE-HEADER>
+    <REQ-IF-HEADER IDENTIFIER="dangling-type"/>
+  </THE-HEADER>
+  <CORE-CONTENT>
+    <REQ-IF-CONTENT>
+      <DATATYPES/>
+      <SPEC-TYPES>
+        <SPEC-OBJECT-TYPE IDENTIFIER="SOT-req" LONG-NAME="requirement"/>
+      </SPEC-TYPES>
+      <SPEC-OBJECTS>
+        <SPEC-OBJECT IDENTIFIER="R-BADTYPE" LONG-NAME="Bad-typed req">
+          <TYPE><SPEC-OBJECT-TYPE-REF>SOT-DOES-NOT-EXIST</SPEC-OBJECT-TYPE-REF></TYPE>
+        </SPEC-OBJECT>
+      </SPEC-OBJECTS>
+      <SPEC-RELATIONS/>
+    </REQ-IF-CONTENT>
+  </CORE-CONTENT>
+</REQ-IF>"#;
+
+        let err = parse_reqif(xml, &HashMap::new())
+            .expect_err("dangling SPEC-OBJECT-TYPE-REF should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("R-BADTYPE"),
+            "error should name the SPEC-OBJECT: {msg}"
+        );
+        assert!(
+            msg.contains("SOT-DOES-NOT-EXIST"),
+            "error should name the dangling type ref: {msg}"
+        );
+    }
+
+    /// A SPEC-RELATION whose `SPEC-RELATION-TYPE-REF` points at an undeclared
+    /// SPEC-RELATION-TYPE must be rejected rather than silently falling back
+    /// to the `"traces-to"` link role.
+    // rivet: verifies REQ-079
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_spec_relation_dangling_type_ref_rejected() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd">
+  <THE-HEADER>
+    <REQ-IF-HEADER IDENTIFIER="rel-bad-type"/>
+  </THE-HEADER>
+  <CORE-CONTENT>
+    <REQ-IF-CONTENT>
+      <DATATYPES/>
+      <SPEC-TYPES>
+        <SPEC-OBJECT-TYPE IDENTIFIER="SOT-req" LONG-NAME="requirement"/>
+      </SPEC-TYPES>
+      <SPEC-OBJECTS>
+        <SPEC-OBJECT IDENTIFIER="R-1" LONG-NAME="Source req">
+          <TYPE><SPEC-OBJECT-TYPE-REF>SOT-req</SPEC-OBJECT-TYPE-REF></TYPE>
+        </SPEC-OBJECT>
+        <SPEC-OBJECT IDENTIFIER="R-2" LONG-NAME="Target req">
+          <TYPE><SPEC-OBJECT-TYPE-REF>SOT-req</SPEC-OBJECT-TYPE-REF></TYPE>
+        </SPEC-OBJECT>
+      </SPEC-OBJECTS>
+      <SPEC-RELATIONS>
+        <SPEC-RELATION IDENTIFIER="REL-1">
+          <TYPE><SPEC-RELATION-TYPE-REF>SRT-DOES-NOT-EXIST</SPEC-RELATION-TYPE-REF></TYPE>
+          <SOURCE><SPEC-OBJECT-REF>R-1</SPEC-OBJECT-REF></SOURCE>
+          <TARGET><SPEC-OBJECT-REF>R-2</SPEC-OBJECT-REF></TARGET>
+        </SPEC-RELATION>
+      </SPEC-RELATIONS>
+    </REQ-IF-CONTENT>
+  </CORE-CONTENT>
+</REQ-IF>"#;
+
+        let err = parse_reqif(xml, &HashMap::new())
+            .expect_err("dangling SPEC-RELATION-TYPE-REF should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("REL-1"),
+            "error should name the SPEC-RELATION: {msg}"
+        );
+        assert!(
+            msg.contains("SRT-DOES-NOT-EXIST"),
+            "error should name the dangling type ref: {msg}"
+        );
+    }
+
+    /// A well-formed ReqIF — every SPEC-OBJECT and SPEC-RELATION carries a
+    /// `<TYPE>` resolving to a declared type — still imports cleanly. Guards
+    /// against the REQ-079 rejection over-firing on valid input.
+    // rivet: verifies REQ-079
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_well_formed_reqif_with_types_imports_ok() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd">
+  <THE-HEADER>
+    <REQ-IF-HEADER IDENTIFIER="well-formed"/>
+  </THE-HEADER>
+  <CORE-CONTENT>
+    <REQ-IF-CONTENT>
+      <DATATYPES/>
+      <SPEC-TYPES>
+        <SPEC-OBJECT-TYPE IDENTIFIER="SOT-req" LONG-NAME="requirement"/>
+        <SPEC-RELATION-TYPE IDENTIFIER="SRT-traces-to" LONG-NAME="traces-to"/>
+      </SPEC-TYPES>
+      <SPEC-OBJECTS>
+        <SPEC-OBJECT IDENTIFIER="R-1" LONG-NAME="Source req">
+          <TYPE><SPEC-OBJECT-TYPE-REF>SOT-req</SPEC-OBJECT-TYPE-REF></TYPE>
+        </SPEC-OBJECT>
+        <SPEC-OBJECT IDENTIFIER="R-2" LONG-NAME="Target req">
+          <TYPE><SPEC-OBJECT-TYPE-REF>SOT-req</SPEC-OBJECT-TYPE-REF></TYPE>
+        </SPEC-OBJECT>
+      </SPEC-OBJECTS>
+      <SPEC-RELATIONS>
+        <SPEC-RELATION IDENTIFIER="REL-1">
+          <TYPE><SPEC-RELATION-TYPE-REF>SRT-traces-to</SPEC-RELATION-TYPE-REF></TYPE>
+          <SOURCE><SPEC-OBJECT-REF>R-1</SPEC-OBJECT-REF></SOURCE>
+          <TARGET><SPEC-OBJECT-REF>R-2</SPEC-OBJECT-REF></TARGET>
+        </SPEC-RELATION>
+      </SPEC-RELATIONS>
+    </REQ-IF-CONTENT>
+  </CORE-CONTENT>
+</REQ-IF>"#;
+
+        let arts = parse_reqif(xml, &HashMap::new())
+            .expect("well-formed ReqIF with types should import cleanly");
+        assert_eq!(arts.len(), 2);
+        assert_eq!(arts[0].artifact_type, "requirement");
+        assert_eq!(arts[0].links.len(), 1, "the traces-to link should survive");
+        assert_eq!(arts[0].links[0].link_type, "traces-to");
+        assert_eq!(arts[0].links[0].target, "R-2");
     }
 
     /// Legacy comma-joined tags (from older rivet exports or other tools)

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -519,6 +519,18 @@ fn link_satisfies_field(actual: &str, required: &str) -> bool {
             .is_some_and(|base| base == required)
 }
 
+/// An artifact whose ID is `prefix:ID`-qualified was loaded from a linked
+/// external project (`rivet sync`), present in the store ONLY so the
+/// consumer's `prefix:ID` cross-links resolve. It must NOT be subjected to
+/// the consumer's own per-artifact validation — that is the supplier's
+/// gate, surfaced opt-in via `rivet validate --with-externals-validate`
+/// (REQ-065 / AoU-X1). Every per-artifact diagnostic pass skips these
+/// (REQ-082). The broken-link check is unaffected — it reads `graph`,
+/// which is built from the full store, so cross-links still resolve.
+fn is_external_artifact(artifact: &crate::model::Artifact) -> bool {
+    artifact.id.contains(':')
+}
+
 /// Structural validation only (phases 1-7).
 ///
 /// Validates types, required fields, allowed values, link cardinality,
@@ -577,6 +589,11 @@ pub fn validate_structural_with_externals_and_variant(
 
     // 1. Check that every artifact has a known type
     for artifact in store.iter() {
+        // REQ-082: external (prefixed) artifacts are present only for
+        // cross-link resolution — do not validate the supplier's project.
+        if is_external_artifact(artifact) {
+            continue;
+        }
         let type_def = match lookup_type(artifact, schema, externals) {
             TypeLookup::Found(td) => td,
             TypeLookup::Unknown => {
@@ -922,6 +939,10 @@ pub fn validate_structural_with_externals_and_variant(
     use std::collections::BTreeSet;
     let known_link_types: BTreeSet<&str> = schema.link_types.keys().map(String::as_str).collect();
     for artifact in store.iter() {
+        // REQ-082: skip external (prefixed) artifacts — supplier's gate.
+        if is_external_artifact(artifact) {
+            continue;
+        }
         let (ext_prefix, ext_known): (Option<&str>, BTreeSet<&str>) =
             match artifact.id.split_once(':') {
                 Some((prefix, _)) => match externals.get(prefix) {
@@ -981,6 +1002,10 @@ pub fn validate_structural_with_externals_and_variant(
 
     // 9. Check unknown fields (not defined in schema for this artifact type)
     for artifact in store.iter() {
+        // REQ-082: skip external (prefixed) artifacts — supplier's gate.
+        if is_external_artifact(artifact) {
+            continue;
+        }
         if let Some(type_def) = schema.artifact_type(&artifact.artifact_type) {
             let known_fields: std::collections::HashSet<&str> =
                 type_def.fields.iter().map(|f| f.name.as_str()).collect();
@@ -1024,6 +1049,10 @@ pub fn validate_structural_with_externals_and_variant(
     // unknown-link-type pass's per-(artifact, link-type) policy.
     // (BTreeSet is already imported at the top of pass 8 above.)
     for artifact in store.iter() {
+        // REQ-082: skip external (prefixed) artifacts — supplier's gate.
+        if is_external_artifact(artifact) {
+            continue;
+        }
         let linked_targets: BTreeSet<&str> =
             artifact.links.iter().map(|l| l.target.as_str()).collect();
         let mut warned: BTreeSet<String> = BTreeSet::new();
@@ -1242,6 +1271,10 @@ pub fn validate_variants(
     let known_sorted: Vec<&str> = known_variants.iter().map(String::as_str).collect();
 
     for artifact in store.iter() {
+        // REQ-082: skip external (prefixed) artifacts — supplier's gate.
+        if is_external_artifact(artifact) {
+            continue;
+        }
         // ── 1. variant-key cross-check ──────────────────────────────
         for variant_key in artifact.fields_per_variant.keys() {
             if !known_variants.contains(variant_key) {

--- a/rivet-core/tests/commits_integration.rs
+++ b/rivet-core/tests/commits_integration.rs
@@ -44,6 +44,7 @@ fn make_commit(
         date: "2025-06-01T00:00:00+00:00".into(),
         commit_type: rivet_core::commits::parse_commit_type(subject),
         artifact_refs,
+        malformed_refs: Vec::new(),
         changed_files,
         has_skip_trailer,
     }

--- a/rivet-core/tests/externals_schemas.rs
+++ b/rivet-core/tests/externals_schemas.rs
@@ -10,19 +10,25 @@
     clippy::print_stderr
 )]
 
-//! Integration tests for issue #245: externals must load their own schemas
-//! so externally-prefixed artifacts type-check against the schemas they were
-//! authored under, not the downstream's.
+//! Integration tests for externally-prefixed artifact validation.
 //!
-//! Without this fix, sigil's repro produces 326 `unknown artifact type`
-//! ERRORs on synth-prefixed artifacts (types defined in synth's schemas
-//! but not in sigil's). After the fix, those errors collapse to zero.
+//! Issue #245 originally type-checked externally-prefixed artifacts against
+//! the external's own schema (loaded via the external loader) so a consumer
+//! whose schema set differs from the supplier's would not see spurious
+//! `unknown artifact type` ERRORs. REQ-082 (v0.11.1) supersedes that: a
+//! consumer's default `rivet validate` gate must reflect only the consumer's
+//! own artifacts, so externally-prefixed artifacts are skipped by every
+//! per-artifact validation pass entirely — they are loaded ONLY so the
+//! consumer's `prefix:ID` cross-links resolve. The external's own
+//! diagnostics are opt-in via `rivet validate --with-externals-validate`
+//! (REQ-065 / AoU-X1). The external-loader half (`load_all_externals`
+//! surfacing the supplier's schema) is still exercised here — that loader
+//! feeds `--with-externals-validate`.
 
 use rivet_core::externals::{load_all_externals, load_external_project};
 use rivet_core::links::LinkGraph;
 use rivet_core::model::ExternalProject;
 use rivet_core::model::{Artifact, Link};
-use rivet_core::schema::Severity;
 use rivet_core::store::Store;
 use rivet_core::validate::{ExternalSchemas, validate_with_externals};
 use std::collections::BTreeMap;
@@ -36,26 +42,27 @@ fn spar_fixture_dir() -> PathBuf {
         .join("spar-external")
 }
 
-/// Simulates the sigil-loading-synth scenario. Downstream declares only
-/// `common`; the external declares `common + aadl`. Before this fix, the
-/// downstream's validator produced an ERROR for every synth-prefixed
-/// `aadl-component` artifact. With the fix, the external's schema resolves
-/// the type and the validator stays silent.
+/// REQ-082 supersedes the issue-#245 design this test originally pinned.
+/// #245 type-checked externally-prefixed artifacts against the external's
+/// own schema to suppress spurious `unknown artifact type` ERRORs. REQ-082
+/// goes further: externally-prefixed (`spar:`) artifacts are loaded only so
+/// the consumer's cross-links resolve, and are skipped by the schema
+/// per-artifact passes (type, fields, link-type, shorthand, variant-key) —
+/// the supplier's project is the supplier's gate
+/// (`--with-externals-validate` / AoU-X1). So a `spar:`-prefixed
+/// `aadl-component` produces NO `known-type` diagnostic whether or not the
+/// external's schema is registered.
 ///
-/// rivet: verifies REQ-007
+/// (Cross-link integrity — the `broken-link` pass — deliberately still runs
+/// over the full store so consumer→external links resolve; that pass is not
+/// a schema check and is out of scope here. The CLI's REQ-082 filter drops
+/// any residual prefixed-artifact diagnostics before the gate count.)
+///
+/// rivet: verifies REQ-082
 #[test]
-fn external_schemas_eliminate_spurious_unknown_type_errors() {
+fn external_prefixed_artifacts_skip_type_checking() {
     let fixture = spar_fixture_dir();
     let (artifacts, ext_schema) = load_external_project(&fixture).unwrap();
-    assert!(
-        ext_schema.is_some(),
-        "spar fixture declares schemas; loader must surface them"
-    );
-    let ext_schema = ext_schema.unwrap();
-    assert!(
-        ext_schema.artifact_type("aadl-component").is_some(),
-        "fixture's aadl schema declares 'aadl-component'"
-    );
 
     // Build a downstream-shaped store: simulate prefixing with `spar:`.
     let mut store = Store::new();
@@ -64,8 +71,8 @@ fn external_schemas_eliminate_spurious_unknown_type_errors() {
         store.upsert(a);
     }
 
-    // Downstream's own schema declares only `common`. `aadl-component` is
-    // NOT in it — exactly the sigil scenario.
+    // Downstream's own schema declares only `common`; `aadl-component` is
+    // NOT in it — pre-REQ-082 this produced an ERROR per spar artifact.
     let downstream_schema = rivet_core::load_schemas(
         &["common".to_string()],
         &PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../schemas"),
@@ -73,57 +80,49 @@ fn external_schemas_eliminate_spurious_unknown_type_errors() {
     .expect("loading downstream-only schemas");
     assert!(
         downstream_schema.artifact_type("aadl-component").is_none(),
-        "downstream-only schema must NOT declare 'aadl-component' for the test \
-         to be meaningful (the fix removes spurious errors)"
+        "downstream-only schema must NOT declare 'aadl-component' for the \
+         test to be meaningful"
     );
-
     let graph = LinkGraph::build(&store, &downstream_schema);
 
-    let aadl_count = |diags: &[rivet_core::validate::Diagnostic]| -> usize {
+    // Every per-artifact diagnostic pass skips prefixed artifacts under
+    // REQ-082. The graph-level `broken-link` pass is deliberately exempt
+    // (it reads the full store so consumer→external links resolve), so it
+    // is carved out here — the test asserts on the per-artifact passes.
+    let schema_diags = |diags: &[rivet_core::validate::Diagnostic]| -> Vec<(String, String)> {
         diags
             .iter()
             .filter(|d| {
-                d.rule == "known-type"
-                    && d.severity == Severity::Error
-                    && d.artifact_id
-                        .as_deref()
-                        .is_some_and(|id| id.starts_with("spar:"))
-                    && d.message.contains("aadl-component")
+                d.artifact_id
+                    .as_deref()
+                    .is_some_and(|id| id.starts_with("spar:"))
+                    && d.rule != "broken-link"
             })
-            .count()
+            .map(|d| (d.rule.clone(), d.message.clone()))
+            .collect()
     };
 
-    // 1) Externals-unaware validation reproduces the bug: every spar-prefixed
-    //    `aadl-component` artifact yields an `unknown artifact type` ERROR.
-    let baseline =
+    // REQ-082: with NO external schema registered, spar-prefixed artifacts
+    // produce zero per-artifact diagnostics — they are skipped, not checked.
+    let no_ext =
         validate_with_externals(&store, &downstream_schema, &graph, &ExternalSchemas::new());
-    assert!(
-        aadl_count(&baseline) > 0,
-        "without the fix, externally-prefixed aadl-component artifacts must \
-         generate 'unknown artifact type' ERRORs — this baseline pins the \
-         pre-fix behaviour. all diags: {:?}",
-        baseline.iter().map(|d| &d.message).collect::<Vec<_>>()
+    assert_eq!(
+        schema_diags(&no_ext),
+        Vec::<(String, String)>::new(),
+        "REQ-082: externally-prefixed artifacts must produce no schema \
+         per-artifact diagnostics even with no external schema registered"
     );
 
-    // 2) With the external's own schema in the per-prefix map, those errors
-    //    must not appear. Other unrelated diagnostics may remain (e.g. the
-    //    spar fixture has a `requirement` artifact whose type is declared in
-    //    `dev.yaml`, which neither the downstream nor the external loaded);
-    //    we only assert on the AC-relevant aadl-component path.
+    // Registering the external's own schema changes nothing — prefixed
+    // artifacts are skipped regardless.
     let mut externals = ExternalSchemas::new();
-    externals.insert("spar".to_string(), Some(ext_schema));
-    let fixed = validate_with_externals(&store, &downstream_schema, &graph, &externals);
+    externals.insert("spar".to_string(), ext_schema);
+    let with_ext = validate_with_externals(&store, &downstream_schema, &graph, &externals);
     assert_eq!(
-        aadl_count(&fixed),
-        0,
-        "with the external's schema registered, externally-prefixed \
-         aadl-component artifacts must NOT generate 'unknown artifact type' \
-         ERRORs. still seeing: {:?}",
-        fixed
-            .iter()
-            .filter(|d| d.rule == "known-type")
-            .map(|d| (&d.artifact_id, &d.message))
-            .collect::<Vec<_>>()
+        schema_diags(&with_ext),
+        Vec::<(String, String)>::new(),
+        "REQ-082: registering the external's schema must not resurrect \
+         schema per-artifact diagnostics on prefixed artifacts"
     );
 }
 
@@ -165,18 +164,17 @@ fn load_all_externals_populates_schema() {
     );
 }
 
-/// Permissive-fallback: when an external is registered with `schema: None`
-/// (because its `rivet.yaml` declared no schemas, or its schemas failed to
-/// load), unknown-type findings for that prefix get demoted from ERROR to
-/// INFO so the downstream isn't spammed by an external it cannot type-check.
+/// REQ-082: a `prefix:`-qualified external artifact whose type the consumer
+/// cannot resolve produces NO `known-type` diagnostic at all — not ERROR,
+/// not the issue-#245 INFO demote. The supplier's types are the supplier's
+/// concern (AoU-X1); the consumer only loads external artifacts so its own
+/// `prefix:ID` cross-links resolve. Registration state of the prefix in
+/// `ExternalSchemas` is irrelevant — prefixed artifacts are skipped before
+/// the type check runs.
 ///
-/// rivet: verifies REQ-007
+/// rivet: verifies REQ-082
 #[test]
-fn external_without_schema_demotes_unknown_type_to_info() {
-    // Synthetic store: one artifact with a prefix whose external has no
-    // schema. We do not need any artifacts on disk for this — the
-    // permissive-fallback path is purely about `ExternalSchemas[prefix] ==
-    // None` triggering the demote.
+fn external_prefixed_unknown_type_is_not_diagnosed() {
     let mut store = Store::new();
     store.upsert(Artifact {
         id: "supplier:THING-1".to_string(),
@@ -199,45 +197,45 @@ fn external_without_schema_demotes_unknown_type_to_info() {
     .unwrap();
     let graph = LinkGraph::build(&store, &downstream_schema);
 
-    // Unknown to downstream → ERROR (sanity: no externals registered).
-    let baseline =
+    let known_type_diags = |diags: &[rivet_core::validate::Diagnostic]| -> usize {
+        diags
+            .iter()
+            .filter(|d| {
+                d.rule == "known-type" && d.artifact_id.as_deref() == Some("supplier:THING-1")
+            })
+            .count()
+    };
+
+    // No externals registered: still zero — the artifact is prefixed, so
+    // REQ-082 skips it before the type check.
+    let no_ext =
         validate_with_externals(&store, &downstream_schema, &graph, &ExternalSchemas::new());
-    assert!(
-        baseline.iter().any(|d| d.rule == "known-type"
-            && d.severity == Severity::Error
-            && d.artifact_id.as_deref() == Some("supplier:THING-1")),
-        "baseline must emit unknown-type ERROR when no externals registered"
+    assert_eq!(
+        known_type_diags(&no_ext),
+        0,
+        "REQ-082: a prefixed external artifact must produce no known-type \
+         diagnostic even with no ExternalSchemas registered"
     );
 
-    // Register the prefix with `None` schema → demote to INFO.
+    // Prefix registered with `None` schema: unchanged — still zero.
     let mut externals = ExternalSchemas::new();
     externals.insert("supplier".to_string(), None);
-    let demoted = validate_with_externals(&store, &downstream_schema, &graph, &externals);
-    let unknown_type: Vec<_> = demoted
-        .iter()
-        .filter(|d| d.rule == "known-type" && d.artifact_id.as_deref() == Some("supplier:THING-1"))
-        .collect();
+    let with_none = validate_with_externals(&store, &downstream_schema, &graph, &externals);
     assert_eq!(
-        unknown_type.len(),
-        1,
-        "expected exactly one known-type diagnostic for supplier:THING-1"
-    );
-    assert_eq!(
-        unknown_type[0].severity,
-        Severity::Info,
-        "with no schema registered for the prefix, unknown-type must be INFO, not ERROR"
-    );
-    assert!(
-        unknown_type[0].message.contains("supplier"),
-        "INFO message should name the external prefix"
+        known_type_diags(&with_none),
+        0,
+        "REQ-082: registering the prefix must not resurrect a known-type \
+         diagnostic on a prefixed external artifact"
     );
 }
 
-/// Unknown-link-type symmetry: a link type defined in the external's schema
-/// but not the downstream's must NOT be flagged for externally-prefixed
-/// artifacts. The fallback (no external schema) demotes to INFO.
+/// REQ-082 link-type symmetry: an externally-prefixed artifact is skipped by
+/// the per-artifact unknown-link-type pass exactly as it is by the type-check
+/// pass, so a link type the consumer's schema does not declare is never
+/// flagged on a `prefix:`-qualified artifact — with or without the prefix
+/// registered in `ExternalSchemas`.
 ///
-/// rivet: verifies REQ-007
+/// rivet: verifies REQ-082
 #[test]
 fn external_link_types_are_not_flagged_unknown() {
     // Synthetic store: external artifact whose link uses a link-type
@@ -270,24 +268,33 @@ fn external_link_types_are_not_flagged_unknown() {
     .unwrap();
     let graph = LinkGraph::build(&store, &downstream_schema);
 
-    // Permissive fallback: prefix registered with no schema.
+    let link_type_diags = |diags: &[rivet_core::validate::Diagnostic]| -> usize {
+        diags
+            .iter()
+            .filter(|d| {
+                d.rule == "unknown-link-type" && d.artifact_id.as_deref() == Some("spar:SPAR-X-001")
+            })
+            .count()
+    };
+
+    // No externals registered.
+    let no_ext =
+        validate_with_externals(&store, &downstream_schema, &graph, &ExternalSchemas::new());
+    assert_eq!(
+        link_type_diags(&no_ext),
+        0,
+        "REQ-082: a prefixed external artifact must produce no \
+         unknown-link-type diagnostic even with no ExternalSchemas registered"
+    );
+
+    // Prefix registered with no schema — unchanged.
     let mut externals = ExternalSchemas::new();
     externals.insert("spar".to_string(), None);
-    let diags = validate_with_externals(&store, &downstream_schema, &graph, &externals);
-    let link_type_diags: Vec<_> = diags
-        .iter()
-        .filter(|d| {
-            d.rule == "unknown-link-type" && d.artifact_id.as_deref() == Some("spar:SPAR-X-001")
-        })
-        .collect();
-    // If `implements` is in the downstream `common` schema, there will be
-    // zero diagnostics. Otherwise, the demoted-to-INFO path should fire.
-    for d in &link_type_diags {
-        assert_eq!(
-            d.severity,
-            Severity::Info,
-            "any unknown-link-type for an externally-prefixed artifact whose \
-             external has no schema must be INFO, not ERROR. got: {d:?}",
-        );
-    }
+    let with_none = validate_with_externals(&store, &downstream_schema, &graph, &externals);
+    assert_eq!(
+        link_type_diags(&with_none),
+        0,
+        "REQ-082: registering the prefix must not resurrect an \
+         unknown-link-type diagnostic on a prefixed external artifact"
+    );
 }

--- a/rivet-core/tests/stpa_sec_verification.rs
+++ b/rivet-core/tests/stpa_sec_verification.rs
@@ -162,6 +162,7 @@ fn make_commit(
         date: "2025-06-01T00:00:00+00:00".into(),
         commit_type: parse_commit_type(subject),
         artifact_refs,
+        malformed_refs: Vec::new(),
         changed_files,
         has_skip_trailer,
     }

--- a/scripts/mythos/HOWTO.md
+++ b/scripts/mythos/HOWTO.md
@@ -31,6 +31,17 @@ One of:
 - Code path with no commit trailer (`Implements:` / `Refs:` / `Fixes:` /
   `Verifies:`) and no artifact that references it by path — i.e. the code
   drifted from the spec or was never traced to one.
+- **Silent-failure slop** — a path that reports success (`PASS`, exit 0,
+  empty `diagnostics`, a silently-dropped record) over a degraded input
+  it should have rejected. The Cederqvist cliff: textual success over a
+  semantically-failed operation. Surfaced by the 2026-05-19 cross-git
+  investigation (FEAT-135, REQ-062..REQ-076). Hunted by the variant
+  prompt `discover-silent-failure.md` with the **degraded-input
+  oracle** (construct a malformed/duplicate/ambiguous input, show the
+  command passes anyway) rather than the excision oracle. Run that
+  prompt against ingest / parse / count / merge / check surfaces;
+  the cross-git fixes already cleared validate/load/supplier, so hunt
+  the OTHER subsystems (import, migrate, coverage, stamp, export, mcp).
 
 ## Prerequisites
 

--- a/scripts/mythos/discover-silent-failure.md
+++ b/scripts/mythos/discover-silent-failure.md
@@ -1,0 +1,126 @@
+Please find a piece of **silent-failure slop** in this program.
+
+This is a variant of the Mythos slop hunt (see `HOWTO.md`). The standard
+`discover.md` hunts *reachability* slop — code that can be excised
+because nothing exercises it. This prompt hunts a different class,
+surfaced by the 2026-05-19 cross-git investigation (FEAT-135): code that
+**reports success over an input it should have rejected**.
+
+## What silent-failure slop is
+
+A code path where a degraded input — malformed, duplicate, ambiguous,
+truncated, missing, or out-of-range — produces a SUCCESS result
+(`PASS`, exit 0, an empty `diagnostics` array, a silently-dropped
+record) instead of surfacing the problem. The Cederqvist cliff: the
+tool reports textual success over a semantically-failed operation.
+
+The cross-git investigation found six instances in the validate / load /
+supplier subsystems and they shipped as REQ-062..REQ-076:
+- `rivet validate` reported `PASS` over artifact files that failed to
+  parse (the skip was a stderr `log::warn!`, uncounted) — REQ-062.
+- two artifacts with the same `id` collapsed via `Store::upsert`
+  last-write-wins, no diagnostic — REQ-075.
+- orphan artifacts (no links) were invisible to `rivet validate` —
+  REQ-076.
+- `rivet supplier pull` silently overwrote the cache on sha256 drift —
+  REQ-068.
+- `rivet init --preset <safety-standard>` produced an unvalidatable
+  project, exit 0 — REQ-063.
+
+Those subsystems are now fixed. **Hunt elsewhere.** Your job: find the
+NEXT one, in `{{file}}`.
+
+## The tell-tale code patterns (priors, not proof)
+
+Rank a path as a silent-failure candidate when you see:
+- an error or `Result::Err` discarded — `let _ = ...`, `.ok()`,
+  `unwrap_or_default()`, `unwrap_or(...)`, `if let Ok(..)` with no
+  `else`, `.map_err(|e| log::warn!(...))` then drop;
+- a loop that `continue`s past a bad element without recording it;
+- a `match` with `_ => {}` / `_ => Ok(())` on a validation or parse arm;
+- "update-or-insert" / last-write-wins on a keyed collection with no
+  collision check (`upsert`, `insert` over an existing key, `HashMap`
+  overwrite);
+- a count or status computed from a *post-degradation* view (e.g.
+  counting survivors after a silent drop, so the count looks clean);
+- a `--format json` field that omits a problem the text path mentions
+  only on stderr, or vice versa.
+
+A prior is not a finding. Leniency is sometimes correct (genuinely
+optional fields, documented best-effort paths). You must construct the
+degraded input and *show* the wrong silence.
+
+## Oracle — the degraded-input oracle
+
+Slop is **confirmed** when you can exhibit all three:
+
+1. **A degraded input.** Construct a concrete, minimal input that a
+   careful tool should reject or flag — and write down, in one
+   sentence, the invariant it violates (a stated rule in
+   `docs/`, a schema constraint, "two things claim one ID", "the
+   bytes changed", "the file did not parse"). If you cannot name the
+   violated invariant, it is not slop — stop.
+
+2. **A success result over it.** Run the relevant `rivet` command (or
+   call the function in a throwaway test) on the degraded input and
+   show it returns success: exit 0, `result: PASS`, an empty / clean
+   `diagnostics`, or a silently-mutated-but-unreported state. Paste the
+   verbatim output.
+
+3. **The contrast.** Show what a correct tool would do — name the
+   diagnostic `rule` it should emit, or the non-zero exit it should
+   give. If `rivet` already has a sibling check that DOES catch an
+   analogous degradation (e.g. `cited-source-drift` catches file
+   drift), cite it as the precedent the gap should match.
+
+If you cannot produce all three, do not report. Hallucinated
+silent-failure findings are more expensive than silence.
+
+## Procedure
+
+1. Read `{{file}}`. Identify every spot where it ingests, parses,
+   counts, merges, or checks something — those are the candidate
+   surfaces. Note the tell-tale patterns above.
+
+2. For the strongest candidate, design the degraded input. Prefer the
+   smallest possible: one malformed field, one duplicate key, one
+   out-of-range value, one truncated record.
+
+3. Exhibit the success result. Two ways, pick whichever is sound:
+   - **End-to-end**: build a temp project / input file and run the
+     real `rivet` subcommand. Best evidence.
+   - **Unit-level**: a throwaway `#[test]` calling the function
+     directly with the degraded input, asserting the (wrong) success.
+   Build with `--target-dir /tmp/mythos-sf-build` to dodge the
+   environment's default-target flakiness.
+
+4. Confirm the silence is *wrong*, not *intended*. Search `docs/`,
+   the schema, and `artifacts/` for a stated invariant the degraded
+   input violates. If the leniency is documented as intentional,
+   the finding is `no-slop (intended leniency)` — report that
+   truthfully.
+
+5. Classify the fix size — this drives the release decision:
+   - `SMALL` — a localized fix: add a diagnostic, change a `_ => {}`
+     to an error arm, count what was dropped. (→ patch-release
+     material.)
+   - `LARGE` — needs a new flag, a new diagnostic rule wired through
+     multiple layers, an architectural change, or it interacts with
+     other subsystems. (→ minor-release material.)
+
+## Output format
+
+- `TARGET_FILE:` {{file}}
+- `SURFACE:` the function / code path that ingests or checks
+- `CLASS:` silent-failure-slop | no-slop (intended leniency) |
+  no-slop (already-diagnosed)
+- `VIOLATED_INVARIANT:` one sentence — what rule the degraded input breaks
+- `DEGRADED_INPUT:` fenced block — the exact malformed input
+- `SUCCESS_RESULT:` fenced block — verbatim output showing the wrong PASS
+- `CORRECT_BEHAVIOUR:` what should happen — the diagnostic `rule` or
+  non-zero exit; cite a sibling check if one exists
+- `VERDICT:` slop-confirmed | no-slop
+- `FIX_SIZE:` SMALL | LARGE — with one sentence of why
+- `PROPOSED_FIX:` 2-4 sentences — the concrete change
+- `NOTES:` anything unexpected, especially a second silent-failure in
+  a neighbouring file you noticed while constructing the input

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

v0.11.1 — a patch release shipping the five fixes from the post-v0.11.0
**Mythos silent-failure hunt**. After v0.11.0 closed the cross-git
investigation (FEAT-135), `scripts/mythos/` was re-run with a new
degraded-input oracle (`discover-silent-failure.md`) targeting the F2
silent-failure class across the ingest/parse subsystems the FEAT-135
waves did not cover. Four discovery agents → four confirmed findings;
in every case the subsystem already had a sibling check doing the right
thing and one code path that forgot to. A fifth fix (REQ-082) addresses
a user-reported v0.11.0 regression.

Findings filed as typed Rivet artifacts in
`artifacts/mythos-silent-failure-findings.yaml` (REQ-078..082, each with
an executable Acceptance block, `derives-from FEAT-135`).

### Fixes

- **REQ-078** `rivet commits` — malformed/typo'd artifact trailers
  (`Implements: REQ-O1`) were silently classed as benign orphans; now
  flagged as broken references.
- **REQ-079** ReqIF import — a SPEC-OBJECT with missing/dangling `<TYPE>`
  was silently typed `unknown`; import now rejected naming the object.
- **REQ-080** Schema migration — field-map-renamed fields skipped the
  enum value-check; the renamed path now hits the conflict path.
- **REQ-081** `needs.json` import — duplicate artifact IDs silently
  collided; importer now rejects, reusing REQ-075's `detect_duplicate_ids`.
- **REQ-082** `rivet validate` — linked external repos' own schema
  violations were counted against the consumer's gate (user-reported,
  ~5800 spurious errors after `rivet sync`). External (`prefix:`)
  artifacts now stay in the store only so cross-links resolve; every
  per-artifact validation pass skips them. `--with-externals-validate`
  remains the opt-in path for the supplier's diagnostics (AoU-X1).

Patch-shaped: localized fixes, no new flags, no schema change.

## Test plan

- [ ] `cargo test --workspace` green (full suite passed locally)
- [ ] `cargo clippy --workspace --all-targets` — no new warnings
- [ ] `cargo fmt --all --check` clean
- [ ] CI: Kani / Playwright / Rocq green
- [ ] `rivet validate` PASS; `rivet commits` PASS
- [ ] REQ-082 regression: consumer `rivet validate` after `rivet sync`
      counts only the consumer's own artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)