### PR TITLE
release(v0.15.0): sub-directory-safe exports + agent-ergonomic CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-02
+
+Self-contained & sub-directory-safe exports, agent-ergonomic CLI, and
+validation-parity fixes. **Headline:** the Zola/HTML export no longer emits
+absolute `/<prefix>/artifacts/…` links that 404 on a sub-directory deploy
+(REQ-115/116/118) — the fix that missed the v0.14.0 cutoff. Plus query-driven
+bulk `modify --where`, `list --rank-by-backlinks`, a global `--quiet`,
+`validate --explain`/`--min-severity`, a salsa status-gate soundness fix, and
+external `prefix:ID` resolution for hyphenated project slugs.
+
 ### Added
 
 - **REQ-151 / #353 — global `-q`/`--quiet` flag.** Suppresses the WARN-level

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts **v0.15.0**, shipping the 35 commits that accumulated since v0.14.0.

## Why now
A user reported that **0.14.0 still emits absolute `/<prefix>/artifacts/…` export links** that 404 on a sub-directory deploy. Verified: the fix (#377, REQ-115/116/118) merged **~17 h after v0.14.0 was tagged**, so it's on `main` but in **no released tag**. This release ships it. Current `main` is verified clean — the export build smoke check builds 1236 pages under a sub-directory `base_url` with **zero absolute-link leaks**.

## Bumps
- `Cargo.toml` workspace `0.14.0 → 0.15.0`
- `vscode-rivet/package.json → 0.15.0`
- `Cargo.lock` regenerated
- CHANGELOG `[Unreleased] → [0.15.0] - 2026-06-02`

## Headline contents
- **Export:** sub-directory-safe Zola/HTML links (REQ-115/116/118), hyphenated external `prefix:ID` resolution (REQ-143), localhost-oEmbed drop (REQ-117), export build smoke check (REQ-138)
- **CLI:** `modify --where` bulk (REQ-141), `list --rank-by-backlinks` (REQ-128), global `--quiet` (REQ-151), `validate --explain` (REQ-125) / `--min-severity` (REQ-137), s-expr error guidance (REQ-142/147)
- **Validation soundness:** salsa now evaluates status-gate rules (REQ-146); source-view whole-token id match (REQ-144); test-results `rivet_tc_id` property (REQ-145); loud-fail ReqIF import (REQ-119/120/123)

## Verification
`rivet validate` PASS; `rivet docs check` PASS (VersionConsistency green — all version files at 0.15.0). Merge gates CI as usual; tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)