### PR TITLE
docs(schemas): recipe for extending a built-in artifact type with project fields (REQ-149, #350)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4173,3 +4173,42 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-004
+
+  - id: REQ-149
+    type: requirement
+    title: "Document the recipe for extending a built-in artifact type with project fields"
+    status: implemented
+    description: |
+      User-reported via #350 (suggestion 4): a project's artifacts carried a
+      `crate:` field the built-in ASPICE `sw-req` doesn't declare, producing
+      37+ `INFO: field 'crate' is not defined in schema` advisories that
+      drowned the actionable diagnostics. The reporter asked for "an easy
+      per-project field extension... without forking the schema."
+
+      Verified the mechanism already exists: `Schema::merge` /
+      `ArtifactTypeDef::merge_in_place` union `fields` by name across schemas
+      sharing a type name, so a project-local schema re-declaring the built-in
+      type with only the extra field — registered AFTER the built-in in
+      `rivet.yaml` `project.schemas` — adds the field without forking.
+      Confirmed empirically: with such an extension the `crate` INFO
+      disappears; without it the INFO is present. It was simply undocumented.
+
+      Documented in docs/schemas.md ("Extending a built-in artifact type with
+      project fields"), with the copy-pasteable recipe and the
+      `--min-severity warning` alternative; also corrected the
+      "Schema merging behavior" note (artifact types merge fields by name,
+      they don't replace wholesale).
+
+      Acceptance:
+        - docs/schemas.md contains the "Extending a built-in artifact type"
+          recipe (project-local schema re-declaring the type + registering it
+          after the built-in).
+        - `rivet docs check` PASS.
+    tags: [docs, dx, schema, user-reported, issue-350]
+    fields:
+      priority: should
+      category: documentation
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-010

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -675,11 +675,54 @@ Place `my-domain.yaml` in the `schemas/` directory alongside `common.yaml`.
 
 When multiple schemas are loaded, Rivet merges them:
 
-- **Artifact types** are unioned. If two schemas define the same type name, the later
-  schema's definition takes precedence.
+- **Artifact types** are unioned **by name**. When two schemas define the same
+  type name, their `fields` and `link-fields` are merged by field name (later
+  wins on a name conflict) — so a later schema *adds* fields to an existing
+  type rather than replacing it wholesale.
 - **Link types** are unioned by name. Duplicates are deduplicated.
 - **Traceability rules** are concatenated. All rules from all schemas apply.
 - **Base fields** are defined by `common` and always present.
 
 This allows composition: load `common` + `aspice` + `cybersecurity` to get V-model
 traceability and SEC process coverage in a single project.
+
+### Extending a built-in artifact type with project fields
+
+Because same-named artifact types **merge their fields**, you can add
+project-specific fields to a built-in type without forking its schema. This is
+the supported fix for the `INFO: field '<x>' is not defined in schema for type
+'<t>'` advisories you get when your artifacts carry a field the built-in schema
+doesn't declare (e.g. a `crate:` field on an ASPICE `sw-req`).
+
+1. Add a small project-local schema file (e.g. `project-ext.yaml`) under your
+   project's `schemas/` directory that re-declares the built-in type name with
+   only the extra field(s):
+
+   ```yaml
+   # project-ext.yaml  (place it in your project's schemas/ directory)
+   schema:
+     name: project-ext
+     version: "0.1.0"
+   artifact-types:
+     - name: sw-req            # same name as the built-in ASPICE type
+       description: "Project extension: add the crate field to sw-req"
+       fields:
+         - name: crate
+           type: string
+           required: false
+   ```
+
+2. Register it **after** the built-in schema in `rivet.yaml` so the field
+   unions onto the built-in type:
+
+   ```yaml
+   project:
+     schemas: [common, aspice, project-ext]
+   ```
+
+`rivet validate` then accepts `crate:` on a `sw-req` with no `field not defined`
+diagnostic, and you keep every built-in field, link, and rule. You only declare
+the delta — the built-in type definition is untouched.
+
+(Alternatively, `rivet validate --min-severity warning` hides the INFO-level
+`field not defined` advisories without changing the schema.)


### PR DESCRIPTION
Closes the documentation half of **#350 suggestion 4**.

## Context

A project's artifacts carried a `crate:` field the built-in ASPICE `sw-req` doesn't declare → dozens of `INFO: field 'crate' is not defined in schema` advisories drowning the actionable diagnostics. The reporter asked for "an easy per-project field extension... without forking the schema."

## Finding (verified, no code change needed)

The mechanism already exists: `Schema::merge` / `ArtifactTypeDef::merge_in_place` **union `fields` by name** across schemas that share a type name. So a project-local schema re-declaring the built-in type with only the extra field — registered *after* the built-in in `rivet.yaml` `project.schemas` — adds the field without forking.

Confirmed empirically:
- **without** the extension: `INFO: field 'crate' is not defined in schema for type 'sw-req'`
- **with** a `project-ext` schema declaring `sw-req { fields: [crate] }` in the schemas list: the INFO is gone; all built-in fields/links/rules preserved.

It was simply undocumented.

## Change (docs-only)
- Added "Extending a built-in artifact type with project fields" to `docs/schemas.md` — the copy-pasteable recipe + the `rivet validate --min-severity warning` alternative.
- Corrected the "Schema merging behavior" note: same-named artifact types **merge their fields by name** (they don't replace wholesale) — which is what makes the recipe work.

`rivet docs check` PASS; `rivet validate` PASS.

Implements: REQ-149

🤖 Generated with [Claude Code](https://claude.com/claude-code)