### PR TITLE
fix(validate): salsa path evaluates status-gate validation-rules (REQ-146, #355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@
 
 ### Fixed
 
+- **REQ-146 / #355 — default `rivet validate` now evaluates status-gate
+  validation-rules (parity with `--direct` / `gaps-json`).** The incremental
+  salsa path (`db::validate_all`) ran structural (phases 1-7) and conditional
+  (phase 8) rules but silently skipped the status-gate `validation-rules`
+  (phase 9 — the V-model promotion gates). So the default `rivet validate`
+  PASSED a project that `rivet check gaps-json` and `rivet validate --direct`
+  FAILED on a gate violation — a soundness gap in the default surface. Both
+  salsa entry points now evaluate `validation_rules` against the same
+  store/schema/graph; all validation surfaces agree. Regression test.
+
 - **REQ-144 — source view no longer links an id that is a substring of a
   longer id.** The source viewer matched artifact ids into code/doc lines with
   `str::contains`, so a short id was linked when it appeared only as a

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4053,3 +4053,39 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-101
+
+  - id: REQ-146
+    type: requirement
+    title: "Salsa validate path must evaluate status-gate validation-rules (parity with the direct path)"
+    status: implemented
+    description: |
+      Surfaced verifying issue #355 Finding 3 ("rivet validate and rivet check
+      gaps-json disagree"). `rivet validate` runs the incremental salsa path
+      (`db::validate_all`), which evaluated structural rules (phases 1-7) and
+      conditional rules (phase 8) but NOT the status-gate `validation-rules`
+      (phase 9 — the `(implies …)` V-model promotion gates). The direct
+      `validate::validate*` path (used by `rivet check gaps-json` and
+      `rivet validate --direct`) DID evaluate them. Result: the default
+      `rivet validate` silently PASSED a project with a status-gate violation
+      that `gaps-json`/`--direct` correctly FAILED — a validation soundness
+      gap, since the default surface under-reported.
+
+      Fix: `db::validate_all` and `validate_all_with_extras` now also call
+      `validate::evaluate_validation_rules` against the same materialized
+      store/schema/graph, so every validation surface agrees.
+
+      Acceptance:
+        - On a project whose schema declares a `validation-rules` status gate
+          that an artifact violates, `rivet validate` (default/salsa) and
+          `rivet validate --direct` report the SAME error count, both
+          including the gate diagnostic.
+        - `cargo test -p rivet-core --lib
+          db::tests::validation_rules_evaluated_in_validate_all` passes.
+    tags: [bug, validation, salsa, soundness, consistency, issue-355]
+    fields:
+      priority: must
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-029

--- a/rivet-core/src/db.rs
+++ b/rivet-core/src/db.rs
@@ -328,6 +328,16 @@ pub fn validate_all(
     // invalidation granularity.
     diagnostics.extend(evaluate_conditional_rules(db, source_set, schema_set));
 
+    // Status-gate / cross-artifact validation rules (phase 9). The direct
+    // `validate::validate*` path evaluates these; the salsa path omitted them,
+    // so the default `rivet validate` silently passed a project that
+    // `rivet check gaps-json` / `validate --direct` failed on a status-gate
+    // violation (issue #355). Evaluate them here against the same materialized
+    // store/schema/graph so every validation surface agrees.
+    diagnostics.extend(crate::validate::evaluate_validation_rules(
+        &store, &schema, &graph,
+    ));
+
     diagnostics
 }
 
@@ -369,6 +379,13 @@ pub fn validate_all_with_extras(
     // invalidation granularity.
     diagnostics.extend(evaluate_conditional_rules_with_extras(
         db, source_set, schema_set, extra_set,
+    ));
+
+    // Status-gate / cross-artifact validation rules (phase 9) — see the note
+    // in `validate_all`; the extras-aware store includes adapter-loaded
+    // artifacts so cross-format status gates resolve too (issue #355).
+    diagnostics.extend(crate::validate::evaluate_validation_rules(
+        &store, &schema, &graph,
     ));
 
     diagnostics
@@ -1426,6 +1443,78 @@ artifacts:
         assert!(
             !conditional.is_empty(),
             "expected conditional approved-needs-desc error in composed diagnostics"
+        );
+    }
+
+    /// #355: the salsa `validate_all` path must evaluate status-gate
+    /// `validation-rules` (phase 9), not only structural + conditional rules.
+    /// Regression for the divergence where the default `rivet validate`
+    /// (salsa) silently passed a status-gate violation that
+    /// `rivet validate --direct` / `rivet check gaps-json` correctly failed.
+    // rivet: verifies REQ-029
+    #[test]
+    fn validation_rules_evaluated_in_validate_all() {
+        let db = RivetDatabase::new();
+        let schema = r#"
+schema:
+  name: test-vrule
+  version: "0.1.0"
+artifact-types:
+  - name: requirement
+    description: A requirement
+    fields: []
+    link-fields: []
+  - name: verification
+    description: A verification
+    fields: []
+    link-fields:
+      - name: verifies
+        link-type: verifies
+        target-types: [requirement]
+        required: false
+        cardinality: zero-or-many
+link-types:
+  - name: verifies
+    description: Verification verifies a requirement
+    inverse: verified-by
+    source-types: [verification]
+    target-types: [requirement]
+validation-rules:
+  - id: verification-needs-approved-req
+    description: An approved verification must verify only approved requirements.
+    rule: |
+      (implies
+        (and (= type "verification") (= status "approved"))
+        (forall-linked "verifies" (= status "approved")))
+    severity: error
+    message: "{id} is approved but verifies a requirement that is not approved."
+"#;
+        // VER-1 is approved but verifies a draft requirement → gate violated.
+        let source = r#"
+artifacts:
+  - id: REQ-1
+    type: requirement
+    title: A requirement
+    status: draft
+  - id: VER-1
+    type: verification
+    title: Verifies REQ-1
+    status: approved
+    links:
+      - type: verifies
+        target: REQ-1
+"#;
+        let sources = db.load_sources(&[("a.yaml", source)]);
+        let schemas = db.load_schemas(&[("test", schema)]);
+        let diags = db.diagnostics(sources, schemas);
+        let gate: Vec<_> = diags
+            .iter()
+            .filter(|d| d.rule == "verification-needs-approved-req")
+            .collect();
+        assert!(
+            !gate.is_empty(),
+            "salsa validate_all must surface the status-gate validation-rule; got rules: {:?}",
+            diags.iter().map(|d| &d.rule).collect::<Vec<_>>()
         );
     }
 

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -414,7 +414,11 @@ pub fn validate_with_externals_and_variant(
 /// when the rule opts in via `draft-downgrade: true` — the default is to
 /// fire at full severity (status-gate rules typically gate *by* status,
 /// so the rule's `when` clause already filters drafts).
-fn evaluate_validation_rules(store: &Store, schema: &Schema, graph: &LinkGraph) -> Vec<Diagnostic> {
+pub(crate) fn evaluate_validation_rules(
+    store: &Store,
+    schema: &Schema,
+    graph: &LinkGraph,
+) -> Vec<Diagnostic> {
     use crate::sexpr_eval;
 
     let mut out = Vec::new();


### PR DESCRIPTION
Addresses **#355 Finding 3** ("`rivet validate` and `rivet check gaps-json` disagree").

## Root cause (verified)

`rivet validate` runs the incremental **salsa** path (`db::validate_all`), which evaluated structural rules (phases 1-7) and conditional rules (phase 8) — but **never evaluated the status-gate `validation-rules`** (phase 9: the `(implies …)` V-model promotion gates). The **direct** `validate::validate*` path — used by `rivet check gaps-json` and `rivet validate --direct` — *did*. So the default `rivet validate` silently **PASSED** a project with a status-gate violation that `gaps-json` / `--direct` **FAILED**. That's both the reported cross-command disagreement and a **soundness gap** (the default surface under-reports).

## Reproduction (local)

A project on `common` + `aspice` with an approved `sys-verification` that `verifies` a `draft` `system-req` (violates `V-sys-verification-needs-approved-req`):

| command | before |
|---|---|
| `rivet validate` (salsa) | `FAIL (1 error)` — gate **missing** |
| `rivet validate --direct` | `FAIL (2 errors)` — gate present |

After the fix both report **2 errors** including the gate.

## Fix

`db::validate_all` and `db::validate_all_with_extras` now call `validate::evaluate_validation_rules` against the same materialized store/schema/graph they already build, so structural + conditional + status-gate rules are all evaluated on every surface.

## Verification
- rivet's own corpus: `rivet validate` and `--direct` both PASS, unchanged.
- New regression test `db::tests::validation_rules_evaluated_in_validate_all` (salsa path surfaces the gate).
- rivet-core `db` (24) + `validation_rule` (3) tests pass; clippy `--all-targets` + fmt clean; `rivet validate` + `rivet docs check` PASS.

Note: this is the *engine-parity* half of #355. Findings 1-2 (no canonical status enum; the gate hardcoding literal `approved` with no ordered lifecycle) remain a maintainer design decision and are untouched here.

Fixes: REQ-146

🤖 Generated with [Claude Code](https://claude.com/claude-code)