### PR TITLE
chore(artifacts): dogfood REQ audit — flip REQ-134, reconcile REQ-149 duplicate, file REQ-150

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3542,7 +3542,7 @@ artifacts:
   - id: REQ-134
     type: requirement
     title: "Per-project field extension for built-in schema types (without forking the schema)"
-    status: draft
+    status: implemented
     description: |
       User-reported via GitHub issue #350. A project's `sw-req` artifacts
       carry a `crate:` field the built-in aspice `sw-req` schema does not
@@ -3557,6 +3557,17 @@ artifacts:
       invent a directive): a project schema declares additional fields on
       a built-in type, and validate treats them as known. This both
       silences the noise and keeps the field schema-validated.
+
+      RESOLUTION: the mechanism already exists — `Schema::merge` /
+      `ArtifactTypeDef::merge_in_place` union `fields` by name across
+      schemas that share a type name, so a project-local schema
+      re-declaring the built-in type with the extra field (registered
+      after the built-in in `project.schemas`) adds it without forking.
+      Verified empirically (the `crate` INFO disappears with the
+      extension, is present without it) and documented in
+      docs/schemas.md via REQ-149 / PR #395 — which was an accidental
+      duplicate of this REQ (filed before noticing REQ-134; see the
+      duplicate-on-add friction filed this iteration).
 
       Acceptance:
         - A project can declare extra fields on a built-in artifact type
@@ -4204,7 +4215,7 @@ artifacts:
           recipe (project-local schema re-declaring the type + registering it
           after the built-in).
         - `rivet docs check` PASS.
-    tags: [docs, dx, schema, user-reported, issue-350]
+    tags: [docs, dx, schema, user-reported, issue-350, duplicate-of-req-134]
     fields:
       priority: should
       category: documentation
@@ -4212,3 +4223,47 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-010
+      - type: traces-to
+        target: REQ-134
+
+  - id: REQ-150
+    type: requirement
+    title: "rivet add should warn when a new artifact closely duplicates an existing one"
+    status: draft
+    description: |
+      Self-found while dogfooding (this loop). `mutate::validate_add`
+      rejects a duplicate `id` but does nothing about a duplicate
+      *intent*: an author can file a requirement whose title/description
+      restates an existing one and rivet accepts it silently. I did
+      exactly this — REQ-149 ("Document the recipe for extending a
+      built-in artifact type…") duplicated the pre-existing REQ-134
+      ("Per-project field extension for built-in schema types…"); only an
+      `rivet list` audit a day later surfaced it. For an agent-driven
+      workflow (the explicit use case — agents file findings as
+      artifacts) this is a recurring trap: the backlog silently accretes
+      near-duplicates.
+
+      Add a discovery aid at add time (and/or a `validate` advisory): when
+      a new artifact's title/keywords strongly overlap an existing
+      artifact of the same type, surface it — "similar to REQ-134: '…'
+      — file anyway?" / an INFO diagnostic listing near-duplicate pairs.
+      Design questions to settle: the similarity signal (shared title
+      tokens vs an edit-distance threshold — must avoid noise on
+      legitimately-distinct short titles), advisory vs blocking, and
+      whether it runs in `add`, `validate`, or both. Conservative default:
+      non-blocking advisory; never reject.
+
+      Acceptance:
+        - Filing an artifact whose title shares a high fraction of
+          significant tokens with an existing same-type artifact prints a
+          "similar to <ID>" advisory (non-blocking).
+        - Distinct artifacts (low token overlap) produce no advisory.
+        - A unit test covers the duplicate-detected and distinct cases.
+    tags: [dx, agent-ux, mutate, duplicate-detection, dogfooding, self-found]
+    fields:
+      priority: could
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-007


### PR DESCRIPTION
A hands-on dogfooding pass: used `rivet list --type requirement` + `rivet validate --explain` to audit the REQs filed over recent iterations and reconcile their statuses. Each finding verified against merged code.

## Marked implemented
- **REQ-134** (per-project field extension for built-in types) → `implemented`. Both acceptance criteria are met: the schema-merge field-union mechanism works (verified empirically last iteration) and it's documented in `docs/schemas.md` (#395).

## Duplicate reconciled
- **REQ-149** (the docs recipe I filed last iteration) was an accidental **duplicate** of the pre-existing **REQ-134**. Linked `REQ-149 → REQ-134` (traces-to) + tagged it so it reads as the docs delivery of REQ-134, not a stray parallel requirement.

## Left correctly draft (verified *not* fully met)
- **REQ-128** — `--orphans` filter shipped (#373), but the inbound-link-count **ranking report** half is still outstanding.
- **REQ-132** — REQ-147 did the *single-hop* link naming; the *multi-hop chain* naming this asks for is not done.
- **REQ-135** — the validate/modify status-enum enforcement is built (#370/#371) but **inert** until the maintainer declares `allowed-values` + reconciles artifacts (policy, #355).

## New friction found + filed
- **REQ-150** (draft): `rivet add` only rejects a duplicate *id*, not a duplicate *intent* — which is how I filed REQ-149 over REQ-134 without noticing. For the agent-driven workflow (agents filing findings as artifacts) this silently accretes near-duplicates. Proposed a non-blocking "similar to `<ID>`" advisory. Also filed as a GitHub issue.

`rivet validate` PASS.

Implements: REQ-134

🤖 Generated with [Claude Code](https://claude.com/claude-code)