### PR TITLE
chore(deps): bump spar pin 84a7363 → v0.10.0 tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +515,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cobs"
@@ -1257,6 +1306,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "good_lp"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf53d2a05420f562c917615b80018647ca03766aa58376de077034627da0fb10"
+dependencies = [
+ "fnv",
+ "highs",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1405,26 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "highs"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ef3d7c6bd21aaa82a1a3530a5529ba82c9a398b24d626c62de532afeb94ecd"
+dependencies = [
+ "highs-sys",
+ "log",
+]
+
+[[package]]
+name = "highs-sys"
+version = "1.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a9fa9dea5b5f277075460b695db30ad7e5ce28554f2dd27c312c640acd101f"
+dependencies = [
+ "bindgen",
+ "cmake",
+]
 
 [[package]]
 name = "http"
@@ -1872,6 +1957,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2149,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3297,19 +3408,20 @@ dependencies = [
 
 [[package]]
 name = "spar-analysis"
-version = "0.1.0"
-source = "git+https://github.com/pulseengine/spar.git?rev=84a7363#84a73630986d194f548541fc86f6c98ef6d79de1"
+version = "0.10.0"
+source = "git+https://github.com/pulseengine/spar.git?tag=v0.10.0#afd5da28ba7f8d678b4741f96eb580456430c87b"
 dependencies = [
  "la-arena",
  "rustc-hash 2.1.2",
  "serde",
  "spar-hir-def",
+ "spar-network",
 ]
 
 [[package]]
 name = "spar-annex"
-version = "0.1.0"
-source = "git+https://github.com/pulseengine/spar.git?rev=84a7363#84a73630986d194f548541fc86f6c98ef6d79de1"
+version = "0.10.0"
+source = "git+https://github.com/pulseengine/spar.git?tag=v0.10.0#afd5da28ba7f8d678b4741f96eb580456430c87b"
 dependencies = [
  "rowan 0.16.1",
  "spar-syntax",
@@ -3317,8 +3429,8 @@ dependencies = [
 
 [[package]]
 name = "spar-base-db"
-version = "0.1.0"
-source = "git+https://github.com/pulseengine/spar.git?rev=84a7363#84a73630986d194f548541fc86f6c98ef6d79de1"
+version = "0.10.0"
+source = "git+https://github.com/pulseengine/spar.git?tag=v0.10.0#afd5da28ba7f8d678b4741f96eb580456430c87b"
 dependencies = [
  "rowan 0.16.1",
  "salsa",
@@ -3328,8 +3440,8 @@ dependencies = [
 
 [[package]]
 name = "spar-hir"
-version = "0.1.0"
-source = "git+https://github.com/pulseengine/spar.git?rev=84a7363#84a73630986d194f548541fc86f6c98ef6d79de1"
+version = "0.10.0"
+source = "git+https://github.com/pulseengine/spar.git?tag=v0.10.0#afd5da28ba7f8d678b4741f96eb580456430c87b"
 dependencies = [
  "salsa",
  "serde",
@@ -3341,8 +3453,8 @@ dependencies = [
 
 [[package]]
 name = "spar-hir-def"
-version = "0.1.0"
-source = "git+https://github.com/pulseengine/spar.git?rev=84a7363#84a73630986d194f548541fc86f6c98ef6d79de1"
+version = "0.10.0"
+source = "git+https://github.com/pulseengine/spar.git?tag=v0.10.0#afd5da28ba7f8d678b4741f96eb580456430c87b"
 dependencies = [
  "la-arena",
  "rowan 0.16.1",
@@ -3355,17 +3467,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spar-network"
+version = "0.10.0"
+source = "git+https://github.com/pulseengine/spar.git?tag=v0.10.0#afd5da28ba7f8d678b4741f96eb580456430c87b"
+dependencies = [
+ "good_lp",
+ "spar-hir-def",
+]
+
+[[package]]
 name = "spar-parser"
-version = "0.1.0"
-source = "git+https://github.com/pulseengine/spar.git?rev=84a7363#84a73630986d194f548541fc86f6c98ef6d79de1"
+version = "0.10.0"
+source = "git+https://github.com/pulseengine/spar.git?tag=v0.10.0#afd5da28ba7f8d678b4741f96eb580456430c87b"
 dependencies = [
  "rowan 0.16.1",
 ]
 
 [[package]]
 name = "spar-syntax"
-version = "0.1.0"
-source = "git+https://github.com/pulseengine/spar.git?rev=84a7363#84a73630986d194f548541fc86f6c98ef6d79de1"
+version = "0.10.0"
+source = "git+https://github.com/pulseengine/spar.git?tag=v0.10.0#afd5da28ba7f8d678b4741f96eb580456430c87b"
 dependencies = [
  "rowan 0.16.1",
  "spar-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,5 +119,5 @@ pulldown-cmark = { version = "0.12", default-features = false, features = ["html
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # AADL (spar) — parser, HIR, analysis
-spar-hir = { git = "https://github.com/pulseengine/spar.git", rev = "84a7363" }
-spar-analysis = { git = "https://github.com/pulseengine/spar.git", rev = "84a7363" }
+spar-hir = { git = "https://github.com/pulseengine/spar.git", tag = "v0.10.0" }
+spar-analysis = { git = "https://github.com/pulseengine/spar.git", tag = "v0.10.0" }


### PR DESCRIPTION
## Summary
- Promotes the spar git pin from the pre-v0.9.0 dev sha (`84a7363`,
  March 2026) to the signed `v0.10.0` tag (`afd5da2`).
- Bug fixes inherited (hir-def, assertion-eval, classifier-match) +
  new v0.10.x capabilities surfaced (EMV2 connection-graph
  propagation, NC tightness, mermaid emitters, trace-topology).
- `rivet-core/src/formats/aadl.rs` — the only spar consumer in rivet
  — needs **no code change**. The 25-pass analysis registration +
  spar-hir Database surface compiles unchanged against v0.10.0.

## Why v0.10.0 and not HEAD?
spar's `origin/main` is mid-v0.11.0 (in-flight trace-topology +
QEMU fixture work). v0.10.0 is the most recent **signed tag** with
the bug-fix burden cleared; v0.11.0 work is staged for the next
spar release tag. This bump is conservative on purpose.

## Test plan
- [x] `cargo check -p rivet-core` — PASS
- [x] `cargo test -p rivet-core aadl` — PASS (3 aadl_* + 2 schema tests)
- [x] `cargo test --workspace --no-fail-fast` — PASS (1 spurious failure
      in `query_ids_format_matches_list_filter` caused by simultaneous
      branch-switching during the run; re-ran cleanly in isolation: PASS)
- [ ] CI

## Inherited fixes worth flagging
- hir-def: `applies_to` accepts feature paths (AADL v2.3, spar #219)
- hir-def: nested binding path resolution, 3+ levels (spar #214)
- assertion-eval: `has()` matches features (spar #217)
- assertion-eval: `count()` comparisons evaluate correctly (spar #218)
- classifier-match: same-direction delegation bus access (spar #216)

🤖 Generated with [Claude Code](https://claude.com/claude-code)