### PR TITLE
fix(serve): external artifact links route to the artifact detail (REQ-108, item 1)

### DIFF
--- a/rivet-cli/src/render/artifacts.rs
+++ b/rivet-cli/src/render/artifacts.rs
@@ -595,9 +595,16 @@ pub(crate) fn render_artifact_detail(ctx: &RenderContext, id: &str) -> RenderRes
                             .iter()
                             .any(|e| e.prefix == *prefix && e.synced && e.store.contains(id));
                         if ext_exists {
+                            // REQ-108: link to the cross-repo artifact's
+                            // own detail view (`/artifacts/<prefix>:<id>`,
+                            // which render_artifact_detail resolves against
+                            // the synced external's store), NOT the
+                            // `/externals/<prefix>` project-list page. The
+                            // badge keeps the external origin visible.
                             format!(
-                                "<a hx-get=\"/externals/{ext_prefix}\" hx-target=\"#content\" hx-push-url=\"true\" href=\"/externals/{ext_prefix}\">\
+                                "<a hx-get=\"/artifacts/{tgt}\" hx-target=\"#content\" hx-push-url=\"true\" href=\"/artifacts/{tgt}\">\
                                  <span class=\"badge badge-info\" style=\"margin-right:.35rem\">{ext_prefix}</span>{ext_id}</a>",
+                                tgt = html_escape(&link.target),
                                 ext_prefix = html_escape(prefix),
                                 ext_id = html_escape(id),
                             )

--- a/tests/playwright/externals.spec.ts
+++ b/tests/playwright/externals.spec.ts
@@ -74,6 +74,58 @@ test.describe("External Projects", () => {
     expect(body!.length).toBeGreaterThan(50);
   });
 
+  // REQ-108: an artifact's outgoing link to a cross-repo (prefix:id)
+  // target must point at the external artifact's OWN detail view
+  // (/artifacts/<prefix>:<id>, which render_artifact_detail resolves
+  // against the synced external store), NOT the /externals/<prefix>
+  // project-list page. Conditional on the project having a synced
+  // external link present (skips cleanly when none — a deterministic
+  // synced-external Playwright fixture is tracked as a follow-up).
+  test("external artifact links target the artifact detail, not the externals list", async ({
+    page,
+  }) => {
+    await page.goto("/artifacts");
+    await waitForHtmx(page);
+    // Collect a sample of artifact detail hrefs to walk.
+    const hrefs = await page
+      .locator('#content a[href^="/artifacts/"]')
+      .evaluateAll((els) =>
+        els
+          .map((e) => (e as HTMLAnchorElement).getAttribute("href"))
+          .filter((h): h is string => !!h)
+          .slice(0, 25),
+      );
+    let sawExternalLink = false;
+    for (const href of hrefs) {
+      const resp = await page.goto(href);
+      if (resp?.status() !== 200) continue;
+      await waitForHtmx(page);
+      // A cross-repo outgoing link renders as an <a> wrapping a
+      // badge-info prefix chip. Whenever one exists it must route to
+      // /artifacts/<prefix>:<id>, never the /externals/<prefix> list.
+      const extToArtifact = await page
+        .locator('a[href*="/artifacts/"]:has(span.badge-info)')
+        .count();
+      const extToList = await page
+        .locator('a[href^="/externals/"]:has(span.badge-info)')
+        .count();
+      if (extToArtifact > 0) {
+        sawExternalLink = true;
+      }
+      // The REQ-108 regression: external refs linking to /externals/.
+      expect(extToList).toBe(0);
+    }
+    if (!sawExternalLink) {
+      test
+        .info()
+        .annotations.push({
+          type: "note",
+          description:
+            "no synced external artifact links present to assert against",
+        });
+    }
+  });
+
   test("unknown external prefix returns 200 with not-found message", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
You flagged a suspected regression in external-artifact browsing. **It's not a regression** — the behaviour has existed since PR #86 (LSP WebView rendering) — but it is a real navigation gap, surfaced now that cross-repo externals (REQ-085) are in active use.

An artifact's outgoing link to a cross-repo `prefix:id` target rendered as `href="/externals/<prefix>"` (the external *project-list* page) instead of `/artifacts/<prefix>:<id>` (the external artifact's own detail view). `render_artifact_detail` already resolves `prefix:id` against the synced external's store, so the detail view worked — you could reach it by typing the URL, but never by clicking a link.

**Fix:** point the link at `/artifacts/<prefix>:<id>`, keeping the badge-info prefix chip. One behavioural line.

## Playwright coverage (your question: "do we have enough?")
**No** — `externals.spec.ts` only covered the `/externals` project-list page, not artifact-level cross-repo navigation. Adds a test that walks artifact detail pages and asserts any external reference links to `/artifacts/`, never `/externals/`. It's conditional on synced externals being present (skips cleanly otherwise).

## Tracked follow-ups (REQ-108, not in this PR)
- Deterministic synced-external Playwright fixture (so the guard runs unconditionally in CI).
- Followable recursive `prefix:ref` links from the external detail view.
- Inbound internal→external link display.
- Shortcut-link contrast on the light background.

## Test plan
- [x] `cargo build -p rivet-cli` + render::artifacts unit tests pass
- [ ] CI (incl. Playwright)

Refs: REQ-108, REQ-085

🤖 Generated with [Claude Code](https://claude.com/claude-code)