### PR TITLE
feat(cli): global -q/--quiet flag to suppress the WARN log preamble (REQ-151, #353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ### Added
 
+- **REQ-151 / #353 — global `-q`/`--quiet` flag.** Suppresses the WARN-level
+  log preamble (e.g. "could not load externals: …") that otherwise prefixes a
+  command's output, emitting only ERROR-level logs. A command's own stdout and
+  hard-error reporting are untouched, so it pairs with `--format json` for
+  clean machine-consumable output. Complements `-v/--verbose` (mutually
+  exclusive). Closes the `--quiet` half of #353's agent-ergonomics asks.
+
 - **REQ-128 — `rivet list --rank-by-backlinks`.** Orders the listing by
   inbound-link count (descending) — the most depended-upon artifacts first,
   i.e. the highest-impact-if-changed nodes — and surfaces the count (an

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4267,3 +4267,36 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-151
+    type: requirement
+    title: "Global --quiet flag: suppress the WARN log preamble for scripted/agent use"
+    status: implemented
+    description: |
+      User-reported via #353 (feature ask): every rivet invocation can emit
+      WARN-level log lines before a command's real output (e.g. "could not
+      load externals: …", and previously per-file skip notices), which is
+      noise for scripted/agent consumption — especially combined with
+      `--format json`. There was a `-v/--verbose` flag to raise the log
+      level but no way to lower it below the default `warn`.
+
+      Add a global `-q/--quiet` flag (mutually exclusive with `--verbose`)
+      that sets the log filter to `error`, suppressing the WARN preamble
+      while leaving a command's own stdout and hard-error reporting intact.
+      Pairs with `--format json` for clean machine-consumable output.
+
+      Acceptance:
+        - `rivet --quiet <cmd>` emits no `WARN`-level log lines on stderr for
+          a project that otherwise would (e.g. a misconfigured external),
+          while the command's stdout is unchanged.
+        - Hard errors (e.g. an unparseable rivet.yaml) are still reported
+          under `--quiet`.
+        - `cargo test -p rivet-cli --test cli_commands quiet_suppresses` passes.
+    tags: [cli, dx, agent-ux, logging, quiet, user-reported, issue-353]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -205,6 +205,13 @@ struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
 
+    /// Quiet: suppress the WARN-level log preamble (e.g. the externals
+    /// "could not load" / skipped-file notices), emitting only ERROR-level
+    /// logs. Leaves a command's own stdout untouched, so it pairs with
+    /// `--format json` for clean machine-consumable output (#353).
+    #[arg(short = 'q', long, conflicts_with = "verbose")]
+    quiet: bool,
+
     /// Restrict rivet to the qualified-for-safety-use feature set
     /// (TCL design A5).
     ///
@@ -1811,10 +1818,16 @@ enum CheckAction {
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let log_level = match cli.verbose {
-        0 => "warn",
-        1 => "info",
-        _ => "debug",
+    let log_level = if cli.quiet {
+        // Below the default `warn` — only hard errors. Suppresses the
+        // WARN preamble that noises up agent/scripted use (#353).
+        "error"
+    } else {
+        match cli.verbose {
+            0 => "warn",
+            1 => "info",
+            _ => "debug",
+        }
     };
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level))
         .format_timestamp(None)
@@ -8960,6 +8973,7 @@ fn cmd_diff(
                 project: bp.to_path_buf(),
                 schemas: cli.schemas.clone(),
                 verbose: cli.verbose,
+                quiet: cli.quiet,
                 qualification_mode: cli.qualification_mode,
                 command: Command::Validate {
                     format: "text".to_string(),
@@ -8985,6 +8999,7 @@ fn cmd_diff(
                 project: hp.to_path_buf(),
                 schemas: cli.schemas.clone(),
                 verbose: cli.verbose,
+                quiet: cli.quiet,
                 qualification_mode: cli.qualification_mode,
                 command: Command::Validate {
                     format: "text".to_string(),

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5170,3 +5170,59 @@ fn supplier_pull_unknown_anchor_errors() {
         "error must name the missing anchor, got: {stderr}"
     );
 }
+
+/// #353: `--quiet` suppresses the WARN-level log preamble (e.g. the externals
+/// "could not load" notice) while leaving the command's stdout and
+/// hard-error reporting intact.
+#[test]
+fn quiet_suppresses_warn_preamble() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("artifacts")).unwrap();
+    // A bad external path triggers a deterministic WARN ("could not load
+    // externals: …") at default log level.
+    std::fs::write(
+        root.join("rivet.yaml"),
+        "project:\n  name: t\n  version: \"0.1.0\"\n  schemas:\n    - common\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n\
+         externals:\n  missing:\n    path: /nonexistent/path/xyz\n    prefix: missing\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("artifacts").join("reqs.yaml"),
+        "artifacts:\n  - id: REQ-1\n    type: requirement\n    title: A\n    status: draft\n",
+    )
+    .unwrap();
+
+    let run = |quiet: bool| {
+        let mut args = vec!["--project", root.to_str().unwrap()];
+        if quiet {
+            args.push("--quiet");
+        }
+        args.push("list");
+        Command::new(rivet_bin())
+            .args(&args)
+            .output()
+            .expect("rivet list")
+    };
+
+    let default = run(false);
+    let quiet = run(true);
+    assert!(default.status.success() && quiet.status.success());
+
+    let default_err = String::from_utf8_lossy(&default.stderr);
+    let quiet_err = String::from_utf8_lossy(&quiet.stderr);
+    assert!(
+        default_err.contains("WARN"),
+        "default run should emit the WARN preamble; got: {default_err}"
+    );
+    assert!(
+        !quiet_err.contains("WARN"),
+        "--quiet must suppress WARN-level logs; got: {quiet_err}"
+    );
+    // stdout is unaffected — the artifact still lists.
+    assert!(
+        String::from_utf8_lossy(&quiet.stdout).contains("REQ-1"),
+        "--quiet must not alter stdout"
+    );
+}


### PR DESCRIPTION
Closes the `--quiet` half of **#353**'s agent-ergonomics asks.

## Problem
Every rivet invocation can emit WARN-level log lines before a command's real output (e.g. `[WARN rivet] could not load externals: …`), which is noise for scripted/agent consumption — especially with `--format json`. There was `-v/--verbose` to *raise* the log level but no way to *lower* it below the default `warn`.

## Change
A global `-q/--quiet` (mutually exclusive with `--verbose`) sets the log filter to `error`: the WARN preamble is suppressed, while the command's own stdout and **hard-error reporting stay intact**. Pairs with `--format json`.

```
$ rivet list                 # [WARN rivet] could not load externals: …  ⏎  REQ-1 …
$ rivet --quiet list         # (no stderr)                                ⏎  REQ-1 …
$ rivet -q list --format json   # clean JSON, no preamble
```

## Verification
- New `cli_commands::quiet_suppresses_warn_preamble`: on a project with a misconfigured external, default stderr contains `WARN`, `--quiet` stderr does not, and stdout still lists the artifact. (Hard errors verified still shown under `--quiet`.)
- clippy `--all-targets` + fmt clean; `rivet validate` PASS (191), `rivet docs check` PASS.

## Also (triage, verified — no code needed)
**#353 part 3** ("tight `modify` loop silently no-op'd"; "is modify's exit code reliable / can rapid successive modifys race?") does **not reproduce** on current `main`: 90/90 rapid sequential `rivet modify` calls (3 trials × 30) all exited 0 and persisted; `validate` PASS. Likely resolved by intervening modify rework, or was environment-specific to the reporter's 0.13.3 — and it's superseded by `modify --where` (#380) regardless. Commenting this on #353.

Implements: REQ-151

🤖 Generated with [Claude Code](https://claude.com/claude-code)