### PR TITLE
fix(ci): Rocq Proofs job — use cachix Nix installer (match working synth pattern)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,24 +640,18 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
-      # Same NoNewPrivileges constraint as the verus job above — use the
-      # DeterminateSystems installer which works without sudo.
+      # `ubuntu-latest` is GitHub-hosted (full sudo, no NoNewPrivileges) so
+      # the standard cachix multi-user installer works here — matches the
+      # green `synth` pattern (`pulseengine/synth/.github/workflows/ci.yml`,
+      # `bazel` job). The DeterminateSystems daemonless variant we used
+      # before emitted `unknown setting 'build-provenance-tags'` and then
+      # failed with `Permission denied` on `/nix/var/nix/db/big-lock` —
+      # that constraint was copied from the self-hosted verus job (which
+      # IS NoNewPrivileges) and never applied to this `ubuntu-latest` job.
       - name: Install Nix
-        # Pinned by SHA + `determinate: false`. The action's `determinate`
-        # input default flipped false->true between v17 and v22, so the
-        # former `@main` pin started installing Determinate Nix, whose
-        # `determinate-nixd` daemon ignores `init: none` and fails on
-        # no-sudo / NoNewPrivileges runners (missing daemon socket,
-        # root-owned store lock). `determinate: false` restores the plain
-        # upstream daemonless install this job was written for.
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        uses: cachix/install-nix-action@v30
         with:
-          determinate: false
-          init: none
-          extra-conf: |
-            experimental-features = nix-command flakes
-      - name: Add Nix to PATH
-        run: echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: Verify Rocq proofs
         run: bazel test //proofs/rocq:rivet_metamodel_test
 


### PR DESCRIPTION
## Summary
The Rocq Proofs job has been red on every PR because its `Install Nix` step has been failing with:

\`\`\`
warning: unknown setting 'build-provenance-tags'
error: opening lock file "/nix/var/nix/db/big-lock": Permission denied
ERROR: ... fetch of repository 'rules_rocq_rust++rocq+rocq_toolchains'
\`\`\`

**Root cause**: The job uses `DeterminateSystems/nix-installer-action@v22` with `determinate: false` + `init: none` — a config copied from the **self-hosted** verus job (which IS `NoNewPrivileges=true` and genuinely needs the daemonless path). The rocq job runs on `ubuntu-latest`, which is GitHub-hosted with full sudo. The NoNewPrivileges constraint never applied here, but the comment kept claiming it did.

The DeterminateSystems daemonless variant emits `build-provenance-tags` (a Determinate-Nix-specific setting) and then fails to acquire the store lock — the failure mode that has been red for several PR cycles.

**Fix**: Match the working `synth` pattern. The sibling pulseengine repo `synth` runs the same Rocq-of-Rust / Bazel / Nix chain on `ubuntu-latest` with the standard `cachix/install-nix-action@v30 + nix_path: nixpkgs=channel:nixos-unstable`, and its `Bazel Build & Proofs` job is green on every recent main commit (e.g. run 26369114819).

Subagent diff was deterministic: rivet's installer is the only meaningful difference from synth's working setup for this job.

## What this PR does
- Replace `DeterminateSystems/nix-installer-action@v22` (+ `determinate: false`, `init: none`, `extra-conf`) with `cachix/install-nix-action@v30` (+ `nix_path: nixpkgs=channel:nixos-unstable`).
- Drop the manual `Add Nix to PATH` step — cachix v30 handles PATH itself.
- Rewrite the comment to capture the real reason this works on `ubuntu-latest` (and why the prior NoNewPrivileges framing was inapplicable).

## What this PR does NOT do
- **Verus job is intentionally NOT changed** — it runs on `[self-hosted, linux, x64, lean-mem]` which IS `NoNewPrivileges=true`, so the DeterminateSystems daemonless path stays correct there.
- If after this change the Rocq toolchain hits the `rules_rocq_rust++rocq+rocq_toolchains` repo-name shape (Nix-store double-tilde collision that synth defuses with `patches/rules_rocq_rust_nix_name.patch` + a newer pin), that's a follow-up. The installer is the upstream failure mode.

## Test plan
- [ ] CI run on this PR — Rocq Proofs should go from red to either green (full success) or red with a NEW error mode that's not the lock-file issue (in which case the follow-up about the patch + pin is next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)