### PR TITLE
docs(req-105): consolidate the 3 HTML-export asset gaps + serve image-rewrite tests

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1921,45 +1921,70 @@ artifacts:
 
   - id: REQ-105
     type: requirement
-    title: "HTML export: relative internal links + decouple from the serve module"
+    title: "HTML export must be a self-contained static site (bundle the serve-only assets)"
     status: draft
     description: |
-      Two coupled findings from the v0.13.1 export-format review:
+      `cmd_export_html` reuses the `rivet serve` dashboard rendering
+      (`serve::reload_state`, `serve::components`) verbatim. It does NOT
+      spin up a server (reload_state is a pure offline loader), but the
+      rendered HTML references serve-ONLY routes and JS that the static
+      export does not bundle. Three confirmed gaps, all the same root
+      cause — "export reuses serve's HTML but ships none of serve's
+      runtime assets":
 
-      1. `cmd_export_html` reuses the `rivet serve` dashboard rendering
-         (`serve::reload_state`, `serve::components`) verbatim. It does
-         NOT spin up a server (reload_state is a pure offline loader),
-         but the rendered pages inherit the dashboard's **absolute
-         server-route** links: `href="/artifacts/CD-001"`,
-         `href="/coverage"`, etc. — with no `.html` extension.
-
-      2. As static files, those links are broken: from
+      1. **Absolute server-route links.** Pages link
+         `href="/artifacts/CD-001"`, `href="/coverage"`, … with no
+         `.html` extension. As static files these break: from
          `file:///…/html/index.html`, `/artifacts/CD-001` resolves to
-         the filesystem root, and the actual file is
-         `artifacts/CD-001.html`. So the multi-page HTML export's
-         internal navigation does not work when opened as files or
-         hosted at a non-root base path. (Content is all present; only
-         the inter-page links are wrong.)
+         the filesystem root; the real file is `artifacts/CD-001.html`.
+         Hosting under a sub-path breaks identically. (Content is all
+         present; only the inter-page links are wrong.)
 
-      Fix direction (needs care — regression-risk, hence not in v0.13.2):
-        - Either a `--base-path` option written into the links, OR
-        - rewrite links to relative + `.html` on export (the export
-          already computes a depth-adjusted `"../".repeat(depth)`
-          prefix for `_assets/`; extend that to artifact/report links),
-          AND
-        - longer-term, decouple export rendering from the `serve`
-          module so `rivet export --format html` doesn't transitively
-          depend on axum / the dashboard handlers.
+      2. **SVG-viewer toolbar JS not bundled.** The mermaid / graph
+         toolbar buttons (`svgZoomFit`, `svgFullscreen`, `svgPopout`)
+         render in the exported HTML (the `svg-viewer-toolbar` markup
+         is there) but are DEAD — their handlers live in serve's
+         `js.rs`, and the export's `_assets/` ships only
+         `mermaid.min.js` + `styles.css`. So a static export shows
+         non-functional zoom/fullscreen/popout buttons. (In `rivet
+         serve` they work and are Playwright-tested.)
+
+      3. **`/docs-asset/` images not copied.** Documentation can
+         reference PNG/SVG/jpg/gif/webp/pdf images; `render::source.rs
+         ::rewrite_image_paths` rewrites a relative `src` to
+         `/docs-asset/<path>`, which the serve `/docs-asset/{*path}`
+         route serves from the doc directories. The static export
+         neither rewrites those to a relative file path nor copies the
+         referenced image files, so `<img src="/docs-asset/…">` 404s in
+         an exported site. (Serve path verified by unit test
+         `render::source::tests::relative_image_src_rewritten_to_docs_asset`.)
+
+      Fix direction (regression-risk — own focused cycle, not a patch):
+        - Rewrite internal links to relative + `.html` on export (the
+          export already computes a depth-adjusted `"../".repeat(depth)`
+          prefix for `_assets/`; extend it to artifact/report links and
+          to image `src`), OR add a `--base-path` option.
+        - Bundle the svg-viewer toolbar JS into `_assets/` (extract the
+          handlers from `js.rs` into a shared file both serve and export
+          emit).
+        - Copy `/docs-asset/`-referenced images into the export tree and
+          rewrite their `src` to the relative copied path.
+        - Longer-term: decouple export rendering from the `serve` module
+          so `rivet export --format html` doesn't transitively depend on
+          axum / the dashboard handlers.
 
       Acceptance:
         - Opening the exported `index.html` via `file://` and clicking
           any artifact / coverage / matrix / graph link lands on the
           correct local `.html` page (no absolute `/…` routes remain).
-        - Hosting the export under a sub-path (e.g. `/v0.13.2/`) keeps
-          all internal links working.
+        - Hosting the export under a sub-path keeps all links working.
+        - The mermaid / graph zoom-fit / fullscreen / popout buttons
+          function in the exported static HTML (handler JS bundled).
+        - A doc that references a relative PNG/SVG renders that image in
+          the exported site (image copied + `src` relative).
         - `rivet export --format html` builds without linking the axum
           server stack (decoupling milestone).
-    tags: [export, html, serve-coupling, relative-links, regression-risk]
+    tags: [export, html, serve-coupling, relative-links, assets, mermaid, docs-images, regression-risk]
     fields:
       priority: must
       category: functional

--- a/rivet-cli/src/render/source.rs
+++ b/rivet-cli/src/render/source.rs
@@ -1003,3 +1003,47 @@ pub(crate) fn build_artifact_info(
         backlinks,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_image_paths;
+
+    /// A relative image `src` in documentation is rewritten to the
+    /// `/docs-asset/` route the serve dashboard serves from the doc
+    /// directories — so `![diagram](diagram.svg)` renders a real image.
+    /// This is the serve-side mechanism behind "reference PNG/SVG from
+    /// documentation"; the static export does NOT yet bundle these
+    /// assets (tracked in REQ-105).
+    #[test]
+    fn relative_image_src_rewritten_to_docs_asset() {
+        let html = r#"<p><img src="diagrams/arch.svg" alt="arch"></p>"#;
+        let out = rewrite_image_paths(html);
+        assert!(
+            out.contains(r#"src="/docs-asset/diagrams/arch.svg""#),
+            "relative src must route through /docs-asset/: {out}"
+        );
+    }
+
+    #[test]
+    fn relative_png_src_rewritten() {
+        let out = rewrite_image_paths(r#"<img src="pic.png">"#);
+        assert!(out.contains(r#"src="/docs-asset/pic.png""#), "{out}");
+    }
+
+    /// Absolute and remote srcs pass through untouched — only relative
+    /// doc-local paths are rerouted.
+    #[test]
+    fn absolute_and_remote_src_pass_through() {
+        for src in [
+            r#"<img src="/already/absolute.svg">"#,
+            r#"<img src="https://example.com/x.png">"#,
+            r#"<img src="//cdn/x.png">"#,
+        ] {
+            let out = rewrite_image_paths(src);
+            assert!(
+                !out.contains("/docs-asset/"),
+                "absolute/remote src must not be rewritten: {out}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Consolidates REQ-105 from "one link bug" into the **three confirmed HTML-export asset gaps** surfaced across the export-format review + the mermaid/PNG-SVG investigation. All share one root cause: `cmd_export_html` reuses the serve dashboard's HTML but ships **none of serve's runtime assets**.

1. **Absolute server-route links** (`/artifacts/X`, no `.html`) → broken static / sub-path navigation.
2. **SVG-viewer toolbar JS not bundled** — `svgZoomFit`/`svgFullscreen`/`svgPopout` render in exported HTML but are dead (handlers live in serve's `js.rs`; export `_assets/` ships only `mermaid.min.js` + `styles.css`). This is the "where did the mermaid zoom buttons go?" report — they're dead **in exported HTML only**.
3. **`/docs-asset/` images not copied** — a doc referencing a relative PNG/SVG renders in serve (`rewrite_image_paths` → `/docs-asset/` route) but 404s in the exported site.

## Changes
- Expanded REQ-105 with all three gaps, a fix direction, and acceptance covering each.
- Added unit tests for the serve-side image rewrite (`render::source::tests`) documenting the working serve behaviour the export must match.

No production behaviour change — the REQ-105 implementation (export-asset bundling refactor) is regression-risky and tracked for its own cycle.

## Test plan
- [x] `render::source::tests` (3 new) pass
- [x] `rivet validate` + `docs check` PASS
- [ ] CI

Refs: REQ-105, REQ-007

🤖 Generated with [Claude Code](https://claude.com/claude-code)