### PR TITLE
feat(list): --rank-by-backlinks — rank artifacts by inbound-link count (REQ-128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ### Added
 
+- **REQ-128 — `rivet list --rank-by-backlinks`.** Orders the listing by
+  inbound-link count (descending) — the most depended-upon artifacts first,
+  i.e. the highest-impact-if-changed nodes — and surfaces the count (an
+  inbound-count column in text, an `inbound_links` field in JSON). The
+  complement of `--orphans`: where `--orphans` finds asserted-but-unanchored
+  claims, this finds the load-bearing hubs. Built on `LinkGraph::backlinks_to`;
+  exact integer counts, deterministic (ties break by id). Completes REQ-128.
+
 - **REQ-138 / #378 — Zola export build smoke check (`scripts/zola-export-smoke.sh`).**
   Exports the corpus into a scaffolded Zola site whose `base_url` is a
   sub-directory deploy, runs a real `zola build`, and fails on a build error

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -3344,7 +3344,7 @@ artifacts:
   - id: REQ-128
     type: requirement
     title: "rivet list --orphans: mechanical detection of asserted-but-unanchored claims"
-    status: draft
+    status: implemented
     description: |
       Sourced from garrytan/gbrain's `src/core/search/graph-signals.ts`
       (inbound-link / cross-source signals), taking ONLY the deterministic

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -447,6 +447,14 @@ enum Command {
         /// asserted-but-unanchored claim). Combine with `--type` to scope.
         #[arg(long)]
         orphans: bool,
+
+        /// Rank by inbound-link count (descending) — the most
+        /// depended-upon artifacts first, i.e. the highest-impact-if-changed
+        /// nodes. The complement of `--orphans`. Adds an inbound-count column
+        /// (text) / `inbound_links` field (JSON). Deterministic; ties break
+        /// by id.
+        #[arg(long)]
+        rank_by_backlinks: bool,
     },
 
     /// Show artifact summary statistics
@@ -1977,6 +1985,7 @@ fn run(cli: Cli) -> Result<bool> {
             baseline,
             variant,
             orphans,
+            rank_by_backlinks,
         } => cmd_list(
             &cli,
             r#type.as_deref(),
@@ -1986,6 +1995,7 @@ fn run(cli: Cli) -> Result<bool> {
             baseline.as_deref(),
             variant.as_deref(),
             *orphans,
+            *rank_by_backlinks,
         ),
         Command::Get { id, format } => cmd_get(&cli, id, format),
         Command::Bundle { id, depth, format } => cmd_bundle(&cli, id, *depth, format),
@@ -5974,6 +5984,7 @@ fn cmd_list(
     baseline_name: Option<&str>,
     variant_arg: Option<&str>,
     orphans_only: bool,
+    rank_by_backlinks: bool,
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let ctx = ProjectContext::load(cli)?;
@@ -6014,6 +6025,26 @@ fn cmd_list(
         results.retain(|a| orphan_ids.contains(a.id.as_str()));
     }
 
+    // REQ-128: `--rank-by-backlinks` orders the listing by inbound-link count
+    // (descending) — the most depended-upon artifacts first — and surfaces the
+    // count. Built on `LinkGraph::backlinks_to`; deterministic (ties break by
+    // id). The complement of `--orphans`.
+    let inbound_counts: std::collections::HashMap<String, usize> = if rank_by_backlinks {
+        let graph = rivet_core::links::LinkGraph::build(&store, &ctx.schema);
+        let counts: std::collections::HashMap<String, usize> = results
+            .iter()
+            .map(|a| (a.id.clone(), graph.backlinks_to(&a.id).len()))
+            .collect();
+        results.sort_by(|a, b| {
+            let ca = counts.get(&a.id).copied().unwrap_or(0);
+            let cb = counts.get(&b.id).copied().unwrap_or(0);
+            cb.cmp(&ca).then_with(|| a.id.cmp(&b.id))
+        });
+        counts
+    } else {
+        std::collections::HashMap::new()
+    };
+
     if format == "json" {
         let artifacts_json: Vec<serde_json::Value> = results
             .iter()
@@ -6031,6 +6062,12 @@ fn cmd_list(
                         "target": l.target,
                     })).collect::<Vec<_>>(),
                 });
+                if rank_by_backlinks {
+                    if let serde_json::Value::Object(ref mut map) = entry {
+                        let n = inbound_counts.get(&a.id).copied().unwrap_or(0);
+                        map.insert("inbound_links".into(), serde_json::json!(n));
+                    }
+                }
                 if let Some(ref name) = variant_name {
                     // Emit the merged fields view so downstream tooling
                     // can see the variant-resolved values without a
@@ -6064,10 +6101,18 @@ fn cmd_list(
         for artifact in &results {
             let status = artifact.status.as_deref().unwrap_or("-");
             let links = artifact.links.len();
-            println!(
-                "  {:20} {:25} {:12} {:3} links  {}",
-                artifact.id, artifact.artifact_type, status, links, artifact.title
-            );
+            if rank_by_backlinks {
+                let inbound = inbound_counts.get(&artifact.id).copied().unwrap_or(0);
+                println!(
+                    "  {:4} in  {:20} {:25} {:12} {:3} out  {}",
+                    inbound, artifact.id, artifact.artifact_type, status, links, artifact.title
+                );
+            } else {
+                println!(
+                    "  {:20} {:25} {:12} {:3} links  {}",
+                    artifact.id, artifact.artifact_type, status, links, artifact.title
+                );
+            }
         }
         println!("\n{} artifacts", results.len());
     }

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1783,6 +1783,53 @@ fn list_orphans_is_subset() {
     );
 }
 
+/// REQ-128: `rivet list --rank-by-backlinks` orders by inbound-link count
+/// (descending) and emits an `inbound_links` field on each artifact.
+#[test]
+fn list_rank_by_backlinks_orders_descending() {
+    let root = project_root();
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            root.to_str().unwrap(),
+            "list",
+            "--rank-by-backlinks",
+            "--type",
+            "requirement",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("rivet list --rank-by-backlinks failed");
+    assert!(out.status.success(), "list must exit 0");
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("valid JSON");
+    let arts = v["artifacts"].as_array().expect("artifacts array");
+    assert!(arts.len() > 1, "need several requirements to rank");
+
+    // Every entry carries the inbound count, and the sequence is
+    // non-increasing (most depended-upon first).
+    let mut prev: Option<u64> = None;
+    for a in arts {
+        let n = a["inbound_links"]
+            .as_u64()
+            .expect("each artifact must carry inbound_links under --rank-by-backlinks");
+        if let Some(p) = prev {
+            assert!(
+                n <= p,
+                "ranking must be descending by inbound count: saw {n} after {p}"
+            );
+        }
+        prev = Some(n);
+    }
+    // The most depended-upon requirement should have a non-trivial fan-in
+    // on the dogfood corpus (sanity that counts are real, not all zero).
+    assert!(
+        arts[0]["inbound_links"].as_u64().unwrap() > 0,
+        "top-ranked artifact must have inbound links"
+    );
+}
+
 /// `rivet get REQ-001 --format yaml` produces YAML output.
 #[test]
 fn get_yaml_produces_valid_output() {


### PR DESCRIPTION
Completes **REQ-128**. `--orphans` (already shipped) finds artifacts with no links — asserted-but-unanchored claims. This adds the complement: rank by **inbound-link count** (descending) to surface the most **depended-upon** artifacts, i.e. the highest-impact-if-changed hubs.

```
$ rivet list --rank-by-backlinks --type requirement
    58 in  REQ-004   requirement   approved   23 out  Validation engine
    40 in  REQ-014   requirement   approved    0 out  ASPICE SWE.4/5/6 test structure
    38 in  REQ-007   requirement   approved   16 out  CLI and serve pattern
    …
```

- **Text:** inbound-count column. **JSON:** an `inbound_links` field per artifact.
- Built on `LinkGraph::backlinks_to`; **exact integer counts only** (no semantic/relevance ranking, per REQ-128 acceptance); deterministic, ties break by id. Composes with `--type` / `--filter`.

## Verification
- Integration test `list_rank_by_backlinks_orders_descending`: ordering is non-increasing and every entry carries `inbound_links`.
- `list_orphans_is_subset` still passes; clippy `--all-targets` + fmt clean; `rivet validate` PASS (190), `rivet docs check` PASS.

REQ-128 flipped to `implemented` (both halves now delivered).

Implements: REQ-128

🤖 Generated with [Claude Code](https://claude.com/claude-code)