### PR TITLE
test(serve): stabilize graph_type_filter flake with a 15s budget (#389)

### DIFF
--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -1111,7 +1111,18 @@ fn graph_type_filter_renders_when_under_budget() {
     let (mut child, port) = start_server();
 
     let start = std::time::Instant::now();
-    let (status, body, _) = fetch(port, "/graph?types=requirement", true);
+    // The type-filtered graph still does a BFS + layout over the dogfood
+    // corpus, which can brush past the default 5s read timeout on a loaded CI
+    // runner — the same chronic flake the focus-graph tests hit, where a
+    // timeout surfaces as status=0 and fails the `== 200` assertion. Give it
+    // the same generous budget the other graph endpoints use; this test
+    // asserts on the response, not on a hard latency bound.
+    let (status, body, _) = fetch_with_timeout(
+        port,
+        "/graph?types=requirement",
+        true,
+        Duration::from_secs(15),
+    );
     let elapsed = start.elapsed();
     let has_svg = body.contains("<svg");
     let has_budget = body.contains("budget");


### PR DESCRIPTION
Closes #389.

`graph_type_filter_renders_when_under_budget` fetched `/graph?types=requirement` with the **default 5s** read timeout. That endpoint runs a BFS + layout over the dogfood corpus (~742 nodes / 1477 edges); on a loaded CI runner it can brush past 5s. `fetch_with_timeout` parses a timed-out/empty response's status as `0`, so the timeout surfaced as `status == 0` and failed `assert_eq!(status, 200)`.

This is the **same chronic flake** the focus-graph tests already fixed by moving to a 15s budget (per the comment block above `fetch_with_timeout`) — this one test was missed. It produced false CI failures (Test / Proptest-extended jobs) on #380, #387, and #388, each verified to pass locally.

**Fix:** use `fetch_with_timeout(..., Duration::from_secs(15))`, matching the sibling graph endpoints. The test asserts on the response shape (SVG **or** budget message), not a hard latency bound, so the wider timeout is safe.

**Verification:** passes 3/3 local runs; clippy `--all-targets` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)