### PR TITLE
fix(yaml): rowan parser handles flush-left block sequences + links loud-fail (REQ-091, v0.13.1)

### DIFF
--- a/rivet-cli/tests/migrate_integration.rs
+++ b/rivet-cli/tests/migrate_integration.rs
@@ -156,7 +156,7 @@ fn plan_dev_to_aspice_writes_plan_and_manifest() {
 }
 
 #[test]
-fn apply_rewrites_dev_to_aspice_and_validate_passes() {
+fn apply_rewrites_dev_to_aspice_and_validate_reports_expected_link_gaps() {
     let (_tmp, dir) = make_dev_project();
     // Plan first.
     let plan = run_rivet(&dir, &["schema", "migrate", "aspice"]);
@@ -206,20 +206,47 @@ fn apply_rewrites_dev_to_aspice_and_validate_passes() {
     );
 
     // Migration doesn't update rivet.yaml in Phase 1 — the user is
-    // expected to do that separately. For the test we patch
-    // rivet.yaml to load aspice schemas, then assert `rivet validate`
-    // exits 0 on the migrated tree.
+    // expected to do that separately. Patch rivet.yaml to load aspice
+    // schemas, then check `rivet validate` behaviour.
     let cfg = dir.join("rivet.yaml");
     let cfg_text = std::fs::read_to_string(&cfg).unwrap();
     let patched = cfg_text.replace("- dev", "- aspice");
     std::fs::write(&cfg, patched).unwrap();
 
+    // The dev preset's sample artifacts (REQ-001, FEAT-001) carry no
+    // upstream system-level link, so once they are renamed to
+    // sw-req / sw-arch-component the aspice schema's cardinality
+    // rules (`derives-from`, `allocated-from`) cannot be satisfied
+    // without the user manually attaching links to system-level
+    // artifacts. The migration is intentionally structural-only — it
+    // renames types in place, it does not invent semantic links — so
+    // validate is *expected* to fail with exactly those two cardinality
+    // errors and nothing else. This documents the migration's
+    // contract: post-migration, the user attaches semantic links;
+    // until they do, `rivet validate` names exactly what is missing.
+    //
+    // Pre-REQ-091: the rowan-yaml CST silently dropped flush-left
+    // sequences (which is the format serde_yaml::to_string emits),
+    // so validate read zero artifacts from the migrated files and
+    // exited 0 — the test "passed" by hiding the gap. After REQ-091
+    // the validator sees the artifacts and surfaces the real link
+    // obligations.
     let val = run_rivet(&dir, &["validate"]);
     assert!(
-        val.status.success(),
-        "post-migration validate failed:\nstderr={}\nstdout={}",
-        String::from_utf8_lossy(&val.stderr),
-        String::from_utf8_lossy(&val.stdout)
+        !val.status.success(),
+        "post-migration validate should report missing aspice links \
+         (the migration renames types but cannot invent links)"
+    );
+    let stdout = String::from_utf8_lossy(&val.stdout);
+    assert!(
+        stdout.contains("derives-from"),
+        "expected a 'derives-from' cardinality error for the migrated \
+         sw-req artifact; got stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("allocated-from"),
+        "expected an 'allocated-from' cardinality error for the migrated \
+         sw-arch-component artifact; got stdout:\n{stdout}"
     );
 }
 

--- a/rivet-core/src/yaml_cst.rs
+++ b/rivet-core/src/yaml_cst.rs
@@ -710,14 +710,22 @@ impl<'src> Parser<'src> {
                 }
                 if !self.at_eof() {
                     let child_indent = self.current_indent();
-                    if child_indent > entry_indent {
-                        if self.at(SyntaxKind::Dash) {
-                            self.parse_block_sequence(child_indent);
-                        } else {
-                            self.parse_block_mapping(child_indent);
-                        }
+                    if self.at(SyntaxKind::Dash) && child_indent >= entry_indent {
+                        // YAML "zero-indent" block sequence (flush-left under
+                        // a mapping key): a `- item` line at the same column
+                        // as the parent key is a child sequence of that key.
+                        // Required for documents like
+                        //     artifacts:
+                        //     - id: A
+                        // where `artifacts:` is at indent 0 and the sequence
+                        // items cannot indent further. Without this branch
+                        // the value silently becomes empty and the link graph
+                        // disappears from the salsa validate path (REQ-091).
+                        self.parse_block_sequence(child_indent);
+                    } else if child_indent > entry_indent {
+                        self.parse_block_mapping(child_indent);
                     }
-                    // If child_indent <= entry_indent, empty value
+                    // Else: empty value.
                 }
             }
             // Empty value or EOF

--- a/rivet-core/src/yaml_hir.rs
+++ b/rivet-core/src/yaml_hir.rs
@@ -669,7 +669,7 @@ fn extract_section_item(
                 field_spans.insert("tags".into(), value_span);
             }
             "links" => {
-                links.extend(extract_links(&value_node));
+                links.extend(extract_links(&value_node, &mut result.diagnostics));
                 field_spans.insert("links".into(), value_span);
             }
             "provenance" => {
@@ -885,7 +885,7 @@ fn extract_artifact_from_item(item: &SyntaxNode, result: &mut ParsedYamlFile) {
                 field_spans.insert("tags".into(), value_span);
             }
             "links" => {
-                links = extract_links(&value_node);
+                links = extract_links(&value_node, &mut result.diagnostics);
                 field_spans.insert("links".into(), value_span);
             }
             "provenance" => {
@@ -1011,7 +1011,7 @@ fn extract_artifact_from_item(item: &SyntaxNode, result: &mut ParsedYamlFile) {
 
 // ── Link extraction ────────────────────────────────────────────────────
 
-fn extract_links(value_node: &SyntaxNode) -> Vec<Link> {
+fn extract_links(value_node: &SyntaxNode, diagnostics: &mut Vec<ParseDiagnostic>) -> Vec<Link> {
     let mut links = Vec::new();
 
     // Links is a Sequence of Mappings: each with "type" + "target".
@@ -1022,7 +1022,7 @@ fn extract_links(value_node: &SyntaxNode) -> Vec<Link> {
     // and block styles produce identical links and prevents silent
     // under-counting by the cardinality validator.
     let Some(seq) = child_of_kind(value_node, SyntaxKind::Sequence) else {
-        return extract_links_via_serde(value_node);
+        return extract_links_via_serde(value_node, diagnostics);
     };
 
     for item in seq.children() {
@@ -1108,27 +1108,48 @@ fn extract_links(value_node: &SyntaxNode) -> Vec<Link> {
     links
 }
 
-/// Fallback parser for `links:` values the CST didn't recognise as a block
-/// `Sequence` — most importantly flow-style `[{type: X, target: Y}, ...]`.
-/// Re-parses the value text via serde_yaml and converts `type` + `target`
-/// into `Link`s. Unknown shapes and parse errors silently produce no
-/// links (matching the permissive behaviour of the primary path).
+/// Fallback parser for `links:` values the CST didn't recognise as a
+/// block `Sequence` — most importantly flow-style
+/// `[{type: X, target: Y}, ...]`. Re-parses the value text via
+/// `serde_yaml` and converts `type` + `target` into `Link`s.
+///
+/// Loud-fail on parse error (REQ-091): if `serde_yaml::from_str`
+/// rejects the value text, push a parse diagnostic naming the
+/// underlying error and return an empty link list. The previous
+/// behaviour silently returned `Vec::new()`, which an outer
+/// cardinality validator then read as "links field present but empty"
+/// — an F2-class silent failure that hid malformed `links:` blocks
+/// from CI grading.
 ///
 /// Accepts both the flat-string and the structured `target:` mapping
 /// shapes (issue #288) by delegating directly to `Link`'s
 /// `Deserialize` impl.
-fn extract_links_via_serde(value_node: &SyntaxNode) -> Vec<Link> {
+fn extract_links_via_serde(
+    value_node: &SyntaxNode,
+    diagnostics: &mut Vec<ParseDiagnostic>,
+) -> Vec<Link> {
     let text = value_node.text().to_string();
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return Vec::new();
     }
-    let Ok(raws) = serde_yaml::from_str::<Vec<Link>>(trimmed) else {
-        return Vec::new();
-    };
-    raws.into_iter()
-        .filter(|l| !l.link_type.is_empty() && !l.target.is_empty())
-        .collect()
+    match serde_yaml::from_str::<Vec<Link>>(trimmed) {
+        Ok(raws) => raws
+            .into_iter()
+            .filter(|l| !l.link_type.is_empty() && !l.target.is_empty())
+            .collect(),
+        Err(err) => {
+            diagnostics.push(ParseDiagnostic {
+                span: Span::from_text_range(value_node.text_range()),
+                message: format!(
+                    "failed to parse `links:` value as a sequence of {{type, target}} \
+                     entries: {err}"
+                ),
+                severity: Severity::Error,
+            });
+            Vec::new()
+        }
+    }
 }
 
 /// Strip the minimum common leading-whitespace prefix from every
@@ -1850,6 +1871,41 @@ artifacts:
         let hir = extract_generic_artifacts(source);
         assert!(hir.artifacts.is_empty());
         assert!(hir.diagnostics.is_empty());
+    }
+
+    /// REQ-091 Acceptance #3 — F2 loud-fail: when the `links:` value is
+    /// not a Sequence the parser recognises AND `serde_yaml` cannot
+    /// reparse it as a `Vec<Link>`, emit a parse diagnostic instead of
+    /// silently returning an empty link list. Previously this branch
+    /// returned `Vec::new()` with no signal, which the cardinality
+    /// validator then graded as "links field present but empty."
+    #[test]
+    fn extract_links_via_serde_emits_diagnostic_on_parse_error() {
+        let source = "\
+artifacts:
+  - id: A-1
+    type: req
+    title: Malformed links value
+    links: not a list, just a string
+";
+        let hir = extract_generic_artifacts(source);
+        assert_eq!(
+            hir.artifacts.len(),
+            1,
+            "the artifact itself must still extract"
+        );
+        assert!(
+            hir.artifacts[0].artifact.links.is_empty(),
+            "no parseable links → empty link vec"
+        );
+        assert!(
+            hir.diagnostics
+                .iter()
+                .any(|d| d.message.contains("`links:`")),
+            "expected a loud-fail diagnostic naming the `links:` field; \
+             got: {:?}",
+            hir.diagnostics
+        );
     }
 
     /// 7. Missing id → ParseDiagnostic error.

--- a/rivet-core/tests/req_091_flush_left_yaml.rs
+++ b/rivet-core/tests/req_091_flush_left_yaml.rs
@@ -1,0 +1,166 @@
+// SAFETY-REVIEW (SCRC Phase 1, DD-058): Integration test / bench code.
+// Tests legitimately use unwrap/expect/panic/assert-indexing patterns
+// because a test failure should panic with a clear stack. Blanket-allow
+// the Phase 1 restriction lints at crate scope; real risk analysis for
+// these lints is carried by production code in rivet-core/src and
+// rivet-cli/src, not by the test harnesses.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::wildcard_enum_match_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::print_stderr
+)]
+
+//! REQ-091 regression: the rowan-yaml salsa parser must extract links
+//! from artifacts written in YAML's flush-left (zero-indent) list style.
+//!
+//! Until this fix, `yaml_hir::extract_schema_driven` (the default salsa
+//! load path) returned 0 artifacts + 0 diagnostics for flush-left files
+//! while `parse_generic_yaml` (the `--direct` legacy path) returned
+//! them correctly. The link graph silently disappeared from the
+//! validator's grading. Clean-room verified before the fix.
+//!
+//! Drives `extract_schema_driven` directly with both fixture shapes and
+//! asserts identical artifact + link counts.
+//!
+//! rivet: verifies REQ-091
+
+use rivet_core::schema::Schema;
+use rivet_core::yaml_hir::extract_schema_driven;
+
+/// An empty merged Schema is sufficient: when no artifact-type declares
+/// `yaml-section: artifacts`, `extract_schema_driven` falls through to
+/// the generic `artifacts:`-key extraction path (the same code path the
+/// salsa validate stack actually uses for generic-yaml files). That is
+/// exactly the path REQ-091 says is broken for flush-left input.
+fn empty_schema() -> Schema {
+    Schema::merge(&[])
+}
+
+/// REQ-091 Acceptance #1 + #4: extract_schema_driven returns 1 artifact
+/// + 1 link for flush-left YAML, matching the indented form exactly.
+#[test]
+fn extract_schema_driven_handles_flush_left_list() {
+    let flush = "\
+artifacts:
+- id: COMP_REQ__FLUSH__A
+  type: comp-req
+  title: Flush-left
+  status: approved
+  links:
+  - type: satisfies
+    target: COMP_REQ__OTHER__B
+";
+    let indent = "\
+artifacts:
+  - id: COMP_REQ__INDENT__A
+    type: comp-req
+    title: Indented
+    status: approved
+    links:
+      - type: satisfies
+        target: COMP_REQ__OTHER__B
+";
+    let schema = empty_schema();
+
+    let f = extract_schema_driven(flush, &schema, None);
+    let i = extract_schema_driven(indent, &schema, None);
+
+    assert!(
+        f.diagnostics.is_empty(),
+        "flush-left fixture must parse without diagnostics; got: {:?}",
+        f.diagnostics
+    );
+    assert!(
+        i.diagnostics.is_empty(),
+        "indented fixture must parse without diagnostics; got: {:?}",
+        i.diagnostics
+    );
+
+    assert_eq!(
+        f.artifacts.len(),
+        1,
+        "flush-left: expected 1 artifact, got {}",
+        f.artifacts.len()
+    );
+    assert_eq!(
+        i.artifacts.len(),
+        1,
+        "indented: expected 1 artifact, got {}",
+        i.artifacts.len()
+    );
+
+    let f_links = &f.artifacts[0].artifact.links;
+    let i_links = &i.artifacts[0].artifact.links;
+    assert_eq!(
+        f_links.len(),
+        1,
+        "flush-left: expected 1 link (this is the REQ-091 regression — \
+         the rowan parser used to drop flush-left sequences entirely)"
+    );
+    assert_eq!(i_links.len(), 1);
+    assert_eq!(f_links[0].link_type, "satisfies");
+    assert_eq!(f_links[0].target, "COMP_REQ__OTHER__B");
+    assert_eq!(i_links[0].link_type, "satisfies");
+    assert_eq!(i_links[0].target, "COMP_REQ__OTHER__B");
+}
+
+/// Cross-style parity: flush-left and indented forms must produce
+/// structurally-identical artifact records (id excepted) so that the
+/// salsa path and the `--direct` path grade identically.
+#[test]
+fn flush_left_and_indented_produce_equivalent_artifacts() {
+    let flush = "\
+artifacts:
+- id: REQ-A
+  type: comp-req
+  title: Flush
+  status: draft
+  links:
+  - type: satisfies
+    target: REQ-B
+  - type: satisfies
+    target: REQ-C
+";
+    let indent = "\
+artifacts:
+  - id: REQ-A
+    type: comp-req
+    title: Flush
+    status: draft
+    links:
+      - type: satisfies
+        target: REQ-B
+      - type: satisfies
+        target: REQ-C
+";
+    let schema = empty_schema();
+    let f = extract_schema_driven(flush, &schema, None);
+    let i = extract_schema_driven(indent, &schema, None);
+
+    assert_eq!(f.artifacts.len(), i.artifacts.len(), "artifact count mismatch");
+    assert_eq!(
+        f.artifacts[0].artifact.links.len(),
+        i.artifacts[0].artifact.links.len(),
+        "link count mismatch (REQ-091)"
+    );
+    assert_eq!(
+        f.artifacts[0].artifact.id,
+        i.artifacts[0].artifact.id
+    );
+    assert_eq!(
+        f.artifacts[0].artifact.title,
+        i.artifacts[0].artifact.title
+    );
+}

--- a/rivet-core/tests/req_091_flush_left_yaml.rs
+++ b/rivet-core/tests/req_091_flush_left_yaml.rs
@@ -149,18 +149,16 @@ artifacts:
     let f = extract_schema_driven(flush, &schema, None);
     let i = extract_schema_driven(indent, &schema, None);
 
-    assert_eq!(f.artifacts.len(), i.artifacts.len(), "artifact count mismatch");
+    assert_eq!(
+        f.artifacts.len(),
+        i.artifacts.len(),
+        "artifact count mismatch"
+    );
     assert_eq!(
         f.artifacts[0].artifact.links.len(),
         i.artifacts[0].artifact.links.len(),
         "link count mismatch (REQ-091)"
     );
-    assert_eq!(
-        f.artifacts[0].artifact.id,
-        i.artifacts[0].artifact.id
-    );
-    assert_eq!(
-        f.artifacts[0].artifact.title,
-        i.artifacts[0].artifact.title
-    );
+    assert_eq!(f.artifacts[0].artifact.id, i.artifacts[0].artifact.id);
+    assert_eq!(f.artifacts[0].artifact.title, i.artifacts[0].artifact.title);
 }


### PR DESCRIPTION
## Summary
Two REQ-091 fixes that together close the F2 silent-failure where the default \`rivet validate\` (salsa + rowan-yaml) silently graded **zero** links for artifacts written in YAML's flush-left list style.

### The CST bug — flush-left sequences silently dropped
\`yaml_cst::parse_mapping_entry\` required \`child_indent > entry_indent\` when descending into a same-line \`value\`. YAML allows the zero-indent block sequence form where the dashed list sits at the same column as the parent key:

\`\`\`yaml
artifacts:
- id: A           # <-- dash at column 0, same column as "artifacts:"
  type: req
\`\`\`

For this shape the parser silently treated the value as **empty** and dropped the entire sequence from the tree. \`extract_schema_driven\` then returned 0 artifacts + 0 diagnostics, while \`rivet list\` (which routes through the legacy \`parse_generic_yaml\`) returned the artifact correctly — the link graph the validator should grade was **invisible**.

The fix: when the next-line content is a \`Dash\`, accept \`child_indent >= entry_indent\` (YAML 1.2's zero-indent block-sequence rule).

CST probe — both shapes now produce identical trees:
\`Mapping → MappingEntry → Value → Sequence → SequenceItem → Mapping\`.

### The F2 silent-failure — \`extract_links_via_serde\` silently returned empty
The fallback for \`links:\` values the CST doesn't recognise as a block \`Sequence\` (most importantly flow-style \`links: [{type:X, target:Y}]\`) silently returned \`Vec::new()\` when \`serde_yaml::from_str\` rejected the value text. The outer cardinality validator then graded that as "links field present but empty."

Threads \`&mut Vec<ParseDiagnostic>\` through \`extract_links\` and \`extract_links_via_serde\`. On serde parse error, emit an ERROR diagnostic naming the underlying error and the value's span.

## Tests
- New: \`rivet-core/tests/req_091_flush_left_yaml.rs\` — drives \`extract_schema_driven\` with both flush-left and indented fixtures; asserts 1 artifact + 1 link parity (Acceptance #1 + #4).
- New: \`yaml_hir::tests::extract_links_via_serde_emits_diagnostic_on_parse_error\` — malformed \`links:\` produces a diagnostic naming the field (Acceptance #3).

## Test plan
- [x] \`cargo test -p rivet-core\` — all tests pass (1068 lib + 83 yaml-test-suite + 2 new integration tests)
- [x] \`rivet validate\` smoke test on this repo's corpus — PASS
- [x] CST probe before vs after — flush-left now produces the same tree as indented
- [ ] CI

## What this does NOT do
Acceptance #5 — re-grading the parallel agent's sphinx-needs port corpus against the Python reference's ~2500 warnings — requires their \`feat/import-results-sphinx-needs\` branch. Once this lands they can rebase and re-grade.

Fixes: REQ-091
Refs: REQ-051, REQ-082

🤖 Generated with [Claude Code](https://claude.com/claude-code)