### PR TITLE
docs(artifacts): note runner9 podman unblocker on REQ-084

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1488,6 +1488,20 @@ artifacts:
       no installer, no daemon, no sudo, no unpinned-action drift
       surface.
 
+      Unblocker (2026-05-23): smithy runner9 is now podman-capable —
+      `podman_userns: true`, `NoNewPrivileges=0`,
+      `ProtectKernelTunables=false` deployed and verified live
+      (`podman run nixos/nix@sha256:fd7a5c67... nix --version` returns
+      `nix (Nix) 2.24.9`). GHA label set is
+      `[self-hosted, Linux, X64, hetzner, rust-cpu, podman]`. The
+      Verus job can switch `runs-on:` to include the `podman` label
+      and drive the Bazel/Nix work through rootless podman against
+      `docker.io/nixos/nix`; per the smithy note, "the flag is one
+      line per runner — trivial to expand" if contention on runner9
+      becomes a concern. The rivet implementation should follow the
+      `spar` validation of the same pattern (sequential, so we inherit
+      a tested approach rather than co-debug two repos in parallel).
+
       Acceptance:
         - The Verus CI job's `Verify Verus specs` step actually
           executes — assert it is not `skipped` in the job step list.
@@ -1497,6 +1511,10 @@ artifacts:
           never ran the verifier.
         - A completed Verus job's `verus-test-log` artifact contains a
           real Verus solver result.
+        - The Verus job's `runs-on:` targets the `podman` label
+          (scoped to a podman-capable runner) and Nix work runs inside
+          a `nixos/nix` rootless container — no `nix-installer-action`
+          and no host-installed Nix.
     tags: [ci, verus, silent-failure, f2-family, nix]
     fields:
       priority: should


### PR DESCRIPTION
## Summary

Captures the runner9 podman-capability unblocker on **REQ-084** (the
Verus CI silent-failure tracked since v0.11.1).

Smithy reports runner9 now has the scoped flag set deployed:
\`podman_userns=true\`, \`NoNewPrivileges=0\`,
\`ProtectKernelTunables=false\`, verified live with
\`podman run nixos/nix@sha256:fd7a5c67… nix --version\` returning
\`nix (Nix) 2.24.9\`. GHA label set:
\`[self-hosted, Linux, X64, hetzner, rust-cpu, podman]\`.

This unblocks the REQ-084 fix path: the Verus job's \`runs-on:\` targets
the \`podman\` label, Nix work runs inside a \`nixos/nix\` rootless
container — no \`nix-installer-action\`, no host-installed Nix. Per
the smithy note, the flag is "one line per runner — trivial to expand"
if contention on runner9 becomes an issue.

**No CI changes in this PR.** Per rigor-and-honesty, the rivet
implementation follows spar's validation of the same pattern
(sequential — rivet inherits a tested approach rather than co-debug
two repos in parallel). This PR captures the path on REQ-084 so when
that implementation lands it's against a documented Acceptance set.

## Test plan

- [x] \`rivet validate\` PASS (the only REQ-084 INFO is the standard
      "draft requirement not yet satisfied" coverage note).
- [ ] CI green (artifact-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)