### PR TITLE
fix(validate): coverage diagnostics name the link + satisfier types (REQ-147, #350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,15 @@
 
 ### Fixed
 
+- **REQ-147 / #350 — coverage diagnostics now say HOW to satisfy a missing
+  backlink.** A `required-backlink` coverage miss used to print only the rule
+  description ("… should be verified …"), leaving the author to
+  reverse-engineer which link type and source types satisfy it. The diagnostic
+  now appends "— needs an incoming `<link>` link from one of [<types>]", and
+  the `Lifecycle coverage gaps` summary points at `rivet validate --explain
+  <ID>` for the full per-rule breakdown (incoming link + source types +
+  alternates). Schema-agnostic; no rule semantics changed.
+
 - **REQ-146 / #355 — default `rivet validate` now evaluates status-gate
   validation-rules (parity with `--direct` / `gaps-json`).** The incremental
   salsa path (`db::validate_all`) ran structural (phases 1-7) and conditional

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4089,3 +4089,87 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-029
+
+  - id: REQ-147
+    type: requirement
+    title: "Coverage diagnostics say HOW to satisfy a missing backlink, not just what's missing"
+    status: implemented
+    description: |
+      User-reported via #350. Marking a sw-req `implemented` then running
+      `rivet validate` produced "should be verified..." / "missing:
+      <types>" diagnostics that named WHAT was missing but not HOW to satisfy
+      it — which link type connects the artifacts, and that the listed types
+      attach via a specific incoming link. The reporter reverse-engineered the
+      required shape from an unrelated link-target rejection ("a whole
+      detour").
+
+      Two complementary, schema-agnostic improvements:
+        1. The `required-backlink` coverage diagnostic now appends the
+           incoming link type and the allowed source types, e.g. "… — needs an
+           incoming `verifies` link from one of [sw-verification,
+           unit-verification, sw-integration-verification]".
+        2. The `Lifecycle coverage gaps` summary now points at
+           `rivet validate --explain <ID>`, which lists each rule's
+           satisfied/MISSING state with the exact incoming link + source types
+           (and any alternates).
+
+      Acceptance:
+        - On a sw-req with no verification backlink, `rivet validate` output
+          for the coverage rule contains "needs an incoming `verifies` link
+          from one of [...]".
+        - When lifecycle gaps are present, the validate output prints a
+          "run `rivet validate --explain <ID>`" pointer.
+        - `cargo test -p rivet-core --lib validate::tests` passes.
+    tags: [dx, agent-ux, diagnostics, guidance, traceability, user-reported, issue-350]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-125
+
+  - id: REQ-148
+    type: requirement
+    title: "Schema-consistency check: flag a required-backlink rule whose from-types cannot form the link"
+    status: draft
+    description: |
+      Surfaced verifying #350 against the aspice schema. The coverage rule
+      `swe1-has-verification` declares `source-type: sw-req`,
+      `required-backlink: verifies`, `from-types: [sw-verification,
+      unit-verification, sw-integration-verification]` — but the link-target
+      rules only permit `sw-verification` to `verifies` a `sw-req`
+      (unit-verification verifies sw-detail-design; sw-integration-verification
+      verifies sw-arch-component/sw-detail-design). So two of the three
+      advertised satisfiers can never actually form the backlink, which is
+      exactly why the reporter authored a forbidden unit-verification→sw-req
+      link and got rejected.
+
+      Add a schema-consistency meta-check (sibling of
+      `conditional-rule-consistency`) that flags a `required-backlink` rule
+      whose `from-types` include an artifact type that no link-type / rule
+      permits to form `<required_backlink>` to the rule's `source-type`. This
+      catches the "advertises an unsatisfiable satisfier" class in ANY schema.
+      Care needed: target constraints live in both link-type defs and per-type
+      link-fields, and the inverse-name convention applies — implement
+      conservatively to avoid false positives (prefer false-negatives).
+
+      Note: whether the aspice `from-types` is itself wrong (ASPICE intent:
+      SWE.6 sw-verification verifies sw-reqs; unit/integration verify design
+      layers) is a maintainer/compliance-semantics call, tracked on #350/#355,
+      separate from this generic check.
+
+      Acceptance:
+        - A schema with a `required-backlink` rule listing a from-type that
+          cannot form the link emits a `coverage-rule-consistency` diagnostic
+          naming the rule, the unsatisfiable from-type, and the link.
+        - A schema whose from-types are all linkable emits no such diagnostic.
+        - Unit test covers both cases.
+    tags: [validation, schema-consistency, meta-check, dx, issue-350, issue-355]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-004

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -5369,6 +5369,17 @@ fn cmd_validate(
                     gap.missing.join(", "),
                 );
             }
+            // The bare "missing: <types>" list says what, not how — which link
+            // type connects them, and that some listed types may only attach
+            // further down the chain (issue #350). Point at the per-artifact
+            // explainer, which names the exact incoming link + allowed source
+            // types (and any alternates) for each gap.
+            if let Some(first) = lifecycle_gaps.first() {
+                println!(
+                    "  → run `rivet validate --explain {}` to see which link type and source types satisfy a gap",
+                    first.artifact_id
+                );
+            }
         }
 
         if with_externals_validate && !cross_repo_diagnostics.is_empty() {

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -961,6 +961,23 @@ pub fn validate_structural_with_externals_and_variant(
                     .iter()
                     .any(|alt| matches(&alt.link_type, &alt.from_types));
                 if !primary && !alternate {
+                    // Tell the author HOW to satisfy this, not just that it's
+                    // unsatisfied (issue #350). Name the incoming link type and
+                    // the artifact types that may form it, so they don't have
+                    // to reverse-engineer the required shape from a link-target
+                    // rejection. `rivet validate --explain <ID>` shows the full
+                    // breakdown including any alternate backlinks.
+                    let mut message = rule.description.clone();
+                    if !rule.from_types.is_empty() {
+                        message.push_str(&format!(
+                            " — needs an incoming `{}` link from one of [{}]",
+                            required_backlink,
+                            rule.from_types.join(", ")
+                        ));
+                    } else {
+                        message
+                            .push_str(&format!(" — needs an incoming `{required_backlink}` link"));
+                    }
                     diagnostics.push(Diagnostic {
                         source_file: None,
                         line: None,
@@ -968,7 +985,7 @@ pub fn validate_structural_with_externals_and_variant(
                         severity: effective_severity,
                         artifact_id: Some(id.clone()),
                         rule: rule.name.clone(),
-                        message: rule.description.clone(),
+                        message,
                     });
                 }
             }


### PR DESCRIPTION
Addresses **#350** (the actionable, schema-agnostic half).

## Problem

Marking a `sw-req` `implemented` then running `rivet validate` produced coverage diagnostics that said *what* was missing but not *how* to satisfy it. The reporter authored a verification linking directly to the sw-req, got a link-target rejection, and only then reverse-engineered the required shape — "a whole detour."

## Fix (no rule semantics changed)

1. The `required-backlink` coverage diagnostic now names the incoming link type + allowed source types inline:
   > Every SW requirement should be verified … **— needs an incoming `verifies` link from one of [sw-verification, unit-verification, sw-integration-verification]**
2. The `Lifecycle coverage gaps` summary now points at `rivet validate --explain <ID>`, which lists each rule's satisfied/MISSING state with the exact incoming link + source types (and alternates). Verified the pointer resolves to that breakdown.

## Verification
- New aspice repro: a `sw-req` with no verification backlink now shows the link + types inline; the gaps summary prints the `--explain` pointer; `--explain` gives the per-rule breakdown.
- All 74 `validate::tests` pass; clippy `--all-targets` + fmt clean; `rivet validate` + `rivet docs check` PASS.

## Triage of #350's other points
- **Suggestion 2** (allow direct test→sw-req, or a `scaffold-verification` command) is ASPICE/schema *intent* — maintainer call.
- **Suggestion 4** (`crate:` undeclared-field noise) is already mitigated by `rivet validate --min-severity warning` (REQ-137) + schema `extends`.
- **Filed REQ-148 (draft):** a generic `coverage-rule-consistency` meta-check — the aspice `swe1-has-verification` rule advertises `from-types` (`unit-verification`, `sw-integration-verification`) that no link rule permits to `verifies`→`sw-req`, which is *why* the reporter's direct link was rejected. Deferred: needs conservative implementation (target constraints live in both link-types and per-type link-fields) to avoid false positives, and whether the aspice from-types is itself wrong is a compliance-semantics call.

Implements: REQ-147

🤖 Generated with [Claude Code](https://claude.com/claude-code)