### PR TITLE
fix(modify): correct s-expr syntax in --where help examples (REQ-141)

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -992,8 +992,8 @@ enum Command {
         rivet modify <ID> --set-description \"text\"\n  \
         rivet modify <ID> --set-title \"New title\"\n  \
         rivet modify <ID> --set-field key=value\n  \
-        rivet modify --where '(and (type \"requirement\") (status \"draft\"))' --set-status implemented\n  \
-        rivet modify --where '(status \"draft\")' --set-status implemented --dry-run\n\n\
+        rivet modify --where '(= status \"draft\")' --set-status implemented\n  \
+        rivet modify --where '(and (= type \"requirement\") (= status \"draft\"))' --set-status implemented --dry-run\n\n\
         Note: use --set-* flags, not positionals \
         (`modify <ID> status approved` is not valid). Pass exactly one of \
         <ID> or --where.")]


### PR DESCRIPTION
Follow-up to #380. The `modify --where` after_help examples I added used an invalid filter shorthand — `(type "requirement")` / `(status "draft")` — where the s-expr head must be an **operator**, not the field name. Run verbatim they error (`unknown form 'type'`). Corrected to the canonical `(= field "value")` form:

```sh
rivet modify --where '(= status "draft")' --set-status implemented
rivet modify --where '(and (= type "requirement") (= status "draft"))' --set-status implemented --dry-run
```

Verified both now execute (dry-run) without a parse error. Caught while filing #381 (the parse error shows no example of the common field-equality form — the broader discoverability fix is tracked there).

Implements: REQ-141

🤖 Generated with [Claude Code](https://claude.com/claude-code)