### PR TITLE
release(v0.13.0): cross-repo feature models + audit-deliverable releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-05-24
+
+Theme: **cross-repo feature models + audit-deliverable releases**.
+v0.12.0's multi-file feature-model composition (REQ-083) now reaches
+across git repositories via the consumer's `rivet.yaml` `externals:`,
+and the GitHub Release ships the full audit bundle auditors actually
+use instead of navigation-shell HTML.
+
+### Added
+
+- **REQ-085 — cross-repo feature model composition.** A mount in a
+  `feature-model-binding` of the form `<external-prefix>:<inner-path>`
+  resolves through the consumer's `rivet.yaml` `externals:` — single
+  source of truth, no git config duplicated in the binding. Rides the
+  existing `rivet sync` plumbing entirely. Both the core API
+  (`FeatureModel::load_composed_with_externals` /
+  `FeatureModel::load_with_externals`) and the CLI (`rivet variant`,
+  `rivet validate --model`) are threaded; an unknown prefix is a hard
+  error, never a silent local-path fallback (REQ-083 F2 ethos).
+- **REQ-090 — audit-deliverable release bundle.** The GitHub Release
+  attaches the full ~50 MB compliance tarball — rendered specs with
+  resolved artifact tables + coverage + matrix + validate + ReqIF
+  (OMG, importable into DOORS / Polarion / codeBeamer) +
+  generic-yaml + README — instead of the previous 7 MB navigation
+  shell. The compliance action grows an opt-in
+  `include-data-formats` input (default false, backward-compatible);
+  release.yml flips `single-page: false` + `include-data-formats: true`.
+  Feasible at this size because v0.12.0's REQ-088 shared-assets
+  dedup landed.
+
+### Documented (no implementation in v0.13.0)
+
+- **REQ-091** — clean-room-verified finding:
+  `yaml_hir::extract_schema_driven` (the default rowan-yaml salsa
+  load path) silently drops flush-left artifacts. The original
+  parallel-agent attribution (`GenericYamlAdapter` /
+  `parse_generic_yaml`) was falsified by probe — those return the
+  expected 1 artifact + 1 link. Contributing factor:
+  `extract_links_via_serde` silently `Vec::new()`s on
+  `serde_yaml::from_str` parse error. Fix tracked for v0.13.1;
+  `rivet validate --direct` (legacy non-incremental) is the reliable
+  path in the meantime.
+- **REQ-092** — `rivet source-link` design: per-source-line
+  traceability (Eclipse S-CORE `score_source_code_linker` equivalent)
+  for projects converging S-CORE → rivet. v0.14.0-track.
+
+### Maintenance
+
+- `schemas/score.yaml` aligned with an Eclipse S-CORE comparison
+  (+453 lines, -14 lines); worked conversion sketch added under
+  `examples/score-conversion/`.
+- `rules_rocq_rust` bumped to `e4660cc` (hermetic rules_rust toolchain)
+  in the Bazel module config.
+- Test stabilisation: `server_pages_push_url` switched to a 15s
+  timeout + retry-on-status-0 to absorb the runner-load flake class.
+
 ## [0.12.0] — 2026-05-22
 
 Theme: **multi-file feature models**. A product line can now be authored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,13 @@ use instead of navigation-shell HTML.
   `parse_generic_yaml`) was falsified by probe — those return the
   expected 1 artifact + 1 link. Contributing factor:
   `extract_links_via_serde` silently `Vec::new()`s on
-  `serde_yaml::from_str` parse error. Fix tracked for v0.13.1;
-  `rivet validate --direct` (legacy non-incremental) is the reliable
-  path in the meantime.
-- **REQ-092** — `rivet source-link` design: per-source-line
-  traceability (Eclipse S-CORE `score_source_code_linker` equivalent)
-  for projects converging S-CORE → rivet. v0.14.0-track.
+  `serde_yaml::from_str` parse error. Fix tracked for the next patch
+  release; `rivet validate --direct` (legacy non-incremental) is the
+  reliable path in the meantime.
+- **REQ-092** — design for a future per-source-line traceability
+  subcommand (Eclipse S-CORE `score_source_code_linker` equivalent)
+  to ease S-CORE → rivet migration. Tracked for a later minor
+  release.
 
 ### Maintenance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

v0.13.0 — minor release. Theme: **cross-repo feature models + audit-deliverable releases**.

- **REQ-085** — cross-repo feature model composition end-to-end. A mount of the form \`<external-prefix>:<inner-path>\` in a \`feature-model-binding\` resolves through the consumer's \`rivet.yaml\` \`externals:\`. Both the core API (\`FeatureModel::load_composed_with_externals\` / \`load_with_externals\`) and the CLI (\`rivet variant\`, \`rivet validate --model\`) are threaded. Single source of truth — no binding-side git config. Rides existing \`rivet sync\` plumbing. Unknown prefixes error loudly.
- **REQ-090** — the GitHub Release now attaches the full ~50 MB compliance bundle (rendered specs with resolved artifact tables + coverage + matrix + validate + ReqIF + generic-yaml + README) instead of the 7 MB navigation-shell HTML the v0.12.0 release shipped. Feasible at this size because v0.12.0's REQ-088 shared-assets dedup landed.

### Documented (no code in v0.13.0)

- **REQ-091** — rowan-yaml silent-data-loss finding (clean-room-verified; original attribution falsified). Fix → v0.13.1.
- **REQ-092** — \`rivet source-link\` design (Eclipse S-CORE per-line equivalent). v0.14.0-track.

### Maintenance

- score schema aligned with Eclipse S-CORE comparison + worked example.
- \`rules_rocq_rust\` → \`e4660cc\` (hermetic rules_rust toolchain).
- \`server_pages_push_url\` flake fix.

## Test plan

- [x] cargo check --workspace clean.
- [ ] CI green (only known \`continue-on-error\` reds permitted: Rocq, Verus, Miri).
- [ ] After merge: tag \`v0.13.0\`, verify GitHub Release + crates.io publish via \`pulseengine-claude:release-execution\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)