### PR TITLE
fix(externals): resolve refs with a hyphenated (kebab) prefix (REQ-143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,19 @@
 
 ### Fixed
 
+- **REQ-143 — external artifact refs with a hyphenated prefix now resolve
+  (were 404).** Browsing `/artifacts/linc-mesh:A-AVTP-STREAM` in serve returned
+  "Artifact does not exist", and external `prefix:ID` refs with a kebab-case
+  prefix were unresolved in document rendering, even though the artifact
+  existed in the external project. `parse_artifact_ref` required the prefix to
+  be *purely* lowercase ASCII (no hyphens), so a slug like `linc-mesh` fell
+  through to a local lookup — even though externals are *stored* as
+  `<prefix>:<id>` with that same hyphenated prefix, so the parse no longer
+  round-tripped its own output. Now accepts a kebab slug (leading lowercase
+  letter, then lowercase / digits / hyphens). One shared gate, so both the
+  serve detail view and document link resolution are fixed; Kani round-trip
+  proof updated. Regression tests.
+
 - **REQ-142 / #381 — s-expr filter parse error now shows the field-equality
   form.** The filter dialect (shared by `query`, `list --filter`,
   `export --filter`, `modify --where`) puts an operator in head position, but

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3945,3 +3945,111 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-143
+    type: requirement
+    title: "External artifact refs with a hyphenated prefix (kebab project slug) must resolve, not 404"
+    status: implemented
+    description: |
+      User-reported (0.14.0). Browsing `/artifacts/linc-mesh:A-AVTP-STREAM` in
+      serve returned "Artifact does not exist", and external `prefix:ID` refs
+      with a hyphenated prefix were unresolved in document rendering, even
+      though the artifact existed in the external project.
+
+      Root cause: `externals::parse_artifact_ref` required the prefix to be
+      PURELY `is_ascii_lowercase()` — no hyphens. A kebab-case project slug
+      like `linc-mesh` failed the check, so the ref fell through to
+      `ArtifactRef::Local("linc-mesh:A-AVTP-STREAM")` and was looked up as a
+      local id (404). But externals are stored as `<prefix>:<id>` with that
+      same hyphenated prefix, so the parse no longer round-tripped its own
+      stored form. Every external whose prefix contained a hyphen was
+      unreachable in serve detail view and in document link resolution.
+
+      Fix: accept a kebab-case slug prefix — starts with a lowercase letter,
+      then lowercase letters / digits / hyphens. `parse_artifact_ref` is the
+      single shared gate (serve detail handler + document link rendering both
+      delegate to it), so one fix restores both surfaces. The Kani
+      round-trip proof was updated to the new contract.
+
+      Acceptance:
+        - `parse_artifact_ref("linc-mesh:A-AVTP-STREAM")` returns
+          `External { prefix: "linc-mesh", id: "A-AVTP-STREAM" }`.
+        - A ref whose prefix does not start with a lowercase letter (e.g.
+          `H-1:2`) stays `Local`.
+        - `cargo test -p rivet-core --lib externals::tests` passes.
+    tags: [bug, externals, serve, regression, user-reported, v0.14.0]
+    fields:
+      priority: must
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-085
+
+  - id: REQ-144
+    type: requirement
+    title: "Source-view artifact-id linking must match whole tokens, not substrings"
+    status: draft
+    description: |
+      User-reported. In the source view, an artifact id that is a SUBSTRING of
+      another id gets wrongly linked. Example: a doc carrying
+      `doc-id: SDV-BCM-SWR-001` also has an artifact `SWR-001` in the store;
+      because matching uses `str::contains`, `SWR-001` is detected inside
+      `SDV-BCM-SWR-001`, producing a spurious link. For a traceability tool
+      this is a correctness bug — a phantom trace edge.
+
+      Location: `rivet-cli/src/render/source.rs` lines ~841 and ~856 use
+      `line.contains(id.as_str())`. The fix is a whole-token match: an id only
+      matches when it is delimited by non-`[A-Za-z0-9-]` characters (ids
+      contain hyphens, so hyphen is part of the token, not a delimiter).
+
+      Acceptance:
+        - A source line containing `SDV-BCM-SWR-001` does NOT produce a link
+          to a shorter artifact `SWR-001` that is merely a substring.
+        - A line containing the exact id `SWR-001` (surrounded by whitespace /
+          punctuation) still links to it.
+        - Regression test in source.rs covers the substring vs whole-token case.
+    tags: [bug, source-view, traceability, correctness, user-reported]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-092
+
+  - id: REQ-145
+    type: requirement
+    title: "Test-results import: honor a rivet_tc_id property for the testcase artifact id"
+    status: draft
+    description: |
+      User-reported. When importing JUnit-style test results, rivet derives
+      the testcase artifact id from `classname` + `name` (the
+      `format!("{}.{}", classname, name)` fallback in
+      `rivet-core/src/junit.rs::artifact_id_for`), so the link to the intended
+      artifact does not resolve. The user records an explicit id per testcase:
+      a `rivet_tc_id` property (e.g. value `SYS-VER-058`) and wants rivet to
+      use it.
+
+      The JUnit parser does not currently read `<property>` children of
+      `<testcase>` (the `ParsedCase` struct has no properties field; the
+      element is silently ignored). Add: parse `<property>` children, and in
+      `artifact_id_for` add a highest-priority tier that returns the
+      `rivet_tc_id` property value when present, before the existing
+      classname/name heuristics.
+
+      Acceptance:
+        - A testcase (classname `com.x.Y`, name `t`) carrying a `rivet_tc_id`
+          property of `SYS-VER-058` imports with artifact id `SYS-VER-058`,
+          not `com.x.Y.t`.
+        - A testcase with no such property keeps the current classname/name
+          behaviour (back-compatible).
+        - Parser test covers the property-present and property-absent cases.
+    tags: [feature, test-results, junit, import, traceability, user-reported]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-101

--- a/rivet-core/src/externals.rs
+++ b/rivet-core/src/externals.rs
@@ -59,11 +59,21 @@ pub enum ArtifactRef {
 ///
 /// - `"REQ-001"` → `ArtifactRef::Local("REQ-001")`
 /// - `"rivet:REQ-001"` → `ArtifactRef::External { prefix: "rivet", id: "REQ-001" }`
+/// - `"linc-mesh:A-AVTP-STREAM"` → `ArtifactRef::External { prefix: "linc-mesh", id: "A-AVTP-STREAM" }`
 pub fn parse_artifact_ref(s: &str) -> ArtifactRef {
-    // Only split on first colon. The prefix must be purely alphabetic
-    // (no digits, hyphens, or dots) to avoid confusion with IDs like "H-1.2".
+    // Split on the first colon. The prefix must be a kebab-case project slug:
+    // it starts with a lowercase letter and is otherwise lowercase letters,
+    // digits, or hyphens. This matches the external `prefix:` declared in
+    // rivet.yaml (e.g. `linc-mesh`, `spar`) and round-trips the stored
+    // `<prefix>:<id>` form. Requiring a leading letter keeps an ordinary
+    // local ID (which never starts a colon-delimited segment with a letter
+    // slug) from being misread as a cross-repo reference.
     if let Some((prefix, id)) = s.split_once(':') {
-        if !prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_lowercase()) && !id.is_empty() {
+        let valid_prefix = prefix.starts_with(|c: char| c.is_ascii_lowercase())
+            && prefix
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+        if valid_prefix && !id.is_empty() {
             return ArtifactRef::External {
                 prefix: prefix.to_string(),
                 id: id.to_string(),
@@ -1001,6 +1011,46 @@ mod tests {
                 prefix: "meld".into(),
                 id: "UCA-C-1".into(),
             }
+        );
+    }
+
+    // A kebab-case external prefix (a hyphen in the project slug) must
+    // round-trip. Regression for the serve/document 404 where
+    // `linc-mesh:A-AVTP-STREAM` was misread as a local id because the prefix
+    // check rejected the hyphen. (REQ-143)
+    // rivet: verifies REQ-020
+    #[test]
+    fn external_prefix_with_hyphen() {
+        assert_eq!(
+            parse_artifact_ref("linc-mesh:A-AVTP-STREAM"),
+            ArtifactRef::External {
+                prefix: "linc-mesh".into(),
+                id: "A-AVTP-STREAM".into(),
+            }
+        );
+        // A digit in the slug is fine too (e.g. `linc2`).
+        assert_eq!(
+            parse_artifact_ref("linc2:REQ-1"),
+            ArtifactRef::External {
+                prefix: "linc2".into(),
+                id: "REQ-1".into(),
+            }
+        );
+    }
+
+    // A prefix that does not start with a lowercase letter is NOT a project
+    // slug, so the ref stays local (guards an uppercase-led id with a colon
+    // from being misread as cross-repo). (REQ-143)
+    // rivet: verifies REQ-020
+    #[test]
+    fn non_slug_prefix_stays_local() {
+        assert_eq!(
+            parse_artifact_ref("H-1:2"),
+            ArtifactRef::Local("H-1:2".into())
+        );
+        assert_eq!(
+            parse_artifact_ref("-bad:REQ-1"),
+            ArtifactRef::Local("-bad:REQ-1".into())
         );
     }
 

--- a/rivet-core/src/proofs.rs
+++ b/rivet-core/src/proofs.rs
@@ -117,9 +117,18 @@ mod proofs {
                     // prefix:id must reconstruct the original
                     kani::assert(!prefix.is_empty(), "External prefix must be non-empty");
                     kani::assert(!id.is_empty(), "External id must be non-empty");
+                    // A valid prefix is a kebab-case project slug: starts with
+                    // a lowercase letter, then lowercase letters / digits /
+                    // hyphens (REQ-143).
                     kani::assert(
-                        prefix.chars().all(|c| c.is_ascii_lowercase()),
-                        "External prefix must be all lowercase ASCII",
+                        prefix.starts_with(|c: char| c.is_ascii_lowercase()),
+                        "External prefix must start with a lowercase ASCII letter",
+                    );
+                    kani::assert(
+                        prefix
+                            .chars()
+                            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                        "External prefix must be lowercase ASCII, digits, or hyphens",
                     );
                 }
             }


### PR DESCRIPTION
## User report (0.14.0)

> `/artifacts/linc-mesh:A-AVTP-STREAM` → Not Found. Artifact linc-mesh:A-AVTP-STREAM does not exist. …even though i browsed it and i know it is there. …generally still the external artifacts are not to be found.

## Root cause

`externals::parse_artifact_ref` required the prefix to be **purely** `is_ascii_lowercase()` — no hyphens (the old doc-comment even said so). A kebab-case project slug like `linc-mesh` failed that check, so `linc-mesh:A-AVTP-STREAM` fell through to `ArtifactRef::Local(...)` and was looked up as a *local* id → 404.

The kicker: externals are **stored** as `<prefix>:<id>` using that same hyphenated prefix (`ProjectContext` does `artifact.id = format!("{}:{}", ext.prefix, artifact.id)`), so the parser no longer round-tripped its own output. Every external whose prefix contained a hyphen was unreachable in:
- the serve **detail view** (`render_artifact_detail` → `parse_artifact_ref`), and
- **document link resolution** (same function).

One shared gate, so one fix restores both surfaces.

## Fix

Accept a kebab-case slug prefix: **leading lowercase letter, then lowercase letters / digits / hyphens**. Requiring a leading letter keeps an ordinary local id with a colon (e.g. `H-1:2`) from being misread as a cross-repo ref.

## Verification
- New tests: `linc-mesh:A-AVTP-STREAM` and `linc2:REQ-1` → `External`; `H-1:2` and `-bad:REQ-1` → `Local`. The existing `H-1.2` and `rivet:REQ-001` cases still pass. All **28** `externals::tests` green.
- Kani round-trip proof updated to the new prefix contract.
- clippy `--all-targets` + fmt clean; `rivet validate` PASS.

## Also in this iteration (triaged, filed, not yet fixed)
Two more user reports filed as draft REQs to work next:
- **REQ-144** — source-view links match substrings (`SWR-001` wrongly linked inside `SDV-BCM-SWR-001`); `render/source.rs` uses `str::contains`, needs whole-token match.
- **REQ-145** — JUnit import should honor a per-testcase `rivet_tc_id` property instead of `classname.name`.

Fixes: REQ-143

🤖 Generated with [Claude Code](https://claude.com/claude-code)