### PR TITLE
feat(list): --orphans — list artifacts disconnected from the graph (REQ-128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ### Added
 
+- **REQ-128 / #358 — `rivet list --orphans`.** Lists only artifacts with no
+  inbound and no outbound links — disconnected from the traceability graph,
+  i.e. an asserted-but-unanchored claim (a requirement no test verifies, a
+  decision no hazard drives). Combine with `--type`. Built on the existing
+  `LinkGraph::orphans`; works in text and `--format json`. (The
+  inbound-link-count ranking report remains a follow-up.)
+
 - **REQ-125 / #349 / #350 / #358 — `rivet validate --explain <ID>`.** Explains
   one artifact: which traceability rules target its type and whether each is
   satisfied (and via which incoming/outgoing link, or what's missing — e.g.

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -441,6 +441,12 @@ enum Command {
         /// artifact's merged `fields:` view for the variant.
         #[arg(long, value_name = "NAME_OR_PATH")]
         variant: Option<String>,
+
+        /// Only list ORPHANS — artifacts with no inbound and no outbound
+        /// links, disconnected from the traceability graph (an
+        /// asserted-but-unanchored claim). Combine with `--type` to scope.
+        #[arg(long)]
+        orphans: bool,
     },
 
     /// Show artifact summary statistics
@@ -1953,6 +1959,7 @@ fn run(cli: Cli) -> Result<bool> {
             format,
             baseline,
             variant,
+            orphans,
         } => cmd_list(
             &cli,
             r#type.as_deref(),
@@ -1961,6 +1968,7 @@ fn run(cli: Cli) -> Result<bool> {
             format,
             baseline.as_deref(),
             variant.as_deref(),
+            *orphans,
         ),
         Command::Get { id, format } => cmd_get(&cli, id, format),
         Command::Bundle { id, depth, format } => cmd_bundle(&cli, id, *depth, format),
@@ -5924,6 +5932,7 @@ fn cmd_bundle(cli: &Cli, id: &str, depth: usize, format: &str) -> Result<bool> {
 }
 
 /// List artifacts.
+#[allow(clippy::too_many_arguments)] // one parameter per CLI list filter
 fn cmd_list(
     cli: &Cli,
     type_filter: Option<&str>,
@@ -5932,6 +5941,7 @@ fn cmd_list(
     format: &str,
     baseline_name: Option<&str>,
     variant_arg: Option<&str>,
+    orphans_only: bool,
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let ctx = ProjectContext::load(cli)?;
@@ -5961,6 +5971,15 @@ fn cmd_list(
         results.retain(|a| {
             rivet_core::sexpr_eval::matches_filter_with_store(&expr, a, &graph, &store)
         });
+    }
+
+    // REQ-128: `--orphans` keeps only artifacts with no inbound and no
+    // outbound links (disconnected from the traceability graph).
+    if orphans_only {
+        let graph = rivet_core::links::LinkGraph::build(&store, &ctx.schema);
+        let orphan_ids: std::collections::HashSet<&str> =
+            graph.orphans(&store).iter().map(|id| id.as_str()).collect();
+        results.retain(|a| orphan_ids.contains(a.id.as_str()));
     }
 
     if format == "json" {

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1755,6 +1755,34 @@ fn validate_explain_shows_rule_status() {
     );
 }
 
+/// REQ-128: `rivet list --orphans` lists only artifacts disconnected from
+/// the graph. Its count must be a subset of the full list.
+#[test]
+fn list_orphans_is_subset() {
+    let root = project_root();
+    let root_str = root.to_str().unwrap();
+    let run = |orphans: bool| {
+        let mut args = vec!["--project", root_str, "list", "--format", "json"];
+        if orphans {
+            args.push("--orphans");
+        }
+        let out = Command::new(rivet_bin())
+            .args(&args)
+            .output()
+            .expect("rivet list failed");
+        assert!(out.status.success(), "list must exit 0");
+        let v: serde_json::Value =
+            serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("valid JSON");
+        v["count"].as_u64().expect("count field")
+    };
+    let all = run(false);
+    let orphans = run(true);
+    assert!(
+        orphans <= all,
+        "orphans ({orphans}) must be a subset of all artifacts ({all})"
+    );
+}
+
 /// `rivet get REQ-001 --format yaml` produces YAML output.
 #[test]
 fn get_yaml_produces_valid_output() {


### PR DESCRIPTION
The orphan detector — mechanical enforcement of 'no asserted-but-unanchored claim' (a requirement no test verifies, a decision no hazard drives). `rivet list --orphans` keeps only artifacts with no inbound AND no outbound links, built on the existing `LinkGraph::orphans`; composes with `--type` + `--format json`. Verified on rivet's repo (5 disconnected artifacts) + regression test; clippy --all-targets clean. Completes the orphan half of REQ-128 (the inbound-count ranking report remains, so REQ-128 stays draft).