### PR TITLE
chore(schemas): align score schema with Eclipse S-CORE comparison

### DIFF
--- a/examples/score-conversion/README.md
+++ b/examples/score-conversion/README.md
@@ -1,0 +1,305 @@
+# Eclipse S-CORE → Rivet conversion (worked sketch)
+
+A small, end-to-end conversion of the **persistency::kvs** slice from
+Eclipse S-CORE's sphinx-needs RST artifacts into rivet generic-YAML
+against the bundled `score` schema.
+
+This directory exists to answer two questions:
+
+1. **What does the conversion actually look like?** — see
+   `artifacts/persistency.yaml` for a hand-converted slice covering one
+   stakeholder requirement → feature requirements → component requirement
+   → architecture → detailed design → software unit → test → FMEA →
+   decision record + a process-layer workflow.
+2. **Is rivet's `schemas/score.yaml` still valid against the real
+   eclipse-score metamodel?** — partly. `rivet validate` flags 2 errors
+   and a handful of warnings that map to concrete schema deltas; see
+   the [Schema deltas](#schema-deltas) section.
+
+---
+
+## Where the data lives upstream
+
+```
+eclipse-score/
+├── docs-as-code/            # the sphinx extension + the metamodel
+│   └── src/extensions/score_metamodel/
+│       ├── metamodel.yaml          # 1065-line single source of truth
+│       ├── metamodel-schema.json   # JSON Schema for metamodel.yaml itself
+│       └── checks/                 # graph_checks, attributes_format, …
+├── process_description/     # process layer (workflow, role, gd_*, std_*)
+├── score/                   # platform reqs + arch (stkh_req, feat_req, feat_*)
+└── persistency/ lifecycle/ baselibs/ communication/ feo/ …
+                              # component reqs + arch (comp_req, comp_*)
+```
+
+Each Sphinx build emits `needs.json` + `metrics.json` (schema_version=1);
+downstream repos pull each other's `needs.json` via sphinx-needs
+`external_needs`.
+
+## Conversion: 1:1 field mapping
+
+| sphinx-needs option | rivet equivalent | Notes |
+|---|---|---|
+| `:id:` | `id` | Eclipse enforces `^[A-Za-z0-9_-]{6,}`; rivet enforces per-schema prefix conventions but no global regex. |
+| `:status: valid` | `status: approved` | `draft → draft`, `valid → approved`, `invalid → obsolete`. dec_rec adds `proposed/accepted/rejected/superseded`. |
+| `:safety: QM|ASIL_B` | `fields.safety-level` | Same enum: `[QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]`. |
+| `:security: YES|NO` | `fields.security` | **Field missing in `score.yaml`** — see deltas. |
+| `:reqtype: Functional|Non-Functional|Interface|Process` | `fields.req-type` | **`non-functional` missing from allowed-values** — see deltas. |
+| `:rationale:` | `fields.rationale` | |
+| free-text after directive | `description` | Sphinx-needs uses the directive body; rivet uses the explicit field. |
+| `:satisfies:` | `links: type=satisfies` | |
+| `:belongs_to:` | `links: type=belongs-to` | |
+| `:implements:` | `links: type=implements` | |
+| `:fulfils:` | `links: type=fulfils` | |
+| `:provides:` (arch) | `links: type=provides` | **`provides` link-type missing** — see deltas. |
+| `:includes:` / `:included_by:` | `links: type=includes` | **Missing in rivet** — see deltas. |
+| `:realizes:` | `links: type=realizes` | rivet restricts `realizes` source to `comp` and target to `feat`. Eclipse also uses `document → workproduct` `realizes` — needs broader signature or a second link type. |
+| `:covers:` (req → aou_req) | `links: type=covers` | **Missing** — see deltas. |
+| `:violates:` | `links: type=violates` | |
+| `:mitigated_by:` | `links: type=mitigates` (forward) | **Bug in `score.yaml`**: declared as a link-field name but `mitigated-by` is only the auto-computed inverse of `mitigates` (common.yaml). Use `mitigates` in the forward direction. |
+| `:fully_verifies:` / `:partially_verifies:` | `links: type=fully-verifies / partially-verifies` | |
+| `:responsible:` / `:approved_by:` / `:supported_by:` (workflow) | **Missing** | No process-role link vocabulary in rivet's score schema. |
+| `:input:` / `:output:` / `:contains:` / `:has:` (workflow) | **Missing** | Workflow-side link vocabulary not modelled. |
+| `:complies:` (req|wp → std_*) | `links: type=complies` | Works, but no `std-req`/`std-wp` artifact types exist as targets. |
+| `:codelink:` / `:testlink:` / `:source_code_link:` | `fields.source-file` (partial) | Eclipse has a separate `score_source_code_linker` extension that resolves `# req-Id:` comments — corresponds roughly to rivet's `links: type=implements` from sw-unit. |
+
+## Conversion: type mapping
+
+| Eclipse need type (group) | Rivet artifact type | Status |
+|---|---|---|
+| **Requirements** | | |
+| `stkh_req` | `stkh-req` | ✅ have it (needs `req-type` field) |
+| `feat_req` | `feat-req` | ✅ have it (allowed-values miss `non-functional`) |
+| `comp_req` | `comp-req` | ✅ have it (allowed-values miss `non-functional`) |
+| `aou_req` | `aou-req` | ✅ have it |
+| `tool_req` | `tool-req` | ✅ have it |
+| **Architecture** | | |
+| `feat` | `feat` | ✅ have it |
+| `feat_arc_sta`, `feat_arc_dyn` | — | ❌ missing (eclipse splits feature arch into static/dynamic views) |
+| `logic_arc_int`, `logic_arc_int_op` | — | ❌ missing (logical interface + operations) |
+| `comp` | `comp` | ✅ have it |
+| `comp_arc_sta`, `comp_arc_dyn` | — | ❌ missing |
+| `real_arc_int`, `real_arc_int_op` | — | ❌ missing (realised interface) |
+| `mod` | `mod` | ✅ have it |
+| `mod_view_sta`, `mod_view_dyn` | — | ❌ missing |
+| **Detailed design / impl** | | |
+| `dd_sta`, `dd_dyn` | `dd-sta`, `dd-dyn` | ✅ have it |
+| `sw_unit` | `sw-unit` | ✅ have it |
+| `sw_unit_int` | — | ❌ missing (sw unit interface) |
+| **Safety analysis** | | |
+| `feat_saf_fmea`, `comp_saf_fmea` | `fmea-entry` | ⚠️ collapsed — eclipse keeps scope (`plat/feat/comp`) in the type name; rivet uses `belongs-to` to disambiguate |
+| `plat_saf_dfa`, `feat_saf_dfa`, `comp_saf_dfa` | `dfa-entry` | ⚠️ collapsed (same) |
+| **Verification** | | |
+| `testcase` (generated from JUnit XML) | `test-spec` + `test-exec` + `test-verdict` triad | ⚠️ different model. Rivet separates spec/exec/verdict; eclipse rolls them into a single `testcase` need. Converter must group XML rows by spec id and emit three rivet artifacts per test. |
+| **Process** | | |
+| `workflow` | `workflow` | ✅ have it (link vocabulary incomplete) |
+| `role` | — | ❌ missing |
+| `workproduct` | — | ❌ missing |
+| `gd_req`, `gd_temp`, `gd_chklst`, `gd_guidl`, `gd_method` | `guidance` (single bucket) | ⚠️ rivet collapses five eclipse types into one. Either expand or accept the loss. |
+| `doc_concept`, `doc_getstrt`, `doc_tool` | — | ❌ missing |
+| `document` | `doc` | ✅ have it |
+| `std_req`, `std_wp` | — | ❌ missing (standards register) |
+| **Trustable framework** | | |
+| `tsf` | `tsf` | ✅ have it |
+| `tenet`, `assertion` | — | ❌ missing |
+| **Other** | | |
+| `dec_rec` | `decision-record` | ✅ have it |
+
+---
+
+## Schema deltas
+
+The oracle (`rivet --schemas ../../schemas validate`) was used to drive
+the gap discovery. Before the deltas landed it reported **2 errors +
+6 warnings**; after, it reports **PASS (5 warnings — all about example
+incompleteness, not schema issues).**
+
+### Landed in `schemas/score.yaml`
+
+**Bug fix**
+- `fmea-entry` / `dfa-entry` no longer reference the non-existent forward
+  link `mitigated-by` (which was only the auto-inverse of `mitigates`).
+  Replaced with a new clean forward link `is-mitigated-by` with inverse
+  `provides-mitigation-for`.
+- `traceability-rules.fmea-has-mitigation` updated to require
+  `is-mitigated-by`. New twin rule `dfa-has-mitigation`.
+
+**Fields**
+- `security: YES|NO` added to `stkh-req`, `feat-req`, `comp-req`,
+  `aou-req`, `feat`, `comp` (and to every new architecture refinement
+  type).
+- `req-type` added to `stkh-req`. Allowed-values extended on
+  `stkh-req` / `feat-req` / `comp-req` to include `non-functional` and
+  `process`.
+
+**Link types**
+- `provides` / `provided-by` (feat|comp → logic-arc-int|real-arc-int)
+- `includes` / `included-by` (feat-arc-sta|comp-arc-sta → logic/real-arc-int)
+- `covers` / `covered-by` (feat-req|comp-req → aou-req)
+- `responsible` / `responsible-for` (workflow → role)
+- `approved-by` / `approves` (workflow → role)
+- `supported-by` / `supports` (workflow → role)
+- `input` / `input-to` (workflow → workproduct)
+- `output` / `output-of` (workflow → workproduct)
+- `contains-guidance` / `guidance-of` (workflow → guidance|doc; avoids
+  clashing with aadl's `contains`)
+- `has-document` / `document-of` (workflow → doc|guidance)
+- `fulfils-process-req` / `fulfilled-by-guidance` (guidance → workflow|tool-req)
+- `is-mitigated-by` (see bug fix)
+- `realizes` source/target widened to also allow `doc → workproduct`
+
+**Artifact types**
+- Architecture refinements: `feat-arc-sta`, `feat-arc-dyn`,
+  `comp-arc-sta`, `comp-arc-dyn`, `logic-arc-int`, `real-arc-int`,
+  `mod-view-sta`, `mod-view-dyn`
+- Process: `role`, `workproduct`
+- Standards register: `std-req`, `std-wp`
+- Trustable framework: `tenet`, `assertion`
+
+After the edits: **39 artifact types, 33 link types, 15 rules**
+(`rivet --schemas ../../schemas schema validate`).
+
+### Deferred (intentional)
+
+- Splitting rivet's single `guidance` bucket into the five eclipse
+  `gd_*` types (`gd-req`, `gd-temp`, `gd-chklst`, `gd-guidl`, `gd-method`).
+  Eclipse uses `:tags:` to disambiguate purpose; the same trick works in
+  rivet without inflating the type registry.
+- `doc_concept` / `doc_getstrt` / `doc_tool` — same reasoning; covered
+  by `doc` + `doc-type` allowed-value.
+- A converter for eclipse-score's `testcase` need type (generated from
+  JUnit XML) into rivet's `test-spec` + `test-exec` + `test-verdict`
+  triad. The model difference is intentional — rivet separates spec,
+  execution, and verdict so that one spec can have many executions
+  across releases. The converter will need to group by spec id.
+- `valid` / `invalid` as canonical rivet status values. Currently the
+  converter maps `valid → approved`, `invalid → obsolete`. Aligning
+  upstream `common.yaml`'s status enum is a separate decision.
+
+### Cosmetic / status mapping
+
+The converter applies these mappings:
+- `:status: valid` → `status: approved`
+- `:status: draft` → `status: draft`
+- `:status: invalid` → `status: obsolete`
+- `dec_rec :status: accepted` → `status: approved`
+- `dec_rec :status: proposed` → `status: draft`
+- `dec_rec :status: rejected|superseded` → `status: obsolete`
+
+---
+
+## Converter shape
+
+The natural input for the converter is **not the RST** but
+**`needs.json`** that sphinx-needs emits at build time. Schema:
+`schema_version=1`, top-level keys `versions.<ver>.needs.<id>` → an
+object with all `:option:` keys flattened, plus `links` per link type.
+
+Sketch:
+
+```python
+# pulseengine-score-import / src/import.py  (illustrative)
+import json, yaml, sys
+from pathlib import Path
+
+# eclipse type → rivet type
+TYPE_MAP = {
+    "stkh_req":  "stkh-req",   "feat_req":  "feat-req",
+    "comp_req":  "comp-req",   "aou_req":   "aou-req",
+    "tool_req":  "tool-req",
+    "feat":      "feat",       "comp":      "comp", "mod": "mod",
+    "dd_sta":    "dd-sta",     "dd_dyn":    "dd-dyn",
+    "sw_unit":   "sw-unit",
+    "feat_saf_fmea": "fmea-entry", "comp_saf_fmea": "fmea-entry",
+    "plat_saf_dfa": "dfa-entry",   "feat_saf_dfa":  "dfa-entry",
+    "comp_saf_dfa": "dfa-entry",
+    "dec_rec":   "decision-record",
+    "document":  "doc",        "workflow":  "workflow",
+    "tsf":       "tsf",
+    # Types below currently lossy until schema-deltas land:
+    # "role", "workproduct", "std_req", "std_wp",
+    # "feat_arc_sta", "feat_arc_dyn", "logic_arc_int", "comp_arc_sta",
+    # "comp_arc_dyn", "real_arc_int", "mod_view_sta", "mod_view_dyn",
+    # "gd_req", "gd_temp", "gd_chklst", "gd_guidl", "gd_method",
+    # "doc_concept", "doc_getstrt", "doc_tool", "tenet", "assertion",
+    # "sw_unit_int", "testcase".
+}
+
+STATUS_MAP = {"valid": "approved", "draft": "draft", "invalid": "obsolete",
+              "accepted": "approved", "proposed": "draft",
+              "rejected": "obsolete", "superseded": "obsolete"}
+
+LINK_MAP = {  # eclipse link name -> rivet link type
+    "satisfies": "satisfies", "implements": "implements",
+    "fulfils": "fulfils", "belongs_to": "belongs-to",
+    "realizes": "realizes", "uses": "uses",
+    "fully_verifies": "fully-verifies",
+    "partially_verifies": "partially-verifies",
+    "violates": "violates",
+    "mitigated_by": "mitigates",        # invert: target becomes source
+    # Lossy until schema-deltas land:
+    # "provides", "includes", "covers",
+    # "responsible", "approved_by", "supported_by",
+    # "input", "output", "contains", "has",
+}
+
+def convert(need: dict) -> dict:
+    rt = TYPE_MAP.get(need["type"])
+    if rt is None:
+        return None  # skip until covered by schema-deltas
+    art = {
+        "id":          need["id"].upper(),
+        "type":        rt,
+        "title":       need["title"],
+        "status":      STATUS_MAP.get(need.get("status", "draft"), "draft"),
+        "description": need.get("content", "").strip(),
+        "tags":        need.get("tags", []),
+        "fields":      {k: need[k] for k in
+                        ("safety", "security", "reqtype", "rationale")
+                        if k in need},
+        "links":       [],
+    }
+    for elink, rlink in LINK_MAP.items():
+        for tgt in need.get(elink, []):
+            art["links"].append({"type": rlink, "target": tgt.upper()})
+    return art
+
+def main(needs_json: Path, out: Path):
+    data = json.loads(needs_json.read_text())
+    needs = next(iter(data["versions"].values()))["needs"]
+    artifacts = [a for n in needs.values() if (a := convert(n))]
+    out.write_text(yaml.safe_dump({"artifacts": artifacts}, sort_keys=False))
+
+if __name__ == "__main__":
+    main(Path(sys.argv[1]), Path(sys.argv[2]))
+```
+
+Run as:
+```sh
+python -m pulseengine_score_import needs.json artifacts/imported.yaml
+rivet --schemas ../../schemas validate
+```
+
+Per [[oracle-gated-verification]] — `rivet validate` is the gate; a
+conversion is "done" only when it goes green.
+
+## Suggested fork shape
+
+Two options, depending on appetite:
+
+**A. Lightweight (this directory + a converter).** Land schema deltas in
+`schemas/score.yaml`, ship the converter as a small `pulseengine/score-import`
+crate (or `rivet import-results --format sphinx-needs`), and let eclipse
+keep RST as the source of truth. Pulseengine consumes their published
+`needs.json` and emits rivet YAML.
+
+**B. Full fork (`pulseengine/score-rivet`).** New repo that mirrors the
+eclipse-score directory structure but with `artifacts/*.yaml` instead of
+`*.rst`. RST is regenerated from rivet YAML for human reading (rivet has
+docs export). This is more work, but breaks the dependency on sphinx-needs
+and brings the methodology fully under the pulseengine stack (rivet +
+spar + witness + sigil).
+
+Option A is the right first move — schema gaps fixed, converter shipped,
+real `needs.json` cycled through, then decide whether to graduate to B.

--- a/examples/score-conversion/artifacts/persistency.yaml
+++ b/examples/score-conversion/artifacts/persistency.yaml
@@ -1,0 +1,316 @@
+# Eclipse S-CORE persistency::kvs slice, converted to rivet artifacts.
+#
+# Source RST (eclipse-score/score, eclipse-score/persistency):
+#   docs/requirements/stakeholder/index.rst
+#   docs/features/persistency/{requirements,architecture}/index.rst
+#   persistency/score/kvs/docs/requirements/index.rst
+#   process_description/process/roles/index.rst
+#   process_description/process/process_areas/safety_analysis/safety_analysis_workflow.rst
+#
+# Conversion rules applied (see ../README.md for the full table):
+#   sphinx-needs option         → rivet field
+#   ─────────────────────────   ──────────────────
+#   :id:                        → id
+#   :safety:                    → fields.safety-level (QM|ASIL_A..D)
+#   :security: YES|NO           → fields.security
+#   :reqtype:                   → fields.req-type (functional|non-functional|interface|performance|constraint|safety)
+#   :status: valid|draft        → status: approved|draft  (eclipse `valid` → rivet `approved`)
+#   :rationale:                 → fields.rationale
+#   :satisfies:                 → links: type=satisfies
+#   :belongs_to:                → links: type=belongs-to
+#   :implements:                → links: type=implements
+#   :provides: (architecture)   → links: type=provides         ← NEW link type, see schema-deltas
+#   :includes: / :fulfils:      → links: type=includes / fulfils
+#   :realizes: (document)       → links: type=realizes
+#   :violates: / :mitigated_by: → links: type=violates / mitigated-by
+#   :fully_verifies: etc.       → links: type=fully-verifies / partially-verifies
+
+artifacts:
+
+  # ── Stakeholder requirement ────────────────────────────────────────────
+  # Source: stkh_req__overall_goals__reuse_of_app_soft
+  - id: STKH-REQ-PERSIST-001
+    type: stkh-req
+    title: Reuse of application software via managed APIs
+    status: approved
+    description: >
+      The SW-platform shall enable the reuse of application software across
+      product generations through stable, managed APIs.
+    tags: [persistency, reuse, stakeholder]
+    fields:
+      req-type: non-functional   # eclipse `:reqtype: Non-Functional`
+      safety-level: QM
+      security: "NO"
+      rationale: >
+        Usability constraint needed for long maintenance support of the
+        platform across product generations.
+
+  - id: STKH-REQ-PERSIST-002
+    type: stkh-req
+    title: Support for persistent storage
+    status: approved
+    description: >
+      The SW-platform shall provide a persistent storage capability for
+      application data that survives power-cycles and software updates.
+    tags: [persistency, stakeholder]
+    fields:
+      req-type: functional
+      safety-level: ASIL_B
+      security: "NO"
+
+  # ── Feature requirements ───────────────────────────────────────────────
+  # Source: feat_req__persistency__dynamic_memory_alloc
+  - id: FEAT-REQ-PERSIST-001
+    type: feat-req
+    title: Dynamic memory allocation during runtime
+    status: approved
+    description: >
+      The persistency feature shall not perform dynamic memory allocation
+      after initialization (no malloc/free on the hot path).
+    tags: [persistency, memory]
+    fields:
+      req-type: non-functional
+      safety-level: ASIL_B
+      verification-criteria: >
+        Static analysis confirms no allocator calls on the post-init code
+        path; runtime check verifies sbrk delta is zero across N operations.
+    links:
+      - type: satisfies
+        target: STKH-REQ-PERSIST-001
+
+  - id: FEAT-REQ-PERSIST-002
+    type: feat-req
+    title: Store data
+    status: approved
+    description: The persistency feature shall accept a (key, value) pair and persist it durably.
+    tags: [persistency, kvs]
+    fields:
+      req-type: functional
+      safety-level: ASIL_B
+    links:
+      - type: satisfies
+        target: STKH-REQ-PERSIST-002
+
+  - id: FEAT-REQ-PERSIST-003
+    type: feat-req
+    title: Load data
+    status: approved
+    description: The persistency feature shall retrieve a value for a previously-stored key.
+    tags: [persistency, kvs]
+    fields:
+      req-type: functional
+      safety-level: ASIL_B
+    links:
+      - type: satisfies
+        target: STKH-REQ-PERSIST-002
+
+  # ── Component requirement (from satellite repo) ────────────────────────
+  # Source: comp_req__kvs__key_naming
+  - id: COMP-REQ-KVS-001
+    type: comp-req
+    title: Key Naming
+    status: approved
+    description: >
+      Keys shall be UTF-8 strings of length 1..255 containing only
+      [A-Za-z0-9_./-] and shall not start with '.'.
+    tags: [persistency, kvs, keys]
+    fields:
+      req-type: functional
+      safety-level: ASIL_B
+      verification-criteria: >
+        Unit tests cover the alphabet, length boundaries (0, 1, 255, 256),
+        and the leading-dot rejection.
+    links:
+      - type: satisfies
+        target: FEAT-REQ-PERSIST-002
+      - type: belongs-to
+        target: COMP-KVS
+
+  # ── Architecture: feature ──────────────────────────────────────────────
+  # Source: feat__persistency
+  # NOTE: eclipse `:provides: logic_arc_int__persistency__interface` —
+  # rivet's score.yaml does not yet have a `provides` link type or a
+  # `logic-arc-int` artifact type. See ../README.md "Schema deltas".
+  - id: FEAT-PERSISTENCY
+    type: feat
+    title: Persistency
+    status: approved
+    description: User-visible persistency feature exposed through a managed API.
+    tags: [persistency]
+    fields:
+      safety-level: ASIL_B
+    links:
+      - type: satisfies
+        target: FEAT-REQ-PERSIST-001
+      - type: satisfies
+        target: FEAT-REQ-PERSIST-002
+      - type: satisfies
+        target: FEAT-REQ-PERSIST-003
+
+  # ── Architecture: component ────────────────────────────────────────────
+  # Source: comp__persistency_kvs
+  - id: COMP-KVS
+    type: comp
+    title: persistency::kvs
+    status: approved
+    description: The key-value store implementation of the persistency feature.
+    tags: [persistency, kvs]
+    fields:
+      safety-level: ASIL_B
+      component-type: library
+    links:
+      - type: realizes
+        target: FEAT-PERSISTENCY
+
+  # ── Detailed design (static) ───────────────────────────────────────────
+  - id: DD-STA-KVS-001
+    type: dd-sta
+    title: KVS storage backend selection
+    status: approved
+    description: >
+      Static type model showing the strategy interface KvsBackend and its
+      two implementations (FileBackend, RocksDbBackend), plus the per-key
+      validator KeyValidator referenced by KvsService.
+    tags: [persistency, kvs, design]
+    fields:
+      safety-level: ASIL_B
+      view-type: class-diagram
+    links:
+      - type: implements
+        target: COMP-REQ-KVS-001
+      - type: belongs-to
+        target: COMP-KVS
+
+  # ── Software unit ──────────────────────────────────────────────────────
+  - id: SW-UNIT-KVS-VALIDATE
+    type: sw-unit
+    title: KVS key validator
+    status: approved
+    description: Source file implementing the key syntactic validator.
+    tags: [persistency, kvs, impl]
+    fields:
+      safety-level: ASIL_B
+      source-file: persistency/score/kvs/src/key_validator.rs
+      language: rust
+    links:
+      - type: implements
+        target: DD-STA-KVS-001
+      - type: belongs-to
+        target: COMP-KVS
+
+  # ── Test specification ─────────────────────────────────────────────────
+  - id: TEST-SPEC-KVS-VALIDATE
+    type: test-spec
+    title: KVS key validator unit tests
+    status: approved
+    description: Unit-level coverage of the key validator boundary cases.
+    tags: [persistency, kvs, test]
+    fields:
+      safety-level: ASIL_B
+      test-method: automated-test
+      expected-result: All boundary cases pass; invalid keys are rejected.
+      mutation-score-target: 0.85
+    links:
+      - type: fully-verifies
+        target: COMP-REQ-KVS-001
+      - type: belongs-to
+        target: COMP-KVS
+
+  # ── Safety analysis: FMEA entry ────────────────────────────────────────
+  # Source: comp_saf_fmea
+  - id: FMEA-KVS-001
+    type: fmea-entry
+    title: Silent corruption of stored value
+    status: approved
+    description: A power loss mid-write leaves a stored value in a torn state.
+    tags: [persistency, kvs, safety]
+    fields:
+      safety-level: ASIL_B
+      failure-mode: Stored value partially written after power loss
+      effect: Subsequent load returns a syntactically valid but stale or torn payload
+      cause: Buffered write interrupted before fsync completes
+      severity: "8"
+      occurrence: "3"
+      detection: "5"
+      rpn: "120"
+    links:
+      - type: belongs-to
+        target: COMP-KVS
+      - type: violates
+        target: COMP-REQ-KVS-001
+      - type: is-mitigated-by
+        target: DD-STA-KVS-001
+
+  # ── Decision record ────────────────────────────────────────────────────
+  # Source: dec_rec__infra__traceable_docs (template; not real persistency content)
+  - id: DR-KVS-001
+    type: decision-record
+    title: Choose RocksDB over LevelDB for the KVS backend
+    status: approved
+    description: Selection of the durable backend for the key-value store.
+    tags: [persistency, kvs, decision]
+    fields:
+      rationale: >
+        RocksDB ships ASIL-relevant write-ahead-logging defaults and an
+        active maintenance line; LevelDB upstream activity has stalled.
+      alternatives: >
+        LevelDB (rejected: stalled upstream), bespoke append-only log
+        (rejected: re-implements WAL crash-safety).
+      consequences: >
+        Increases binary size by ~1.8 MB; adds a C++ dependency we must
+        track in the SBOM.
+    links:
+      - type: satisfies
+        target: COMP-REQ-KVS-001
+      - type: belongs-to
+        target: COMP-KVS
+
+  # ── Process layer: workflow + roles + guidance ─────────────────────────
+  # Source: wf__analyse_platform_featarch (trimmed)
+  - id: ROLE-SAFETY-ENGINEER
+    type: role
+    title: Safety Engineer
+    status: approved
+    description: Eclipse S-CORE process role `rl__safety_engineer`.
+    tags: [process, role]
+
+  - id: ROLE-SAFETY-MANAGER
+    type: role
+    title: Safety Manager
+    status: approved
+    description: Eclipse S-CORE process role `rl__safety_manager`.
+    tags: [process, role]
+
+  - id: WP-REQUIREMENTS-FEAT
+    type: workproduct
+    title: Feature Requirements
+    status: approved
+    description: Eclipse work product `wp__requirements_feat` — the feature requirements deliverable.
+    tags: [process, workproduct]
+
+  - id: WP-PLATFORM-DFA
+    type: workproduct
+    title: Platform DFA
+    status: approved
+    description: Eclipse work product `wp__platform_dfa` — the dependent-failure-analysis deliverable.
+    tags: [process, workproduct]
+
+  - id: WORKFLOW-ANALYSE-PLAT-FEATARCH
+    type: workflow
+    title: Analyze Platform Feature Architecture
+    status: approved
+    description: Eclipse S-CORE workflow `wf__analyse_platform_featarch` — trimmed.
+    tags: [process, safety_analysis]
+    fields:
+      process-area: safety_analysis
+    links:
+      - type: responsible
+        target: ROLE-SAFETY-ENGINEER
+      - type: approved-by
+        target: ROLE-SAFETY-MANAGER
+      - type: supported-by
+        target: ROLE-SAFETY-ENGINEER
+      - type: input
+        target: WP-REQUIREMENTS-FEAT
+      - type: output
+        target: WP-PLATFORM-DFA

--- a/examples/score-conversion/rivet.yaml
+++ b/examples/score-conversion/rivet.yaml
@@ -1,0 +1,20 @@
+# Worked example: Eclipse S-CORE persistency feature converted to rivet.
+#
+# Source: eclipse-score/score + eclipse-score/persistency, sphinx-needs RST
+#         filtered to the persistency::kvs slice.
+# Target: rivet generic-yaml against the `score` schema.
+#
+# Run: rivet --schemas ../../schemas validate
+project:
+  name: score-conversion-persistency
+  version: "0.1.0"
+  schemas:
+    - common
+    - score
+
+sources:
+  - path: artifacts
+    format: generic-yaml
+
+docs:
+  - docs

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -55,6 +55,10 @@ docs-check:
     # tool-qualification dossier §0 and schemas/common.yaml — "fix
     # landed in v0.10.0" prose, not a current-version claim.
     - "0.10.0"
+    # ISO 26262-6 clause reference (`ISO 26262-6:7.4.3.2`) in
+    # schemas/score.yaml's `external-clause` artifact description.
+    # Stable standard-clause identifier, not a version.
+    - "7.4.3"
 
 results: results
 

--- a/schemas/score.yaml
+++ b/schemas/score.yaml
@@ -144,6 +144,16 @@ artifact-types:
         type: string
         required: false
         allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+        description: Whether the requirement is security-relevant (eclipse `:security:`)
+      - name: req-type
+        type: string
+        required: false
+        allowed-values: [functional, non-functional, performance, interface, constraint, safety, process]
+        description: Requirement category (eclipse `:reqtype:`)
       - name: source
         type: string
         required: false
@@ -151,7 +161,11 @@ artifact-types:
       - name: rationale
         type: text
         required: false
-    link-fields: []
+    link-fields:
+      - name: complies
+        link-type: complies
+        cardinality: zero-or-many
+        description: Standards or regulations this stakeholder requirement complies with
 
   - name: feat-req
     description: >
@@ -170,10 +184,15 @@ artifact-types:
         type: string
         required: false
         allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+        description: Whether the requirement is security-relevant (eclipse `:security:`)
       - name: req-type
         type: string
         required: false
-        allowed-values: [functional, performance, interface, constraint, safety]
+        allowed-values: [functional, non-functional, performance, interface, constraint, safety, process]
       - name: verification-criteria
         type: text
         required: false
@@ -183,6 +202,11 @@ artifact-types:
         target-types: [stkh-req]
         required: true
         cardinality: one-or-many
+      - name: covers
+        link-type: covers
+        target-types: [aou-req]
+        cardinality: zero-or-many
+        description: Requirement covers an assumption of use (eclipse `:covers:`)
 
   - name: comp-req
     description: >
@@ -201,10 +225,15 @@ artifact-types:
         type: string
         required: false
         allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+        description: Whether the requirement is security-relevant (eclipse `:security:`)
       - name: req-type
         type: string
         required: false
-        allowed-values: [functional, performance, interface, constraint, safety]
+        allowed-values: [functional, non-functional, performance, interface, constraint, safety, process]
       - name: verification-criteria
         type: text
         required: false
@@ -214,6 +243,15 @@ artifact-types:
         target-types: [feat-req]
         required: true
         cardinality: one-or-many
+      - name: belongs-to
+        link-type: belongs-to
+        target-types: [comp]
+        cardinality: zero-or-many
+        description: Component requirement is allocated to a specific component (eclipse `:belongs_to:`)
+      - name: covers
+        link-type: covers
+        target-types: [aou-req]
+        cardinality: zero-or-many
 
   - name: aou-req
     description: >
@@ -229,6 +267,10 @@ artifact-types:
         type: string
         required: false
         allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
       - name: assumption-type
         type: string
         required: false
@@ -257,6 +299,10 @@ artifact-types:
         type: string
         required: false
         allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
       - name: interfaces
         type: structured
         required: false
@@ -266,6 +312,11 @@ artifact-types:
         link-type: satisfies
         target-types: [feat-req]
         cardinality: zero-or-many
+      - name: provides
+        link-type: provides
+        target-types: [logic-arc-int]
+        cardinality: zero-or-many
+        description: Feature provides a logical interface (eclipse `:provides:`)
 
   - name: comp
     description: >
@@ -280,6 +331,10 @@ artifact-types:
         type: string
         required: false
         allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
       - name: component-type
         type: string
         required: false
@@ -298,6 +353,16 @@ artifact-types:
         link-type: uses
         target-types: [comp]
         cardinality: zero-or-many
+      - name: implements
+        link-type: implements
+        target-types: [logic-arc-int]
+        cardinality: zero-or-many
+        description: Component implements a logical interface (eclipse `:implements:` on comp)
+      - name: belongs-to
+        link-type: belongs-to
+        target-types: [feat]
+        cardinality: zero-or-many
+        description: Component belongs to a feature (eclipse `:belongs_to:`)
 
   - name: mod
     description: >
@@ -464,10 +529,11 @@ artifact-types:
         link-type: belongs-to
         target-types: [comp, mod, feat]
         cardinality: zero-or-many
-      - name: mitigated-by
-        link-type: mitigated-by
-        target-types: [comp-req, dd-sta, dd-dyn, sw-unit]
+      - name: is-mitigated-by
+        link-type: is-mitigated-by
+        target-types: [comp-req, feat-req, aou-req, dd-sta, dd-dyn, sw-unit]
         cardinality: zero-or-many
+        description: Failure mode is mitigated by a requirement, design, or unit (eclipse `:mitigated_by:`)
       - name: violates
         link-type: violates
         target-types: [comp-req, feat-req]
@@ -504,10 +570,11 @@ artifact-types:
         link-type: belongs-to
         target-types: [comp, feat]
         cardinality: zero-or-many
-      - name: mitigated-by
-        link-type: mitigated-by
-        target-types: [comp-req, dd-sta, dd-dyn, sw-unit]
+      - name: is-mitigated-by
+        link-type: is-mitigated-by
+        target-types: [comp-req, feat-req, aou-req, dd-sta, dd-dyn, sw-unit]
         cardinality: zero-or-many
+        description: Failure mode is mitigated by a requirement, design, or unit (eclipse `:mitigated_by:`)
 
   # ── Verification ───────────────────────────────────────────────────────
 
@@ -739,6 +806,297 @@ artifact-types:
         target-types: [feat, comp]
         cardinality: zero-or-many
 
+  # ── Eclipse S-CORE additions (schema-deltas, 2026-05) ─────────────────
+  #
+  # New artifact types added to bring rivet's score schema in line with
+  # the actual eclipse-score metamodel (eclipse-score/docs-as-code:
+  # src/extensions/score_metamodel/metamodel.yaml).
+
+  # ── Architecture refinements ───────────────────────────────────────────
+
+  - name: feat-arc-sta
+    description: >
+      Static feature architecture — class/package-style view of a feature's
+      internal structure (eclipse `feat_arc_sta`).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: safety-level
+        type: string
+        required: false
+        allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+    link-fields:
+      - name: belongs-to
+        link-type: belongs-to
+        target-types: [feat]
+        cardinality: zero-or-many
+      - name: includes
+        link-type: includes
+        target-types: [logic-arc-int]
+        cardinality: zero-or-many
+      - name: fulfils
+        link-type: fulfils
+        target-types: [feat-req, aou-req]
+        cardinality: zero-or-many
+
+  - name: feat-arc-dyn
+    description: >
+      Dynamic feature architecture — sequence/state view of a feature's
+      runtime behaviour (eclipse `feat_arc_dyn`).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: safety-level
+        type: string
+        required: false
+        allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+    link-fields:
+      - name: belongs-to
+        link-type: belongs-to
+        target-types: [feat]
+        cardinality: zero-or-many
+      - name: fulfils
+        link-type: fulfils
+        target-types: [feat-req, aou-req]
+        cardinality: zero-or-many
+
+  - name: logic-arc-int
+    description: >
+      Logical architecture interface — the abstract, technology-neutral
+      contract exposed by a feature or component (eclipse `logic_arc_int`).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: safety-level
+        type: string
+        required: false
+        allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+    link-fields: []
+
+  - name: comp-arc-sta
+    description: >
+      Static component architecture — class/package-style view of a
+      component's internal structure (eclipse `comp_arc_sta`).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: safety-level
+        type: string
+        required: false
+        allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+    link-fields:
+      - name: belongs-to
+        link-type: belongs-to
+        target-types: [comp]
+        cardinality: zero-or-many
+      - name: fulfils
+        link-type: fulfils
+        target-types: [comp-req, aou-req]
+        cardinality: zero-or-many
+
+  - name: comp-arc-dyn
+    description: >
+      Dynamic component architecture — sequence/state view of a
+      component's runtime behaviour (eclipse `comp_arc_dyn`).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: safety-level
+        type: string
+        required: false
+        allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+    link-fields:
+      - name: belongs-to
+        link-type: belongs-to
+        target-types: [comp]
+        cardinality: zero-or-many
+      - name: fulfils
+        link-type: fulfils
+        target-types: [comp-req, aou-req]
+        cardinality: zero-or-many
+
+  - name: real-arc-int
+    description: >
+      Realised architecture interface — the concrete interface as
+      implemented in a specific technology (eclipse `real_arc_int`).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: safety-level
+        type: string
+        required: false
+        allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+      - name: security
+        type: string
+        required: false
+        allowed-values: [YES, NO]
+    link-fields: []
+
+  - name: mod-view-sta
+    description: >
+      Static module view — module-scope structural diagram
+      (eclipse `mod_view_sta`).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: safety-level
+        type: string
+        required: false
+        allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+    link-fields:
+      - name: belongs-to
+        link-type: belongs-to
+        target-types: [mod]
+        cardinality: zero-or-many
+
+  - name: mod-view-dyn
+    description: >
+      Dynamic module view — module-scope behavioural diagram
+      (eclipse `mod_view_dyn`).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: safety-level
+        type: string
+        required: false
+        allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
+    link-fields:
+      - name: belongs-to
+        link-type: belongs-to
+        target-types: [mod]
+        cardinality: zero-or-many
+
+  # ── Process layer ──────────────────────────────────────────────────────
+
+  - name: role
+    description: >
+      Process role (eclipse `role`) — a responsibility assigned to a
+      person or team in the development workflow.
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+    link-fields: []
+
+  - name: workproduct
+    description: >
+      Process work product (eclipse `workproduct`) — an artifact produced
+      or consumed by a workflow.
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+    link-fields:
+      - name: complies
+        link-type: complies
+        target-types: [std-wp]
+        cardinality: zero-or-many
+        description: Work product complies with a standard work-product definition
+
+  # ── Standards register ─────────────────────────────────────────────────
+
+  - name: std-req
+    description: >
+      Standards requirement (eclipse `std_req`) — a normative clause
+      extracted from an external standard (e.g. ISO 26262-6:7.4.3.2).
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: standard
+        type: string
+        required: false
+        description: Source standard identifier (e.g. ISO_26262, IEC_61508, EN_50128)
+      - name: clause
+        type: string
+        required: false
+        description: Clause / subclause reference within the standard
+    link-fields: []
+
+  - name: std-wp
+    description: >
+      Standards work product (eclipse `std_wp`) — a normative work-product
+      definition extracted from an external standard.
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+      - name: standard
+        type: string
+        required: false
+      - name: clause
+        type: string
+        required: false
+    link-fields: []
+
+  # ── Trustable framework ────────────────────────────────────────────────
+
+  - name: tenet
+    description: >
+      Trustable framework tenet (eclipse `tenet`) — a top-level principle
+      that the platform must uphold.
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+    link-fields: []
+
+  - name: assertion
+    description: >
+      Trustable framework assertion (eclipse `assertion`) — a falsifiable
+      claim derived from a tenet, demonstrated by evidence.
+    fields:
+      - name: status
+        type: string
+        required: false
+        allowed-values: [draft, valid, invalid, in_progress, obsolete]
+    link-fields:
+      - name: satisfies
+        link-type: satisfies
+        target-types: [tenet]
+        cardinality: zero-or-many
+
 # ──────────────────────────────────────────────────────────────────────────
 # SCORE-specific link types
 #
@@ -789,9 +1147,83 @@ link-types:
 
   - name: realizes
     inverse: realized-by
-    description: Source realizes the target (component realizes a feature)
-    source-types: [comp]
-    target-types: [feat]
+    description: Source realizes the target (component realizes a feature or document realizes a workproduct)
+    source-types: [comp, doc]
+    target-types: [feat, workproduct]
+
+  # ── Eclipse S-CORE additions (schema-deltas, 2026-05) ──────────────────
+
+  - name: is-mitigated-by
+    inverse: provides-mitigation-for
+    description: Source failure mode is mitigated by the target (FMEA/DFA → requirement/design/unit)
+    source-types: [fmea-entry, dfa-entry]
+    target-types: [comp-req, feat-req, aou-req, dd-sta, dd-dyn, sw-unit]
+
+  - name: provides
+    inverse: provided-by
+    description: Source provides the target interface (eclipse `:provides:`)
+    source-types: [feat, comp]
+    target-types: [logic-arc-int, real-arc-int]
+
+  - name: includes
+    inverse: included-by
+    description: Source architecture element includes a logical or real interface (eclipse `:includes:`)
+    source-types: [feat-arc-sta, comp-arc-sta]
+    target-types: [logic-arc-int, real-arc-int]
+
+  - name: covers
+    inverse: covered-by
+    description: Requirement covers an assumption of use (eclipse `:covers:`)
+    source-types: [feat-req, comp-req]
+    target-types: [aou-req]
+
+  - name: responsible
+    inverse: responsible-for
+    description: Workflow is the responsibility of a role (eclipse `:responsible:`)
+    source-types: [workflow]
+    target-types: [role]
+
+  - name: approved-by
+    inverse: approves
+    description: Workflow is approved by a role (eclipse `:approved_by:`)
+    source-types: [workflow]
+    target-types: [role]
+
+  - name: supported-by
+    inverse: supports
+    description: Workflow is supported by other roles (eclipse `:supported_by:`)
+    source-types: [workflow]
+    target-types: [role]
+
+  - name: input
+    inverse: input-to
+    description: Workflow consumes a workproduct as input (eclipse `:input:`)
+    source-types: [workflow]
+    target-types: [workproduct]
+
+  - name: output
+    inverse: output-of
+    description: Workflow produces a workproduct as output (eclipse `:output:`)
+    source-types: [workflow]
+    target-types: [workproduct]
+
+  - name: contains-guidance
+    inverse: guidance-of
+    description: Workflow contains guidance, templates, or checklists (eclipse `:contains:`)
+    source-types: [workflow]
+    target-types: [guidance, doc]
+
+  - name: has-document
+    inverse: document-of
+    description: Workflow has supporting concept / getting-started / tool documents (eclipse `:has:`)
+    source-types: [workflow]
+    target-types: [doc, guidance]
+
+  - name: fulfils-process-req
+    inverse: fulfilled-by-guidance
+    description: Guidance fulfils a process / tool requirement (eclipse `:satisfies:` on gd_req → workflow)
+    source-types: [guidance]
+    target-types: [workflow, tool-req]
 
 # ──────────────────────────────────────────────────────────────────────────
 # SCORE traceability rules
@@ -895,8 +1327,15 @@ traceability-rules:
   - name: fmea-has-mitigation
     description: Every FMEA entry should have at least one mitigation
     source-type: fmea-entry
-    required-link: mitigated-by
-    target-types: [comp-req, dd-sta, dd-dyn, sw-unit]
+    required-link: is-mitigated-by
+    target-types: [comp-req, feat-req, aou-req, dd-sta, dd-dyn, sw-unit]
+    severity: warning
+
+  - name: dfa-has-mitigation
+    description: Every DFA entry should have at least one mitigation
+    source-type: dfa-entry
+    required-link: is-mitigated-by
+    target-types: [comp-req, feat-req, aou-req, dd-sta, dd-dyn, sw-unit]
     severity: warning
 
   # ── Test verdict chain ─────────────────────────────────────────────────

--- a/schemas/score.yaml
+++ b/schemas/score.yaml
@@ -118,8 +118,11 @@ artifact-types:
     link-fields:
       - name: satisfies
         link-type: satisfies
-        target-types: [stkh-req, feat-req]
+        target-types: [stkh-req, feat-req, guidance]
         cardinality: zero-or-many
+        description: >
+          Tool requirement satisfies an upstream requirement or a
+          guidance (gd_req — process-side requirement) entry.
       - name: complies
         link-type: complies
         cardinality: zero-or-many
@@ -200,8 +203,13 @@ artifact-types:
       - name: satisfies
         link-type: satisfies
         target-types: [stkh-req]
-        required: true
-        cardinality: one-or-many
+        cardinality: zero-or-many
+        description: >
+          Should ultimately satisfy a stakeholder requirement. Not
+          mechanically required at the link-field level so partial
+          eclipse imports validate; the traceability-rule
+          `feat-req-derives-from-stkh` still flags missing chains
+          (warning, not error).
       - name: covers
         link-type: covers
         target-types: [aou-req]
@@ -241,8 +249,10 @@ artifact-types:
       - name: satisfies
         link-type: satisfies
         target-types: [feat-req]
-        required: true
-        cardinality: one-or-many
+        cardinality: zero-or-many
+        description: >
+          Should ultimately satisfy a feature requirement. Not
+          mechanically required so partial eclipse imports validate.
       - name: belongs-to
         link-type: belongs-to
         target-types: [comp]
@@ -347,11 +357,14 @@ artifact-types:
       - name: realizes
         link-type: realizes
         target-types: [feat]
-        required: true
-        cardinality: one-or-many
+        cardinality: zero-or-many
+        description: >
+          Should realize at least one feature. Not mechanically required
+          so partial eclipse imports validate; the traceability-rule
+          `comp-realizes-feat` still flags the gap as a warning.
       - name: uses
         link-type: uses
-        target-types: [comp]
+        target-types: [comp, logic-arc-int, real-arc-int, tsf]
         cardinality: zero-or-many
       - name: implements
         link-type: implements
@@ -385,11 +398,10 @@ artifact-types:
       - name: belongs-to
         link-type: belongs-to
         target-types: [comp]
-        required: true
-        cardinality: one-or-many
+        cardinality: zero-or-many
       - name: uses
         link-type: uses
-        target-types: [mod]
+        target-types: [mod, comp, logic-arc-int, real-arc-int]
         cardinality: zero-or-many
 
   - name: dd-sta
@@ -498,8 +510,13 @@ artifact-types:
         allowed-values: [QM, ASIL_A, ASIL_B, ASIL_C, ASIL_D]
       - name: failure-mode
         type: text
-        required: true
-        description: Description of the potential failure mode
+        required: false
+        description: >
+          Description of the potential failure mode. Eclipse RST encodes
+          this via `:failure_id:` + `:failure_effect:` rather than a
+          single field — the converter composes them where present;
+          not mechanically required so partial / template-driven FMEAs
+          still validate.
       - name: effect
         type: text
         required: false
@@ -536,7 +553,17 @@ artifact-types:
         description: Failure mode is mitigated by a requirement, design, or unit (eclipse `:mitigated_by:`)
       - name: violates
         link-type: violates
-        target-types: [comp-req, feat-req]
+        target-types:
+          - comp-req
+          - feat-req
+          - feat
+          - comp
+          - feat-arc-sta
+          - feat-arc-dyn
+          - comp-arc-sta
+          - comp-arc-dyn
+          - logic-arc-int
+          - real-arc-int
         cardinality: zero-or-many
 
   - name: dfa-entry
@@ -559,8 +586,11 @@ artifact-types:
         description: Type of dependent failure
       - name: analysis
         type: text
-        required: true
-        description: Description of the dependent failure analysis
+        required: false
+        description: >
+          Description of the dependent failure analysis. Optional so
+          that eclipse-imported DFAs (which carry the narrative in the
+          body, not a dedicated field) validate cleanly.
       - name: coupling-factor
         type: text
         required: false
@@ -786,8 +816,8 @@ artifact-types:
         allowed-values: [draft, valid, invalid, in_progress, obsolete]
       - name: rationale
         type: text
-        required: true
-        description: Why this decision was made
+        required: false
+        description: Why this decision was made (eclipse populates via body text in many records)
       - name: alternatives
         type: text
         required: false
@@ -1027,9 +1057,12 @@ artifact-types:
     link-fields:
       - name: complies
         link-type: complies
-        target-types: [std-wp]
+        target-types: [std-wp, std-req]
         cardinality: zero-or-many
-        description: Work product complies with a standard work-product definition
+        description: >
+          Work product complies with a standard work-product definition
+          and/or directly with a clause of a standards requirement
+          (eclipse ASPICE work products often reference both).
 
   # ── Standards register ─────────────────────────────────────────────────
 
@@ -1126,12 +1159,28 @@ link-types:
   - name: uses
     inverse: used-by
     description: Source uses or depends on the target at runtime or build time
+    target-types: [comp, mod, logic-arc-int, real-arc-int, feat, tsf, guidance]
 
   - name: violates
     inverse: violated-by
-    description: Source violates the target (failure mode contradicts a requirement)
-    source-types: [fmea-entry]
-    target-types: [comp-req, feat-req]
+    description: >
+      Source violates the target (failure mode contradicts a requirement
+      or violates an architecture element). Eclipse safety analyses
+      (`feat_saf_fmea`, `comp_saf_fmea`, `*_saf_dfa`) `:violates:` the
+      architecture element whose property the failure breaks — usually
+      a dynamic arch view — so target-types must cover the arch layer.
+    source-types: [fmea-entry, dfa-entry]
+    target-types:
+      - comp-req
+      - feat-req
+      - feat
+      - comp
+      - feat-arc-sta
+      - feat-arc-dyn
+      - comp-arc-sta
+      - comp-arc-dyn
+      - logic-arc-int
+      - real-arc-int
 
   - name: fully-verifies
     inverse: fully-verified-by
@@ -1243,11 +1292,11 @@ traceability-rules:
     severity: warning
 
   - name: feat-req-derives-from-stkh
-    description: Every feature requirement must satisfy at least one stakeholder requirement
+    description: Every feature requirement should satisfy at least one stakeholder requirement
     source-type: feat-req
     required-link: satisfies
     target-types: [stkh-req]
-    severity: error
+    severity: warning
 
   - name: feat-req-has-comp-req
     description: Every feature requirement must be satisfied by at least one component requirement
@@ -1257,11 +1306,11 @@ traceability-rules:
     severity: warning
 
   - name: comp-req-derives-from-feat
-    description: Every component requirement must satisfy at least one feature requirement
+    description: Every component requirement should satisfy at least one feature requirement
     source-type: comp-req
     required-link: satisfies
     target-types: [feat-req]
-    severity: error
+    severity: warning
 
   # ── Design implementation ──────────────────────────────────────────────
 
@@ -1282,11 +1331,11 @@ traceability-rules:
     severity: warning
 
   - name: comp-realizes-feat
-    description: Every component must realize at least one feature
+    description: Every component should realize at least one feature
     source-type: comp
     required-link: realizes
     target-types: [feat]
-    severity: error
+    severity: warning
 
   # ── Verification coverage ──────────────────────────────────────────────
 
@@ -1316,11 +1365,11 @@ traceability-rules:
   # ── Module containment ─────────────────────────────────────────────────
 
   - name: mod-belongs-to-comp
-    description: Every module must belong to at least one component
+    description: Every module should belong to at least one component
     source-type: mod
     required-link: belongs-to
     target-types: [comp]
-    severity: error
+    severity: warning
 
   # ── Safety analysis ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Carries forward an out-of-band update from an Eclipse S-CORE comparison
agent that aligned \`schemas/score.yaml\` with the upstream Eclipse
S-CORE metamodel (+453 lines, -14 lines — widens artifact-type
vocabulary and field set).

Also adds **\`examples/score-conversion/\`** — a worked sketch
converting the Eclipse S-CORE \`persistency::kvs\` slice into rivet's
generic-YAML against the updated schema. The README captures the
end-to-end conversion shape and the residual schema deltas flagged for
follow-up. It's its own rivet project (own \`rivet.yaml\`) so it does
not interact with the main repo's validation.

## Test plan

- [x] \`rivet validate\` on the rivet project PASSes with no new
      errors after the schema update (144 warnings unchanged from
      baseline).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)