### PR TITLE
release(v0.14.0): agent-actionable validation + self-contained export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-05-30
+
+Theme: **agent-actionable validation + self-contained export**. Two
+user-facing features: the validator now tells an agent *what to do* about a
+diagnostic (not just what is wrong), and `export --format html` produces a
+genuinely portable static site.
+
+### Added
+
+- **REQ-124 — agent-actionable diagnostic remediation.** A validation error
+  stated *what* was wrong but not *what to do*, nor which of the competing
+  fixes was right. The witnessed failure: an agent saw a `link-target-type`
+  error and "fixed forward" by inventing type-invalid links on sibling
+  artifacts, turning 26 warnings into 8 errors. The new
+  `rivet-core::remediation` module re-derives a structured `Remediation`
+  from the diagnostic plus the live schema + store — a post-construction
+  pass keyed by `Diagnostic.rule`, so the ~70 diagnostic construction sites
+  and the hot validation path are untouched. Each remediable diagnostic now
+  renders a rustc-style `help:` block (artifact-fix first, schema-fix
+  second, each tagged so a tool can tell the surfaces apart) in text, a
+  `remediation` object in `--format json`, and a
+  `rivet docs diagnostics/<rule>` explanation topic. Eight rules covered:
+  `link-target-type`, `broken-link`, `unknown-link-type`, `required-field`,
+  `allowed-values`, `cardinality`, `unknown-field`, `known-type`. Each
+  re-derives the offending link/field/value and the schema menu of allowed
+  alternatives faithfully — matching the validator's own known-set. The
+  `link-target-type` doc explicitly warns against the fix-forward-onto-
+  siblings anti-pattern. 12 unit tests.
+
+### Fixed
+
+- **REQ-105 — HTML export is self-contained.** `export --format html`
+  reused the serve dashboard's rendering but shipped none of serve's runtime
+  assets, so the static site was broken in three ways: absolute `/artifacts/X`
+  links that only resolve under a live server, an unbundled `svg-viewer.js`,
+  and uncopied `/docs-asset/` images. Export now rewrites route links to
+  relative `.html` paths (depth-aware), bundles a standalone `svg-viewer.js`
+  into `_assets/`, and copies referenced doc images into `_assets/docs/`
+  with path-traversal hardening (component-based safe-path check +
+  canonicalize containment, rejecting symlink/absolute escape). Verified on a
+  real export: 0 absolute routes, all links resolve. Playwright `export.spec`
+  updated to assert relative links.
+
+### Roadmap
+
+- Filed (draft, not yet implemented): REQ-110..123 (oracle-verified bug-hunt
+  findings across cross-command reporting, git/remote semantics, path/URL
+  leakage, and F2 silent-failure), and REQ-125..130 (gbrain-derived
+  deterministic-armor backlog: `validate/coverage --explain`,
+  `list --orphans`, baseline-snapshot drift gate, MCP fail-closed invariant,
+  `--review-candidates`, and supersession-as-additive-link).
+
 ## [0.13.3] — 2026-05-29
 
 Theme: **serve dashboard correctness — three user-reported fixes**.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.13.3"
+version = "0.14.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts **v0.14.0**. Workspace version bump (0.13.3 → 0.14.0) + CHANGELOG entry. No code change beyond the version stamp — the features themselves already merged.

## Headline features since v0.13.3
- **REQ-124** — agent-actionable diagnostic remediation (8 rules). `help:` blocks in text, `remediation` object in `--format json`, `rivet docs diagnostics/<rule>` topics. Tells an agent *what to do* and *which fix is right*, with an explicit warning against the fix-forward-onto-siblings anti-pattern.
- **REQ-105** — HTML export self-containment. Relative `.html` links, bundled `svg-viewer.js`, copied doc images, path-traversal hardening. The static site actually works offline now.

## Roadmap filed (draft, not in this release's code)
- REQ-110..123 — oracle-verified bug-hunt findings
- REQ-125..130 — gbrain-derived deterministic-armor backlog (`--explain`, `--orphans`, baseline drift gate, MCP fail-closed invariant, `--review-candidates`, supersession)

After merge: signed tag `v0.14.0` + push → triggers the release build (per-target archives, SBOM, SLSA) and the npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)