### PR TITLE
chore: untrack .claude/scheduled_tasks.lock (committed by accident)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"cb60aa6b-b112-4d31-8e53-2ac3e19a3ff7","pid":73847,"procStart":"Fri May 29 16:53:25 2026","acquiredAt":1780208158852}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ mutants.out*/
 # external declared in rivet.yaml. Per-developer working tree, never
 # committed. (Tracked .rivet/ files like agent-context.md stay tracked.)
 .rivet/repos/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
A merge-resolution `git add -A` accidentally committed the loop scheduler's runtime lock file in #351. Removes it from tracking + gitignores it. No code impact.