### PR TITLE
feat(validate): --min-severity display filter to cut advisory noise (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ### Added
 
+- **Issue #357 — `validate --min-severity` filters display noise.** `rivet
+  validate` printed every diagnostic; on a clean repo that is ~160 advisory
+  warnings for 0 errors, burying the actionable ones. `rivet validate
+  --min-severity error` (or `warning`/`info`) now shows only diagnostics at
+  or above the floor, with a one-line note of how many were suppressed.
+  Counts and exit code are unchanged (display-only).
+
 - **Issues #359 / #360 — `rivet modify --set-description` + clearer usage.**
   `description` is a top-level base field, but the CLI exposed no
   `--set-description` flag — so updating a description forced

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3696,3 +3696,37 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-004
+
+  - id: REQ-137
+    type: requirement
+    title: "validate --min-severity: filter displayed diagnostics to cut advisory noise"
+    status: implemented
+    description: |
+      Self-reported via GitHub issue #357 (dogfooding). `rivet validate`
+      prints every diagnostic regardless of severity — on rivet's own repo
+      that is ~160 warnings (lifecycle aspirations, prose-mention notes)
+      for 0 errors, burying any actionable diagnostic. `--fail-on`
+      controls the exit-code threshold but still prints everything; there
+      was no way to say "show me only what I must act on."
+
+      Add `rivet validate --min-severity <error|warning|info>` (text
+      output) that DISPLAYS only diagnostics at or above the floor. Counts
+      and exit code are unchanged (computed from the full set); when the
+      filter hides anything, a one-line note reports how many of how many
+      were shown, so nothing is silently dropped (loud-fail register).
+      Reuses the existing `--fail-on` severity parser.
+
+      Acceptance:
+        - `rivet validate --min-severity error` on a warning-only repo
+          prints no `WARN:`/`INFO:` lines and notes "(showing N of M …
+          at or above 'error')".
+        - Exit code and the summary counts are identical with and without
+          `--min-severity` (display-only).
+    tags: [validate, diagnostics, dx, agent-ux, signal-to-noise, user-reported, issue-357]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-004

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -333,6 +333,13 @@ enum Command {
         #[arg(long, default_value = "error")]
         fail_on: String,
 
+        /// Only DISPLAY diagnostics at or above this severity (text output).
+        /// Values: "error", "warning", "info". Default shows all. Cuts the
+        /// low-signal advisory noise (e.g. `--min-severity error` shows only
+        /// what you must act on); does not affect counts or exit code.
+        #[arg(long = "min-severity")]
+        min_severity: Option<String>,
+
         /// Promote `cited-source-drift` warnings to errors. See
         /// `rivet docs schema-cited-sources` for the field shape.
         #[arg(long = "strict-cited-sources")]
@@ -1898,6 +1905,7 @@ fn run(cli: Cli) -> Result<bool> {
             binding,
             strict_variants,
             fail_on,
+            min_severity,
             strict_cited_sources,
             strict_cited_source_stale,
             check_remote_sources,
@@ -1915,6 +1923,7 @@ fn run(cli: Cli) -> Result<bool> {
             binding.as_deref(),
             *strict_variants,
             fail_on,
+            min_severity.as_deref(),
             *strict_cited_sources,
             *strict_cited_source_stale,
             *check_remote_sources,
@@ -4582,6 +4591,7 @@ fn cmd_validate(
     binding_path: Option<&std::path::Path>,
     strict_variants: bool,
     fail_on: &str,
+    min_severity: Option<&str>,
     strict_cited_sources: bool,
     strict_cited_source_stale: bool,
     check_remote_sources: bool,
@@ -4590,6 +4600,9 @@ fn cmd_validate(
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let fail_on_threshold = parse_fail_on(fail_on)?;
+    // #357: optional DISPLAY floor — only print diagnostics at/above this
+    // severity. Reuses the same parser as --fail-on. None = show all.
+    let display_floor = min_severity.map(parse_fail_on).transpose()?;
     check_for_updates();
 
     let ctx = ProjectContext::load_with_docs(cli)?;
@@ -5229,7 +5242,31 @@ fn cmd_validate(
             );
         }
 
-        print_diagnostics_with_remediation(&diagnostics, Some((&store, &schema)));
+        // #357: when --min-severity is set, display only diagnostics at/above
+        // the floor (counts + exit code are unaffected — they were computed
+        // above from the full set). Severity rank: Error > Warning > Info.
+        let rank = |s: Severity| match s {
+            Severity::Error => 2u8,
+            Severity::Warning => 1,
+            Severity::Info => 0,
+        };
+        let shown: Vec<validate::Diagnostic> = match display_floor {
+            Some(floor) => diagnostics
+                .iter()
+                .filter(|d| rank(d.severity) >= rank(floor))
+                .cloned()
+                .collect(),
+            None => diagnostics.clone(),
+        };
+        if display_floor.is_some() && shown.len() != diagnostics.len() {
+            println!(
+                "(showing {} of {} diagnostics at or above '{}'; counts above are the full set)",
+                shown.len(),
+                diagnostics.len(),
+                min_severity.unwrap_or("info"),
+            );
+        }
+        print_diagnostics_with_remediation(&shown, Some((&store, &schema)));
 
         if !cross_repo_broken.is_empty() {
             println!();
@@ -8640,6 +8677,7 @@ fn cmd_diff(
                     binding: None,
                     strict_variants: false,
                     fail_on: "error".to_string(),
+                    min_severity: None,
                     strict_cited_sources: false,
                     strict_cited_source_stale: false,
                     check_remote_sources: false,
@@ -8663,6 +8701,7 @@ fn cmd_diff(
                     binding: None,
                     strict_variants: false,
                     fail_on: "error".to_string(),
+                    min_severity: None,
                     strict_cited_sources: false,
                     strict_cited_source_stale: false,
                     check_remote_sources: false,

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1695,6 +1695,34 @@ fn get_nonexistent_returns_error() {
     );
 }
 
+/// issue #357: `rivet validate --min-severity error` only DISPLAYS
+/// error-level diagnostics (filtering the low-signal warning/info noise),
+/// while leaving counts/exit untouched. rivet's own repo has 0 errors, so
+/// the filtered output must contain no `WARN:`/`INFO:` lines and must note
+/// what it suppressed.
+#[test]
+fn validate_min_severity_filters_display() {
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "validate",
+            "--min-severity",
+            "error",
+        ])
+        .output()
+        .expect("failed to execute rivet validate --min-severity error");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("WARN:") && !stdout.contains("INFO:"),
+        "--min-severity error must suppress WARN/INFO lines. Got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("at or above 'error'"),
+        "must note that lower-severity diagnostics were suppressed. Got:\n{stdout}"
+    );
+}
+
 /// `rivet get REQ-001 --format yaml` produces YAML output.
 #[test]
 fn get_yaml_produces_valid_output() {


### PR DESCRIPTION
Implements **#357** (my own dogfooding finding). `rivet validate` printed every diagnostic; on a clean repo that is ~160 advisory warnings for 0 errors, burying anything actionable.

`rivet validate --min-severity error` (or `warning`/`info`) now displays only diagnostics at/above the floor, with a one-line note of how many were suppressed. **Counts + exit code unchanged** (display-only) — loud-fail preserved. Reuses the `--fail-on` parser. Regression test + verified on rivet's repo (`--min-severity error` → 'showing 0 of 356'). REQ-137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)