### PR TITLE
ci(release): build full audit-deliverable compliance bundle (REQ-090)

### DIFF
--- a/.github/actions/compliance/action.yml
+++ b/.github/actions/compliance/action.yml
@@ -91,6 +91,21 @@ inputs:
     required: false
     default: '.'
 
+  # ── Audit bundle additions (REQ-090) ───────────────────────────────
+  include-data-formats:
+    description: >
+      When true, the report directory also includes a ReqIF 1.2 export
+      (`requirements.reqif`, OMG standard importable into DOORS /
+      Polarion / codeBeamer) and a generic-yaml export (`artifacts.yaml`,
+      human-readable diff-friendly) plus a `README.md` documenting the
+      bundle layout. This is the v0.13.0 audit-bundle shape: rendered
+      docs + coverage + matrix + validate + machine-importable data
+      side-by-side — what compliance reviewers actually need.
+
+      Defaults to `false` so existing callers see no behaviour change.
+    required: false
+    default: 'false'
+
 outputs:
   report-dir:
     description: 'Path to the directory containing the generated HTML files.'
@@ -208,6 +223,62 @@ runs:
 
         eval rivet export $ARGS
         echo "report-dir=${REPORT_OUTPUT}" >> "$GITHUB_OUTPUT"
+
+    - name: Add ReqIF + generic-yaml + README (REQ-090 audit bundle)
+      if: inputs.include-data-formats == 'true'
+      shell: bash
+      working-directory: ${{ inputs.project-dir }}
+      env:
+        REPORT_OUTPUT: ${{ inputs.output }}
+        REPORT_LABEL: ${{ steps.label.outputs.value }}
+      run: |
+        set -euo pipefail
+        # ReqIF (OMG standard) — importable into DOORS, Polarion, codeBeamer.
+        rivet export --format reqif --output "${REPORT_OUTPUT}/requirements.reqif"
+        # generic-yaml — diff-friendly, machine-readable, complete.
+        rivet export --format generic-yaml --output "${REPORT_OUTPUT}/artifacts.yaml"
+        # Bundle README — tells the reviewer what each piece is.
+        cat > "${REPORT_OUTPUT}/README.md" <<EOF
+        # Rivet compliance bundle — ${REPORT_LABEL}
+
+        This tarball is the full audit-deliverable view of the rivet
+        project at this release. It is meant to be opened on disk
+        (no web server required) and to feed downstream tools.
+
+        ## What's here
+
+        | Path                  | What it is                                        |
+        |-----------------------|---------------------------------------------------|
+        | \`index.html\`        | Project overview + navigation entry point.        |
+        | \`documents/\`        | Rendered SRS / SDD / SAD / STPA / etc. specs with resolved artifact tables. |
+        | \`coverage/\`         | Coverage percentage per traceability rule.        |
+        | \`matrix/\`           | Traceability matrix (type × type).                |
+        | \`validate/\`         | Validation diagnostics — same set \`rivet validate\` emits. |
+        | \`graph/\`            | Artifact dependency graph view.                   |
+        | \`stpa/\`             | STPA hierarchy (losses → hazards → constraints → controls). |
+        | \`eu-ai-act/\`        | EU AI Act compliance view (when the schema is loaded). |
+        | \`help/\`             | Per-schema-type help pages.                       |
+        | \`artifacts/\`        | Per-artifact detail pages — drilldown only.       |
+        | \`_assets/\`          | Shared CSS + JS (one copy, referenced by every page — REQ-088). |
+        | \`requirements.reqif\` | OMG ReqIF 1.2 export — importable into DOORS / Polarion / codeBeamer. |
+        | \`artifacts.yaml\`    | generic-yaml export — diff-friendly, complete.    |
+
+        ## Importing into a requirements-management tool
+
+        \`requirements.reqif\` is the OMG-standard ReqIF 1.2 format. In
+        DOORS, Polarion, and codeBeamer it imports as a new module
+        carrying every artifact, link, and field. \`artifacts.yaml\` is
+        the same data in rivet's native YAML — useful for grep, diff,
+        and re-ingestion into another rivet project.
+
+        ## Provenance
+
+        Generated from rivet ${REPORT_LABEL} by
+        \`.github/actions/compliance\` with \`include-data-formats: true\`.
+        Asset deduplication via REQ-088. ReqIF/generic-yaml exports
+        per REQ-090.
+        EOF
+        echo "Audit bundle additions emitted to ${REPORT_OUTPUT}/"
 
     - name: Create archive
       id: archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,18 @@ jobs:
         uses: ./.github/actions/compliance
         with:
           theme: dark
+          # REQ-090: ship the full audit-deliverable bundle, not the
+          # single-page nav-shell form. Multi-page emission is now
+          # ~50 MB total on the rivet corpus (REQ-088's shared-assets
+          # fix landed in #319), well within a GitHub Release artifact
+          # budget — and it's what auditors actually use (rendered
+          # specs with resolved artifact tables, per-rule coverage,
+          # matrix, validation).
+          single-page: false
+          # REQ-090: also include ReqIF 1.2 + generic-yaml + README in
+          # the same tarball so DOORS / Polarion / codeBeamer users
+          # get importable data alongside the rendered docs.
+          include-data-formats: true
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

REQ-090 — the GitHub Release now attaches the **audit-deliverable**
compliance bundle (rendered docs + coverage + matrix + validate + ReqIF
+ generic-yaml + README) instead of the ~7 MB navigation-shell HTML the
v0.12.0 release shipped (which the v0.11.1 audit findings flagged as
unusable).

## Changes

- **\`.github/actions/compliance/action.yml\`** — new opt-in input
  \`include-data-formats\` (default \`false\` so existing callers see
  no behaviour change). When true, the report directory gains
  \`requirements.reqif\`, \`artifacts.yaml\`, and a \`README.md\`
  documenting the bundle layout and DOORS/Polarion/codeBeamer import
  conventions.
- **\`.github/workflows/release.yml\`** — \`build-compliance\` job
  sets \`single-page: false\` (the multi-page form) and
  \`include-data-formats: true\`. Multi-page emission is now ~50 MB
  total on the rivet corpus thanks to REQ-088's shared-assets fix
  (#319), well within a GitHub Release artifact budget. Existing
  tarball / upload / \`create-release\` plumbing picks the new
  contents up unchanged.

## Test plan

- [x] Local smoke: \`rivet export --format reqif --output …\` and
      \`--format generic-yaml --output …\` produce 2.6 MB / 628 KB
      on the rivet corpus (795 artifacts).
- [x] YAML lint OK (both files parse).
- [ ] CI green on this PR.
- [ ] First real exercise = the v0.13.0 tag-push that this PR is
      paving the way for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)