### PR TITLE
release(v0.13.3): serve dashboard correctness (REQ-106 / REQ-107 / REQ-108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@
 
 ## [Unreleased]
 
+## [0.13.3] — 2026-05-29
+
+Theme: **serve dashboard correctness — three user-reported fixes**.
+All three surfaced from real cross-repo / variant usage; each ships
+with a regression test.
+
+### Fixed
+
+- **REQ-106 — variant scope resolves bindings embedded in the variant
+  file.** The serve dashboard reported `bound_artifact_count: 0` for
+  every variant while the CLI (`variant solve --binding <variant-file>`)
+  reported the correct counts. `ProjectVariants::discover` only loaded a
+  separate project-level `bindings.yaml`; when the `bindings:` section is
+  embedded in the variant file itself (the variant IS its own binding
+  model) the dashboard saw no binding. Discovery now also parses each
+  variant file as a `FeatureBinding`, and scope resolution prefers the
+  variant's own embedded binding (falling back to the project-level
+  one) — mirroring the CLI's `--binding <variant-file>` self-reference.
+- **REQ-108 — external artifact links route to the artifact detail.**
+  An artifact's outgoing link to a cross-repo `prefix:id` target linked
+  to `/externals/<prefix>` (the project-list page) instead of
+  `/artifacts/<prefix>:<id>` (the external artifact's own detail view,
+  which already resolves against the synced external's store). You could
+  reach an external artifact by typing the URL but never by clicking a
+  link. Now links to the detail view, keeping the prefix badge. A
+  Playwright guard asserts external references never route to
+  `/externals/`. (Not a regression — present since the LSP-WebView
+  rendering landed — but a real navigation gap now that cross-repo
+  externals are in active use.)
+- **REQ-107 — sequence / mapping field values render structurally.**
+  A field whose value was a sequence of mappings rendered as the Rust
+  `Debug` form (`Sequence [Mapping {"kind": String("e"), …}]`). Added a
+  recursive `render_field_value` that renders scalars as text,
+  sequences as `<ul>`, and mappings as nested `<dl>` — no Debug tokens
+  reach the page.
+
 ## [0.13.2] — 2026-05-28
 
 Theme: **ReqIF interchange completeness + export polish**. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.13.2"
+version = "0.13.3"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Version bump 0.13.2 → 0.13.3 + CHANGELOG. Patch release carrying the three user-reported serve-dashboard fixes already merged to main, each with a regression test.

| REQ | Fix | Test |
|-----|-----|------|
| **106** | Variant scope resolves bindings **embedded in the variant file** (dashboard was reporting `bound_artifact_count: 0` while the CLI was correct) | `serve::variant` unit tests |
| **108** | External artifact links route to `/artifacts/<prefix>:<id>` (were pointing at the `/externals/<prefix>` project-list page) | `externals.spec.ts` Playwright guard |
| **107** | Sequence/mapping field values render structurally, not Rust `Debug` (`Sequence [Mapping {…}]`) | `render::artifacts` unit tests |

All three surfaced from real cross-repo / variant usage.

## Test plan
- [x] `rivet validate` — PASS
- [x] `rivet docs check` — PASS (no version-literal violations)
- [ ] CI
- [ ] Tag `v0.13.3` → `release.yml` produces the standardized asset set (SBOM + SLSA + cosign + build-env)

## Not in this release (tracked)
- REQ-105 — HTML export self-containment (absolute links + mermaid toolbar JS + docs-asset images not bundled); regression-risky refactor, own cycle. Doc expansion in flight as PR #337.
- REQ-109 — variant scoping for documents (design question).
- `tools/intro-video/` infrastructure — PR #339 (independent tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)