### PR TITLE
fix(validate,coverage): required-backlink matches inverse-name convention + honours alternate-backlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Issue #349 — `required-backlink` rules now match the inverse-name
+  convention.** Schemas (e.g. `safety-case.yaml`) declare
+  `required-backlink: supported-by` — the *inverse* of the forward
+  `supports` link — and both `rivet validate` and `rivet coverage`
+  compared that name against the stored `Backlink.link_type`, which
+  holds the *forward* name. Result: GSN safety-case rules like
+  `goal-has-support` fired (and counted as uncovered) for every
+  artifact, even when the supporting solution was correctly linked.
+  Match now accepts either the forward or the inverse name, so
+  both conventions (`dev.yaml` uses forward, `safety-case.yaml` uses
+  inverse) validate consistently. Same fix path additionally evaluates
+  `alternate-backlinks` in both engines — previously a goal satisfied
+  only via an alternate (e.g. `decomposed-by` instead of
+  `supported-by`) was reported as missing.
+
 ## [0.13.3] — 2026-05-29
 
 Theme: **serve dashboard correctness — three user-reported fixes**.

--- a/rivet-core/src/coverage.rs
+++ b/rivet-core/src/coverage.rs
@@ -191,22 +191,40 @@ pub fn compute_coverage(store: &Store, schema: &Schema, graph: &LinkGraph) -> Co
                                 .is_some_and(|a| target_types.contains(&a.artifact_type))
                         }
                     }),
-                CoverageDirection::Backward => graph
-                    .backlinks_to(id)
-                    .iter()
-                    // Same reasoning as forward: a backlink from the artifact
-                    // to itself (self-referential link) cannot count as
-                    // "satisfied by a different artifact."
-                    .filter(|bl| bl.link_type == link_type && bl.source != *id)
-                    .any(|bl| {
-                        if target_types.is_empty() {
-                            true
-                        } else {
-                            store
-                                .get(&bl.source)
-                                .is_some_and(|a| target_types.contains(&a.artifact_type))
-                        }
-                    }),
+                CoverageDirection::Backward => {
+                    // Schemas write the backlink name as either the forward
+                    // link-type (e.g. `satisfies`) or the inverse
+                    // (e.g. `supported-by`); accept either. `alternate-backlinks`
+                    // adds further acceptable shapes (e.g. a safety-goal that
+                    // is `supported-by` OR `decomposed-by` OR `has-sub-goal`).
+                    let backlinks = graph.backlinks_to(id);
+                    let backlink_matches = |link_name: &str, from_types: &[String]| {
+                        backlinks
+                            .iter()
+                            // Same reasoning as forward: a backlink from the
+                            // artifact to itself (self-referential link) cannot
+                            // count as "satisfied by a different artifact."
+                            .filter(|bl| bl.source != *id)
+                            .filter(|bl| {
+                                bl.link_type == link_name
+                                    || bl.inverse_type.as_deref() == Some(link_name)
+                            })
+                            .any(|bl| {
+                                if from_types.is_empty() {
+                                    true
+                                } else {
+                                    store
+                                        .get(&bl.source)
+                                        .is_some_and(|a| from_types.contains(&a.artifact_type))
+                                }
+                            })
+                    };
+                    backlink_matches(&link_type, &target_types)
+                        || rule
+                            .alternate_backlinks
+                            .iter()
+                            .any(|alt| backlink_matches(&alt.link_type, &alt.from_types))
+                }
             };
 
             if has_match {
@@ -643,5 +661,141 @@ mod tests {
             "self-backlink must not count REQ-001 as covered"
         );
         assert_eq!(entry.total, 1);
+    }
+
+    /// Issue #349: schemas write `required-backlink` as either the forward
+    /// link-type name (`supports`) or its inverse name (`supported-by`).
+    /// safety-case.yaml uses the inverse-name convention. With the bug,
+    /// no artifact was ever counted as covered for such rules because the
+    /// stored `Backlink.link_type` is the forward name. This regression
+    /// test pins the fix: both conventions must produce identical coverage.
+    ///
+    /// rivet: fixes REQ-004
+    #[test]
+    fn required_backlink_matches_inverse_link_type_name() {
+        use crate::schema::LinkTypeDef;
+        let mut file = minimal_schema("test");
+        // Declare the link type with its inverse — mirrors safety-case.yaml.
+        file.link_types.push(LinkTypeDef {
+            name: "supports".into(),
+            inverse: Some("supported-by".into()),
+            description: "Solution supports goal".into(),
+            source_types: vec!["safety-solution".into()],
+            target_types: vec!["safety-goal".into()],
+        });
+        file.traceability_rules = vec![TraceabilityRule {
+            name: "goal-has-support".into(),
+            description: "Every safety goal must be supported by evidence".into(),
+            source_type: "safety-goal".into(),
+            required_link: None,
+            // INVERSE name — the case that was silently broken.
+            required_backlink: Some("supported-by".into()),
+            target_types: vec![],
+            from_types: vec!["safety-solution".into()],
+            severity: Severity::Error,
+            alternate_backlinks: vec![],
+        }];
+        let schema = Schema::merge(&[file]);
+
+        let mut store = Store::new();
+        store
+            .insert(minimal_artifact("SG-1", "safety-goal"))
+            .unwrap();
+        // SOL-1 has the FORWARD link `supports → SG-1`. The auto-computed
+        // backlink to SG-1 stores `link_type = "supports"` and
+        // `inverse_type = Some("supported-by")`.
+        store
+            .insert(artifact_with_links(
+                "SOL-1",
+                "safety-solution",
+                &[("supports", "SG-1")],
+            ))
+            .unwrap();
+
+        let graph = LinkGraph::build(&store, &schema);
+        let report = compute_coverage(&store, &schema, &graph);
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.rule_name == "goal-has-support")
+            .expect("rule should produce a coverage entry");
+
+        assert_eq!(
+            entry.covered, 1,
+            "SG-1 is supported-by SOL-1 (via the forward `supports` link); \
+             coverage must count it even though the rule names the inverse"
+        );
+        assert!(entry.uncovered_ids.is_empty(), "no goals are uncovered");
+    }
+
+    /// Issue #349 secondary: `alternate-backlinks` were never evaluated.
+    /// Safety-case schemas express "supported-by OR decomposed-by OR
+    /// has-sub-goal" via this field; an artifact satisfied only via an
+    /// alternate must still count as covered.
+    ///
+    /// rivet: fixes REQ-004
+    #[test]
+    fn coverage_honours_alternate_backlinks() {
+        use crate::schema::{AlternateBacklink, LinkTypeDef};
+        let mut file = minimal_schema("test");
+        file.link_types.push(LinkTypeDef {
+            name: "supports".into(),
+            inverse: Some("supported-by".into()),
+            description: "Solution supports goal".into(),
+            source_types: vec!["safety-solution".into()],
+            target_types: vec!["safety-goal".into()],
+        });
+        file.link_types.push(LinkTypeDef {
+            name: "decomposes".into(),
+            inverse: Some("decomposed-by".into()),
+            description: "Strategy decomposes a goal".into(),
+            source_types: vec!["safety-strategy".into()],
+            target_types: vec!["safety-goal".into()],
+        });
+        file.traceability_rules = vec![TraceabilityRule {
+            name: "goal-has-support".into(),
+            description: "Every goal supported OR decomposed".into(),
+            source_type: "safety-goal".into(),
+            required_link: None,
+            required_backlink: Some("supported-by".into()),
+            target_types: vec![],
+            from_types: vec!["safety-solution".into()],
+            alternate_backlinks: vec![AlternateBacklink {
+                link_type: "decomposed-by".into(),
+                from_types: vec!["safety-strategy".into()],
+            }],
+            severity: Severity::Error,
+        }];
+        let schema = Schema::merge(&[file]);
+
+        let mut store = Store::new();
+        // SG-A is decomposed (alternate) — no `supports` backlink. Must
+        // still count as covered.
+        store
+            .insert(minimal_artifact("SG-A", "safety-goal"))
+            .unwrap();
+        store
+            .insert(artifact_with_links(
+                "STRAT-1",
+                "safety-strategy",
+                &[("decomposes", "SG-A")],
+            ))
+            .unwrap();
+        // SG-B has neither — uncovered.
+        store
+            .insert(minimal_artifact("SG-B", "safety-goal"))
+            .unwrap();
+
+        let graph = LinkGraph::build(&store, &schema);
+        let report = compute_coverage(&store, &schema, &graph);
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.rule_name == "goal-has-support")
+            .expect("rule should produce a coverage entry");
+
+        assert_eq!(entry.covered, 1, "SG-A covered via alternate backlink");
+        assert_eq!(entry.uncovered_ids, vec!["SG-B"]);
+        assert_eq!(entry.total, 2);
     }
 }

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -901,15 +901,32 @@ pub fn validate_structural_with_externals_and_variant(
 
             // Backlink check (coverage). Empty `from_types` means "match any"
             // — same convention as `coverage::compute_coverage`.
+            //
+            // Schemas write `required-backlink` as either the forward
+            // link-type name (e.g. `satisfies` in `dev.yaml`) or the
+            // inverse name (e.g. `supported-by` in `safety-case.yaml`).
+            // Accept either so both conventions validate correctly —
+            // matching only `bl.link_type` would miss the inverse-name case.
+            // `alternate-backlinks` provides additional acceptable shapes
+            // for the same rule (e.g. a safety-goal supported via
+            // `supported-by` OR decomposed via `decomposed-by`).
             if let Some(required_backlink) = &rule.required_backlink {
-                let has_backlink = graph.backlinks_to(id).iter().any(|bl| {
-                    bl.link_type == *required_backlink
-                        && (rule.from_types.is_empty()
-                            || store
-                                .get(&bl.source)
-                                .is_some_and(|s| rule.from_types.contains(&s.artifact_type)))
-                });
-                if !has_backlink {
+                let backlinks = graph.backlinks_to(id);
+                let matches = |link_name: &str, from_types: &[String]| {
+                    backlinks.iter().any(|bl| {
+                        (bl.link_type == link_name || bl.inverse_type.as_deref() == Some(link_name))
+                            && (from_types.is_empty()
+                                || store
+                                    .get(&bl.source)
+                                    .is_some_and(|s| from_types.contains(&s.artifact_type)))
+                    })
+                };
+                let primary = matches(required_backlink, &rule.from_types);
+                let alternate = rule
+                    .alternate_backlinks
+                    .iter()
+                    .any(|alt| matches(&alt.link_type, &alt.from_types));
+                if !primary && !alternate {
                     diagnostics.push(Diagnostic {
                         source_file: None,
                         line: None,
@@ -2437,6 +2454,134 @@ then:
             validate_says_covered, coverage_says_covered,
             "validate and coverage must agree (validate_covered={}, coverage={}/{})",
             validate_says_covered, entry.covered, entry.total
+        );
+    }
+
+    /// Issue #349: `required-backlink` written as the INVERSE link-type
+    /// name (e.g. `supported-by`, the convention used by
+    /// `schemas/safety-case.yaml`) was never matched against the stored
+    /// `Backlink.link_type` (the FORWARD name, e.g. `supports`). The
+    /// goal-has-support rule fired for every goal even when a solution
+    /// was correctly linked. Accept either spelling.
+    ///
+    /// rivet: fixes REQ-004
+    #[test]
+    fn required_backlink_inverse_name_is_satisfied_by_forward_link() {
+        use crate::schema::LinkTypeDef;
+        let mut file = minimal_schema("test");
+        file.link_types.push(LinkTypeDef {
+            name: "supports".into(),
+            inverse: Some("supported-by".into()),
+            description: "Solution supports goal".into(),
+            source_types: vec!["safety-solution".into()],
+            target_types: vec!["safety-goal".into()],
+        });
+        file.traceability_rules = vec![TraceabilityRule {
+            name: "goal-has-support".into(),
+            description: "Every safety goal must be supported".into(),
+            source_type: "safety-goal".into(),
+            required_link: None,
+            // Inverse-name convention from safety-case.yaml.
+            required_backlink: Some("supported-by".into()),
+            target_types: vec![],
+            from_types: vec!["safety-solution".into()],
+            severity: Severity::Error,
+            alternate_backlinks: vec![],
+        }];
+        let schema = Schema::merge(&[file]);
+
+        let mut store = Store::new();
+        let mut goal = minimal_artifact("SG-1", "safety-goal");
+        goal.status = Some("approved".to_string());
+        store.insert(goal).unwrap();
+        let mut sol = minimal_artifact("SOL-1", "safety-solution");
+        sol.status = Some("approved".to_string());
+        sol.links = vec![Link {
+            link_type: "supports".to_string(),
+            target: "SG-1".to_string(),
+            external: None,
+        }];
+        store.insert(sol).unwrap();
+
+        let graph = LinkGraph::build(&store, &schema);
+        let diags = validate_structural(&store, &schema, &graph);
+        let rule_diags: Vec<_> = diags
+            .iter()
+            .filter(|d| d.rule == "goal-has-support")
+            .collect();
+        assert!(
+            rule_diags.is_empty(),
+            "SG-1 has a supported-by backlink (from SOL-1's forward `supports` link); \
+             the rule must not fire. Got diagnostics: {:?}",
+            rule_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    /// Issue #349 secondary: `validate.rs` never evaluated
+    /// `rule.alternate_backlinks`. A safety-goal satisfied only via
+    /// an alternate (e.g. `decomposed-by` instead of `supported-by`)
+    /// still erroneously fired the rule.
+    ///
+    /// rivet: fixes REQ-004
+    #[test]
+    fn validate_honours_alternate_backlinks() {
+        use crate::schema::{AlternateBacklink, LinkTypeDef};
+        let mut file = minimal_schema("test");
+        file.link_types.push(LinkTypeDef {
+            name: "supports".into(),
+            inverse: Some("supported-by".into()),
+            description: "Solution supports goal".into(),
+            source_types: vec!["safety-solution".into()],
+            target_types: vec!["safety-goal".into()],
+        });
+        file.link_types.push(LinkTypeDef {
+            name: "decomposes".into(),
+            inverse: Some("decomposed-by".into()),
+            description: "Strategy decomposes a goal".into(),
+            source_types: vec!["safety-strategy".into()],
+            target_types: vec!["safety-goal".into()],
+        });
+        file.traceability_rules = vec![TraceabilityRule {
+            name: "goal-supported-or-decomposed".into(),
+            description: "Every goal supported OR decomposed".into(),
+            source_type: "safety-goal".into(),
+            required_link: None,
+            required_backlink: Some("supported-by".into()),
+            target_types: vec![],
+            from_types: vec!["safety-solution".into()],
+            alternate_backlinks: vec![AlternateBacklink {
+                link_type: "decomposed-by".into(),
+                from_types: vec!["safety-strategy".into()],
+            }],
+            severity: Severity::Error,
+        }];
+        let schema = Schema::merge(&[file]);
+
+        let mut store = Store::new();
+        let mut goal = minimal_artifact("SG-A", "safety-goal");
+        goal.status = Some("approved".to_string());
+        store.insert(goal).unwrap();
+        // Strategy decomposes SG-A. No solution at all.
+        let mut strat = minimal_artifact("STRAT-1", "safety-strategy");
+        strat.status = Some("approved".to_string());
+        strat.links = vec![Link {
+            link_type: "decomposes".to_string(),
+            target: "SG-A".to_string(),
+            external: None,
+        }];
+        store.insert(strat).unwrap();
+
+        let graph = LinkGraph::build(&store, &schema);
+        let diags = validate_structural(&store, &schema, &graph);
+        let rule_diags: Vec<_> = diags
+            .iter()
+            .filter(|d| d.rule == "goal-supported-or-decomposed")
+            .collect();
+        assert!(
+            rule_diags.is_empty(),
+            "SG-A is satisfied via the alternate `decomposed-by` backlink; \
+             the rule must not fire. Got: {:?}",
+            rule_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
Closes #349.

## The bug

`Backlink.link_type` stores the **forward** link-type name (e.g. `supports`) while several built-in schemas — notably `schemas/safety-case.yaml` — write `required-backlink` using the **inverse** name (e.g. `supported-by`). The strict equality match at `rivet-core/src/validate.rs:906` and `rivet-core/src/coverage.rs:200` therefore never matched for any inverse-name rule.

Observable effect on the loom safety case reported in the issue:

```
ERROR: [SG-1] Every safety goal must be supported by evidence (solution) or decomposed into sub-goals ...
```

…fired for every safety goal even though every one of them was correctly supported (`SOL-1 supports → SG-1`, etc.). `dev.yaml`'s `required-backlink: satisfies` happens to use the forward name and worked; the bug surfaced only on schemas following the inverse-name convention.

## The fix

Both call sites now accept either spelling:

```rust
bl.link_type == name || bl.inverse_type.as_deref() == Some(name)
```

Same fix path additionally evaluates `rule.alternate_backlinks` — `validate.rs` previously ignored that field outright, so a safety goal satisfied only via an alternate (e.g. `decomposed-by` from a strategy instead of `supported-by`) still erroneously fired the rule. `coverage.rs` had the same gap. The match helper is now closed over the backlinks, called once for the primary and once per alternate; the rule passes when *any* shape matches.

## Acceptance criteria from the issue

The issue lists a primary fix, a secondary bug, and four frictionless-ness suggestions. This PR addresses the two binding items; the frictionless suggestions are intentionally split out as a follow-up (per "one PR per issue, keep PRs focused" — they touch the CLI's `rivet get` rendering and require a new `rivet why` command, which is a separate feature).

| Issue item | Status | Where |
|---|---|---|
| Match against the backlink's inverse name in `validate.rs` | done | `validate.rs:902–941` |
| Match against the backlink's inverse name in `coverage.rs` | done | `coverage.rs:194–225` |
| Evaluate `rule.alternate_backlinks` in `validate.rs` (secondary bug) | done | `validate.rs:931–935` |
| Evaluate `rule.alternate_backlinks` in `coverage.rs` | done | `coverage.rs:222–225` |
| `rivet get` shows inbound backlinks | follow-up | filed as a separate issue would be more appropriate |
| `required-backlink` failure message lists found backlinks | follow-up | the diagnostic-message redesign cuts across all rules, not this fix |
| `rivet why <id> <rule>` explain mode | follow-up | new CLI surface, separate feature |
| Per-rule failures generally explainable | follow-up | overlaps with REQ-124 agent-actionable remediation work |

## Tests

Four regression tests pin the fix — two per engine:

- `validate::tests::required_backlink_inverse_name_is_satisfied_by_forward_link` — reproduces the loom GSN scenario exactly (rule names `supported-by`, artifact has forward `supports`); without the fix the rule fires, with the fix it does not.
- `validate::tests::validate_honours_alternate_backlinks` — goal satisfied only via the alternate (`decomposed-by` from a strategy) must not fire the rule.
- `coverage::tests::required_backlink_matches_inverse_link_type_name` — same scenario from the coverage engine's perspective; without the fix `covered = 0`, with the fix `covered = 1`.
- `coverage::tests::coverage_honours_alternate_backlinks` — alternate-satisfied goal counts as `covered`, not `uncovered`.

Full `cargo test -p rivet-core --lib` → **1086 passed, 0 failed**.
`rivet validate` on the rivet repo itself → PASS unchanged.

## End-to-end verification

Reproduced and cleared the loom-style scenario on a minimal safety-case project (`SG-1` supported by `SOL-1`; `SG-2` decomposed by `STRAT-1`; `SG-3` with neither):

```
ERROR: [SG-3] Every safety goal must be supported by evidence ...
Result: FAIL (1 errors, ...)
```

Only the genuinely-unsupported `SG-3` errors — `SG-1` (primary backlink path) and `SG-2` (alternate-backlink path) both pass, which matches the user's expectation in the bug report.

## Files touched

- `rivet-core/src/validate.rs` — comparison fix + `alternate_backlinks` evaluation + 2 regression tests
- `rivet-core/src/coverage.rs` — comparison fix + `alternate_backlinks` evaluation + 2 regression tests
- `CHANGELOG.md` — Unreleased entry

Commit trailers: `Fixes: REQ-004`, `Refs: #349`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011U38rAcSJncjtQMpmvAXBh)_