### PR TITLE
feat(modify): wire --set-description flag + clearer usage (#359, #360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### Added
 
+- **Issues #359 / #360 — `rivet modify --set-description` + clearer usage.**
+  `description` is a top-level base field, but the CLI exposed no
+  `--set-description` flag — so updating a description forced
+  `--set-field description=...`, which `mutate` then *rejected* with a hint
+  pointing at a `--set-description` flag that did not exist. The flag is now
+  wired (the core `ModifyParams.set_description` + `yaml_edit` already
+  supported it). `rivet modify --help` now shows `--set-*` examples and a
+  note that positionals (`modify <ID> status approved`) are not valid.
+
 - **Issue #358 — incoming links are visible from `get` and `list`.** The
   single most common traceability question — "what verifies / satisfies X?"
   — lives on the backlink side, but `rivet get <ID>` only showed outbound

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -961,6 +961,19 @@ enum Command {
     },
 
     /// Modify an existing artifact
+    /// Modify an existing artifact (status, title, description, tags, fields)
+    ///
+    /// Use the `--set-*` flags, not positionals. Examples:
+    ///   rivet modify REQ-001 --set-status approved
+    ///   rivet modify REQ-001 --set-description "Updated rationale"
+    ///   rivet modify REQ-001 --set-field priority=must
+    #[command(after_help = "Examples:\n  \
+        rivet modify <ID> --set-status approved\n  \
+        rivet modify <ID> --set-description \"text\"\n  \
+        rivet modify <ID> --set-title \"New title\"\n  \
+        rivet modify <ID> --set-field key=value\n\n\
+        Note: use --set-* flags, not positionals \
+        (`modify <ID> status approved` is not valid).")]
     Modify {
         /// Artifact ID to modify
         id: String,
@@ -972,6 +985,11 @@ enum Command {
         /// Set the title
         #[arg(long)]
         set_title: Option<String>,
+
+        /// Set the description (a top-level base field — use this rather
+        /// than `--set-field description=...`)
+        #[arg(long)]
+        set_description: Option<String>,
 
         /// Add a tag
         #[arg(long)]
@@ -2276,6 +2294,7 @@ fn run(cli: Cli) -> Result<bool> {
             id,
             set_status,
             set_title,
+            set_description,
             add_tag,
             remove_tag,
             set_fields,
@@ -2284,6 +2303,7 @@ fn run(cli: Cli) -> Result<bool> {
             id,
             set_status.as_deref(),
             set_title.as_deref(),
+            set_description.as_deref(),
             add_tag,
             remove_tag,
             set_fields,
@@ -13708,11 +13728,13 @@ fn cmd_unlink(cli: &Cli, source_id: &str, link_type: &str, target_id: &str) -> R
 }
 
 /// Modify an existing artifact.
+#[allow(clippy::too_many_arguments)] // one parameter per CLI `--set-*` flag
 fn cmd_modify(
     cli: &Cli,
     id: &str,
     set_status: Option<&str>,
     set_title: Option<&str>,
+    set_description: Option<&str>,
     add_tags: &[String],
     remove_tags: &[String],
     set_fields: &[(String, String)],
@@ -13725,7 +13747,7 @@ fn cmd_modify(
     let params = ModifyParams {
         set_status: set_status.map(|s| s.to_string()),
         set_title: set_title.map(|s| s.to_string()),
-        set_description: None,
+        set_description: set_description.map(|s| s.to_string()),
         add_tags: add_tags.to_vec(),
         remove_tags: remove_tags.to_vec(),
         set_fields: set_fields.to_vec(),

--- a/rivet-core/src/yaml_edit.rs
+++ b/rivet-core/src/yaml_edit.rs
@@ -1514,4 +1514,30 @@ artifacts:
             Some("`rivet validate` is handy")
         );
     }
+
+    /// issue #360: `ModifyParams.set_description` (wired to the CLI
+    /// `--set-description` flag) writes the top-level `description` field.
+    #[test]
+    fn modify_applies_set_description_param() {
+        let content = "\
+artifacts:
+  - id: REQ-001
+    type: requirement
+    title: First
+    status: draft";
+        let params = crate::mutate::ModifyParams {
+            set_description: Some("Updated via --set-description".to_string()),
+            ..Default::default()
+        };
+        let store = crate::store::Store::new();
+        let out =
+            modify_artifact_yaml(content, "REQ-001", &params, &store).expect("modify must succeed");
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&out).expect("output must parse as YAML");
+        assert_eq!(
+            parsed["artifacts"][0]["description"].as_str(),
+            Some("Updated via --set-description"),
+            "set_description must write the top-level description"
+        );
+    }
 }


### PR DESCRIPTION
Closes the **#360** dead-end (and improves **#359**): `description` is a top-level base field, but the CLI had no `--set-description` flag — so `--set-field description=...` was rejected with a hint pointing at a flag that didn't exist. The core already supported it (`ModifyParams.set_description` + `yaml_edit`); only the clap wiring was missing.

- `rivet modify <ID> --set-description "text"` now works.
- `rivet modify --help` shows `--set-*` examples + a 'positionals not valid' note.

Regression test + verified end-to-end. (REQ-136.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)