### PR TITLE
fix(export): drop the localhost oEmbed discovery tag from static export (REQ-117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
 
 ### Fixed
 
+- **REQ-117 — static export no longer emits a `localhost` oEmbed tag.** Every
+  exported artifact page carried an oEmbed discovery `<link>` pointing at
+  `http://localhost:<port>`, meaningless (and broken metadata) in a static
+  `export --format html` that has no server. The tag is now emitted only when
+  served (a real, non-zero port).
+
 - **Issue #349 — `required-backlink` rules now match the inverse-name
   convention.** Schemas (e.g. `safety-case.yaml`) declare
   `required-backlink: supported-by` — the *inverse* of the forward

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -2867,7 +2867,7 @@ artifacts:
   - id: REQ-117
     type: requirement
     title: "HTML export embeds hardcoded localhost in oEmbed discovery tag"
-    status: draft
+    status: implemented
     description: |
       Bug-hunt finding (path-url-leakage, 3/3 lens-confirmed).
 

--- a/rivet-cli/src/render/artifacts.rs
+++ b/rivet-cli/src/render/artifacts.rs
@@ -536,15 +536,23 @@ pub(crate) fn render_artifact_detail(ctx: &RenderContext, id: &str) -> RenderRes
     };
 
     // oEmbed discovery tag — allows Notion/Confluence to auto-discover the embed
-    let oembed_discovery = format!(
-        r#"<link rel="alternate" type="application/json+oembed" href="http://localhost:{port}/oembed?url={encoded_url}&amp;format=json" title="{title}" />"#,
-        port = ctx.context.port,
-        encoded_url = urlencoding::encode(&format!(
-            "http://localhost:{}/artifacts/{}",
-            ctx.context.port, artifact.id
-        )),
-        title = html_escape(&format!("{}: {}", artifact.id, artifact.title)),
-    );
+    // from a LIVE server. REQ-117 (#117): static `export --format html` has no
+    // server, so `port` is 0 there; emitting a `http://localhost:0/...` tag
+    // produces broken metadata in every exported page. Only emit when served
+    // (a real, non-zero port).
+    let oembed_discovery = if ctx.context.port == 0 {
+        String::new()
+    } else {
+        format!(
+            r#"<link rel="alternate" type="application/json+oembed" href="http://localhost:{port}/oembed?url={encoded_url}&amp;format=json" title="{title}" />"#,
+            port = ctx.context.port,
+            encoded_url = urlencoding::encode(&format!(
+                "http://localhost:{}/artifacts/{}",
+                ctx.context.port, artifact.id
+            )),
+            title = html_escape(&format!("{}: {}", artifact.id, artifact.title)),
+        )
+    };
 
     let mut html = format!(
         "{oembed_discovery}<h2>{}{}</h2><p class=\"meta\">{}</p>",

--- a/tests/playwright/export.spec.ts
+++ b/tests/playwright/export.spec.ts
@@ -261,4 +261,31 @@ test.describe("HTML Export", () => {
       expect(content, `Panic found in ${f}`).not.toContain(panicPattern);
     }
   });
+
+  // issue #117 (REQ-117): static export has no live server, so the oEmbed
+  // discovery <link> (which points at http://localhost:<port>) must not be
+  // emitted — otherwise every page carries broken metadata.
+  test("no exported page emits a localhost oEmbed discovery tag", async () => {
+    const walk = (dir: string): string[] => {
+      const files: string[] = [];
+      for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) files.push(...walk(full));
+        else if (e.name.endsWith(".html")) files.push(full);
+      }
+      return files;
+    };
+    for (const f of walk(EXPORT_DIR)) {
+      const content = fs.readFileSync(f, "utf8");
+      // The oEmbed discovery <link> tag (the leak) — distinct from any
+      // artifact prose that merely mentions "oembed"/"localhost".
+      expect(
+        content,
+        `oEmbed discovery tag leaked into export at ${f}`,
+      ).not.toMatch(/rel="alternate"[^>]*json\+oembed/);
+      expect(content, `localhost:0 leaked into export at ${f}`).not.toContain(
+        "localhost:0",
+      );
+    }
+  });
 });


### PR DESCRIPTION
Bug-hunt finding (REQ-117, 3/3 lens-confirmed). Static `export --format html` emitted an oEmbed discovery `<link>` pointing at `http://localhost:<port>` on every page — broken metadata with no server (export's `RepoContext.port` is 0). Now emitted only when served. Verified on a real export (0 oEmbed tags, 0 `localhost:0`); Playwright guard added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)