### PR TITLE
build: bump rules_rocq_rust to e4660cc (hermetic rules_rust toolchain)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,7 +51,8 @@ bazel_dep(name = "rules_rocq_rust", version = "0.1.0")
 git_override(
     module_name = "rules_rocq_rust",
     remote = "https://github.com/pulseengine/rules_rocq_rust.git",
-    commit = "6a8da0bd30b5f80f811acefbf6ac5740a08d4a8c",
+    # e4660cc: build: migrate rocq-of-rust to a hermetic rules_rust toolchain (#34).
+    commit = "e4660cc1b06fc4c0aefb49401fa2e2184cf804e3",
 )
 
 # rules_rocq_rust needs a Nix toolchain for hermetic Rocq binaries.


### PR DESCRIPTION
## Summary

Bump the \`rules_rocq_rust\` git pin in \`MODULE.bazel\` from
\`6a8da0b\` to \`e4660cc\` (current tip of
\`pulseengine/rules_rocq_rust\` main), picking up
[#34 — *build: migrate rocq-of-rust to a hermetic rules_rust toolchain*](https://github.com/pulseengine/rules_rocq_rust/commit/e4660cc1b06fc4c0aefb49401fa2e2184cf804e3).

Reduces the Rocq CI job's coupling to ambient Rust toolchains.

## Test plan

- [ ] CI Rocq Proofs job picks up the new pin and the toolchain
      migration. (Rocq remains \`continue-on-error\` until the
      Rocq 9.0 port PR; this bump is a build/plumbing improvement,
      not a proof-content fix.)
- [ ] Nothing else regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)