### PR TITLE
fix(reqif): import fails on a title-less SPEC-OBJECT (REQ-123, F2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@
 
 ### Fixed
 
+- **REQ-123 (F2 silent-failure) — ReqIF import fails on a title-less
+  SPEC-OBJECT.** A SPEC-OBJECT with neither a `ReqIF.Name` attribute nor a
+  `@LONG-NAME` used to import as an artifact with an empty `title` (a required
+  base field) via `unwrap_or_default()` — a silently-invalid artifact. Import
+  now returns an `Err` naming the object. Completes the ReqIF F2 sweep
+  (REQ-119, REQ-120, REQ-123). Regression test.
+
 - **REQ-119 (F2 silent-failure) — ReqIF import fails on an unresolved enum
   ref.** An `ENUM-VALUE-REF` matching no defined `ENUM-VALUE` identifier was
   silently dropped via `filter_map`, yielding a degraded/incomplete field

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3102,7 +3102,7 @@ artifacts:
   - id: REQ-123
     type: requirement
     title: "ReqIF title/description default fallbacks mask missing required fields"
-    status: draft
+    status: implemented
     description: |
       Bug-hunt finding (f2-silent-failure, 3/3 lens-confirmed).
 

--- a/rivet-core/src/reqif.rs
+++ b/rivet-core/src/reqif.rs
@@ -971,6 +971,17 @@ pub fn parse_reqif(xml: &str, type_map: &HashMap<String, String>) -> Result<Vec<
         let title = reqif_name
             .or_else(|| obj.long_name.clone())
             .unwrap_or_default();
+        // REQ-123 (F2 silent-failure): a SPEC-OBJECT with neither a ReqIF.Name
+        // attribute nor a @LONG-NAME used to import as an artifact with an EMPTY
+        // `title` (a required base field) via `unwrap_or_default()` — a
+        // silently-invalid artifact. Fail loudly, naming the object, instead.
+        if title.trim().is_empty() {
+            return Err(Error::Adapter(format!(
+                "ReqIF SPEC-OBJECT '{}' has neither a ReqIF.Name attribute nor a @LONG-NAME — \
+                 cannot derive the required `title` field",
+                obj.identifier,
+            )));
+        }
         // Use ReqIF.Text or @DESC as description
         let description = reqif_text.or_else(|| obj.desc.clone());
 
@@ -2806,6 +2817,38 @@ mod tests {
         // falls back to IDENTIFIER ("R-1"). Mutant would set
         // reqif_foreign_id = Some("") → id = "" → broken artifact.
         assert_eq!(arts[0].id, "R-1");
+    }
+
+    /// REQ-123 (F2 silent-failure): a SPEC-OBJECT with neither a ReqIF.Name
+    /// attribute nor a @LONG-NAME must FAIL the parse (naming the object), not
+    /// import an artifact with an empty required `title`.
+    // rivet: verifies REQ-123
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn parse_reqif_fails_on_titleless_spec_object() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd">
+  <THE-HEADER><REQ-IF-HEADER IDENTIFIER="titleless"/></THE-HEADER>
+  <CORE-CONTENT>
+    <REQ-IF-CONTENT>
+      <DATATYPES/>
+      <SPEC-TYPES><SPEC-OBJECT-TYPE IDENTIFIER="SOT-req" LONG-NAME="requirement"/></SPEC-TYPES>
+      <SPEC-OBJECTS>
+        <SPEC-OBJECT IDENTIFIER="R-NO-TITLE">
+          <TYPE><SPEC-OBJECT-TYPE-REF>SOT-req</SPEC-OBJECT-TYPE-REF></TYPE>
+        </SPEC-OBJECT>
+      </SPEC-OBJECTS>
+      <SPEC-RELATIONS/>
+    </REQ-IF-CONTENT>
+  </CORE-CONTENT>
+</REQ-IF>"#;
+        let err = parse_reqif(xml, &HashMap::new())
+            .expect_err("a SPEC-OBJECT with no name/LONG-NAME must fail the parse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("R-NO-TITLE") && msg.contains("title"),
+            "the error must name the object and the missing title; got: {msg}"
+        );
     }
 
     /// `status` and `tags` recognition through both UPPER and lowercase


### PR DESCRIPTION
Bug-hunt finding (REQ-123, f2-silent-failure). A SPEC-OBJECT with no `ReqIF.Name` and no `@LONG-NAME` imported as an artifact with an empty required `title` via `unwrap_or_default()`. Import now `Err`s naming the object. **Completes the ReqIF F2 sweep** (REQ-119 + REQ-120 + REQ-123). Regression test; all 46 reqif tests green; clippy --all-targets clean. Marks REQ-123 implemented.