### PR TITLE
fix(matrix): hint the correct --direction on an all-empty matrix (REQ-152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **REQ-152 — `rivet matrix` no longer silently renders an all-empty matrix as
+  "no traceability".** The matrix defaults (`--direction backward`, auto-detected
+  link) produced an all-`(none)` result for a forward relationship like
+  `design-decision --satisfies--> requirement` — a dangerous false-negative for
+  a traceability tool. When the matrix is all-empty (sources exist, zero links),
+  it now emits an actionable stderr hint, naming the opposite `--direction` when
+  that would surface links (e.g. "0 via 'satisfies' (backward), but 67 do with
+  `--direction forward`") or pointing at `rivet schema show <from>` / `--link`
+  otherwise. Matrices with links are unchanged. (Inferring direction from the
+  link's source/target so the default just works is a tracked follow-up.)
+
 ## [0.15.0] - 2026-06-02
 
 Self-contained & sub-directory-safe exports, agent-ergonomic CLI, and

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4300,3 +4300,49 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-152
+    type: requirement
+    title: "rivet matrix must not silently render an all-empty matrix as 'no traceability'"
+    status: implemented
+    description: |
+      Self-found while dogfooding. `rivet matrix --from <X> --to <Y>` defaults
+      to `--direction backward` and auto-detects the link type
+      (backward→`verifies`). For a FORWARD relationship like
+      `design-decision --satisfies--> requirement`, the defaults produce an
+      all-`(none)` matrix — falsely reading as "no traceability" — even though
+      every design-decision satisfies a requirement. For a traceability tool,
+      a silent empty matrix that contradicts reality is a dangerous
+      false-negative (loud-fail register).
+
+      Verified: `matrix --from design-decision --to requirement` (defaults)
+      shows every row `(none)`; `--link satisfies --direction forward` shows
+      the real `DD-001 -> REQ-006` … links.
+
+      Fix (additive, no behaviour change to valid matrices): when the matrix
+      is all-empty (sources exist, zero links), emit an actionable hint on
+      stderr. If the opposite direction would surface links, name it
+      precisely ("… 0 via 'satisfies' (backward), but 67 do with
+      `--direction forward` — the relationship runs the other way"); otherwise
+      point at `rivet schema show <from>` / `--link`. A matrix with links
+      emits no hint.
+
+      Acceptance:
+        - `rivet matrix --from design-decision --to requirement --link
+          satisfies` (default backward) prints a stderr hint naming
+          `--direction forward`.
+        - The same with `--direction forward` (which has links) prints no hint.
+        - `cargo test -p rivet-cli --test cli_commands
+          matrix_empty_emits_direction_hint` passes.
+
+      Follow-up (filed separately): inferring the direction from the link
+      type's declared source/target so the default just works, rather than
+      hinting after an empty result.
+    tags: [cli, matrix, traceability, loud-fail, dx, dogfooding, self-found]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -7678,6 +7678,38 @@ fn cmd_matrix(
         );
     }
 
+    // An all-empty matrix (sources exist, none link to any target) is a
+    // dangerous false signal for a traceability tool — it reads as "no
+    // traceability" when usually the link runs the other way or a different
+    // link type connects the pair. Never let it pass silently: emit an
+    // actionable hint (stderr, so text/JSON stdout stays clean). If flipping
+    // the direction would surface links, say so precisely.
+    if result.covered == 0 && result.total > 0 {
+        let opp = match dir {
+            Direction::Forward => Direction::Backward,
+            Direction::Backward => Direction::Forward,
+        };
+        let opp_name = match opp {
+            Direction::Forward => "forward",
+            Direction::Backward => "backward",
+        };
+        let opp_result = matrix::compute_matrix(&store, &graph, from, to, link, opp);
+        if opp_result.covered > 0 {
+            eprintln!(
+                "note: 0 of {} {from} link to any {to} via '{link}' ({direction}), \
+                 but {} do with `--direction {opp_name}`. The relationship runs the \
+                 other way — re-run with `--direction {opp_name}`.",
+                result.total, opp_result.covered,
+            );
+        } else {
+            eprintln!(
+                "note: no '{link}' links between {from} and {to} in either direction. \
+                 Check the link type — `rivet schema show {from}` lists its link \
+                 fields — and pass `--link <type>` (e.g. satisfies, verifies, derives-from).",
+            );
+        }
+    }
+
     Ok(true)
 }
 

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1975,6 +1975,58 @@ fn matrix_json() {
     );
 }
 
+/// An all-empty matrix must not silently read as "no traceability": when the
+/// chosen direction yields zero links but the opposite direction would, the
+/// command emits an actionable `--direction` hint on stderr. A matrix that
+/// does have links emits no such hint.
+#[test]
+fn matrix_empty_emits_direction_hint() {
+    let root = project_root();
+    let run = |args: &[&str]| {
+        let mut a = vec!["--project", root.to_str().unwrap(), "matrix"];
+        a.extend_from_slice(args);
+        Command::new(rivet_bin())
+            .args(&a)
+            .output()
+            .expect("rivet matrix")
+    };
+
+    // design-decision --satisfies--> requirement is a FORWARD link; the
+    // default `--direction backward` therefore yields an empty matrix.
+    let empty = run(&[
+        "--from",
+        "design-decision",
+        "--to",
+        "requirement",
+        "--link",
+        "satisfies",
+    ]);
+    assert!(empty.status.success());
+    let err = String::from_utf8_lossy(&empty.stderr);
+    assert!(
+        err.contains("--direction forward") && err.contains("runs the other way"),
+        "all-empty matrix must hint at the correct direction; stderr: {err}"
+    );
+
+    // The correct direction has links and must NOT emit the hint.
+    let ok = run(&[
+        "--from",
+        "design-decision",
+        "--to",
+        "requirement",
+        "--link",
+        "satisfies",
+        "--direction",
+        "forward",
+    ]);
+    assert!(ok.status.success());
+    let ok_err = String::from_utf8_lossy(&ok.stderr);
+    assert!(
+        !ok_err.contains("runs the other way"),
+        "a matrix with links must not emit the empty-direction hint; stderr: {ok_err}"
+    );
+}
+
 // ── rivet next-id ──────────────────────────────────────────────────────
 
 /// `rivet next-id --type requirement --format json` produces valid JSON.


### PR DESCRIPTION
Self-found while dogfooding `rivet matrix`.

## Bug
`rivet matrix --from <X> --to <Y>` defaults to `--direction backward` and auto-detects the link type. For a **forward** relationship like `design-decision --satisfies--> requirement`, the defaults render an all-`(none)` matrix — a false **"no traceability"** signal, which is dangerous for a traceability tool. Confirmed:
- `matrix --from design-decision --to requirement` (defaults) → every row `(none)`
- `--link satisfies --direction forward` → real links: `DD-001 -> REQ-006`, …

## Fix (additive; no change to non-empty matrices)
When the matrix is all-empty (sources exist, zero links), emit an actionable **stderr** hint:
- If the opposite direction would surface links, name it precisely: `note: 0 of 67 design-decision link to any requirement via 'satisfies' (backward), but 67 do with --direction forward. … runs the other way …`
- Otherwise point at `rivet schema show <from>` / `--link`.

stdout (text **and** JSON) is untouched, so scripts are unaffected.

## Verification
New `matrix_empty_emits_direction_hint` test (hint on empty; silent when links exist); clippy `--all-targets` + fmt clean; `rivet validate` PASS (194), `rivet docs check` PASS.

## Follow-up
The deeper fix — infer the traversal direction from the link type's declared source/target types so `--from X --to Y` just works without `--direction` — is noted on REQ-152 and filed as a separate issue (it's a default-behaviour change worth isolating).

Implements: REQ-152

🤖 Generated with [Claude Code](https://claude.com/claude-code)