### PR TITLE
feat(get,list): expose incoming links (what links to an artifact) (#358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Issue #358 — incoming links are visible from `get` and `list`.** The
+  single most common traceability question — "what verifies / satisfies X?"
+  — lives on the backlink side, but `rivet get <ID>` only showed outbound
+  `links` and `rivet list --format json` collapsed links to an integer
+  count. Now `rivet get` emits an `incoming_links` array (`{type, source,
+  inverse}`) in JSON and an `Incoming:` section in text, and `list
+  --format json` emits the real link objects (matching `get`) instead of a
+  count. Built on the existing `LinkGraph::backlinks_to`. (REQ-128.)
+
 ### Fixed
 
 - **Issue #349 — `required-backlink` rules now match the inverse-name

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -5591,6 +5591,22 @@ fn cmd_get(cli: &Cli, id: &str, format: &str) -> Result<bool> {
                 })
                 .collect::<serde_json::Map<String, serde_json::Value>>()
                 .into();
+            // issue #358: expose INCOMING links (what links to this artifact),
+            // not just outbound. The single most common traceability question —
+            // "what verifies/satisfies X?" — lives on the backlink side. `type`
+            // is the source's forward link type; `inverse` its schema inverse.
+            let incoming_json: Vec<serde_json::Value> = ctx
+                .graph
+                .backlinks_to(id)
+                .iter()
+                .map(|bl| {
+                    serde_json::json!({
+                        "type": bl.link_type,
+                        "source": bl.source,
+                        "inverse": bl.inverse_type,
+                    })
+                })
+                .collect();
             let output = serde_json::json!({
                 "command": "get",
                 "id": artifact.id,
@@ -5600,6 +5616,7 @@ fn cmd_get(cli: &Cli, id: &str, format: &str) -> Result<bool> {
                 "description": artifact.description.as_deref().unwrap_or(""),
                 "tags": artifact.tags,
                 "links": links_json,
+                "incoming_links": incoming_json,
                 "fields": fields_json,
             });
             println!("{}", serde_json::to_string_pretty(&output).unwrap());
@@ -5639,6 +5656,17 @@ fn cmd_get(cli: &Cli, id: &str, format: &str) -> Result<bool> {
                 println!("Links:");
                 for link in &artifact.links {
                     println!("  {} -> {}", link.link_type, link.target);
+                }
+            }
+            // issue #358: incoming links (what links TO this artifact).
+            let incoming = ctx.graph.backlinks_to(id);
+            if !incoming.is_empty() {
+                println!("Incoming:");
+                for bl in incoming {
+                    match &bl.inverse_type {
+                        Some(inv) => println!("  {} <- {} ({})", inv, bl.source, bl.link_type),
+                        None => println!("  {} <- {}", bl.link_type, bl.source),
+                    }
                 }
             }
         }
@@ -5718,7 +5746,13 @@ fn cmd_list(
                     "type": a.artifact_type,
                     "title": a.title,
                     "status": a.status.as_deref().unwrap_or("-"),
-                    "links": a.links.len(),
+                    // issue #358: emit the real link objects (matching `get`), not
+                    // an opaque count, so the graph is inspectable from `list`.
+                    // The count is recoverable as `.links | length`.
+                    "links": a.links.iter().map(|l| serde_json::json!({
+                        "type": l.link_type,
+                        "target": l.target,
+                    })).collect::<Vec<_>>(),
                 });
                 if let Some(ref name) = variant_name {
                     // Emit the merged fields view so downstream tooling

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1631,6 +1631,45 @@ fn get_json_produces_valid_output() {
     );
 }
 
+/// issue #358: `rivet get <ID> --format json` exposes INCOMING links
+/// (what links to the artifact), not just outbound `links`. REQ-004 is
+/// heavily traced-to in rivet's own repo, so it must have incoming links.
+#[test]
+fn get_json_includes_incoming_links() {
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "get",
+            "REQ-004",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute rivet get REQ-004 --format json");
+    assert!(output.status.success(), "rivet get must exit 0");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("valid JSON");
+    let incoming = parsed
+        .get("incoming_links")
+        .and_then(|v| v.as_array())
+        .expect("get JSON must expose an 'incoming_links' array");
+    assert!(
+        !incoming.is_empty(),
+        "REQ-004 is widely traced-to; incoming_links must be non-empty"
+    );
+    let first = &incoming[0];
+    assert!(
+        first.get("type").and_then(|v| v.as_str()).is_some(),
+        "each incoming link has the source's forward 'type'"
+    );
+    assert!(
+        first.get("source").and_then(|v| v.as_str()).is_some(),
+        "each incoming link names its 'source' artifact"
+    );
+}
+
 /// `rivet get NONEXISTENT` returns non-zero exit code and prints an error.
 #[test]
 fn get_nonexistent_returns_error() {


### PR DESCRIPTION
Implements the core of **#358** (demanded by #358/#349/#350): incoming-link visibility.

- `rivet get <ID>` → `incoming_links` array in JSON + `Incoming:` section in text (via `LinkGraph::backlinks_to`)
- `rivet list --format json` → real link objects instead of an integer count (consistent with `get`; count = `.links | length`)

Answers "what verifies/satisfies X?" directly from `get`, instead of `matrix --direction backward` + hand-parsing YAML. Regression test + verified on rivet's own repo (REQ-004 → 56 incoming). Part of REQ-128 (the `list --orphans` ranking remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)