### PR TITLE
fix(impact): load --since baseline via the canonical loader (REQ-153, #403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ### Fixed
 
+- **REQ-153 / #403 — `rivet impact --since` no longer massively over-reports.**
+  The baseline was reconstructed with a bespoke per-file parser inconsistent
+  with the live loader, so `impact --since` flagged hundreds of unchanged
+  artifacts as added/changed (503 changed + 354 added on the rivet repo when
+  only ~7 REQs actually changed). The baseline now materialises the git ref's
+  tree (`git archive`) and loads it through the same `load_project_full` /
+  `load_artifacts` path the live store uses, so only genuine changes surface
+  (3 changed + 7 added on that same diff). The bespoke parse helpers were
+  removed. Regression test on a 2-commit fixture.
+
 - **REQ-152 — `rivet matrix` no longer silently renders an all-empty matrix as
   "no traceability".** The matrix defaults (`--direction backward`, auto-detected
   link) produced an all-`(none)` result for a forward relationship like

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4346,3 +4346,51 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-153
+    type: requirement
+    title: "rivet impact --since must load the baseline through the canonical loader (not a bespoke parser)"
+    status: implemented
+    description: |
+      Self-found while dogfooding (GitHub issue #403). `rivet impact --since
+      HEAD~5` on the rivet repo reported 503 changed + 354 added (1207 total)
+      when the only real change was ~7 new REQs in requirements.yaml — the
+      output was misleading to the point of useless.
+
+      Root cause: `load_baseline_from_git` reconstructed the baseline with a
+      bespoke per-file parser (`parse_yaml_content` + `GenericYamlWrapper`)
+      that (a) only handled a couple of source formats and silently skipped
+      the rest (→ spurious "added") and (b) represented artifacts differently
+      from the live `load_artifacts` adapter, so `impact::content_hash`
+      differed for unchanged artifacts (→ every loaded baseline artifact
+      "changed"). A third, inconsistent parse path — the REQ-140 family.
+
+      Fix: materialise the ref's tracked tree via `git archive <ref> | tar`
+      into a temp dir and load it through `rivet_core::load_project_full`
+      (the SAME `load_artifacts`-per-source path the live store uses), then
+      diff. The bespoke `parse_yaml_content` / `git_show_file` /
+      `git_ls_tree_files` helpers + `GenericYamlWrapper` were deleted.
+
+      Verified: `impact --since HEAD~5` now reports 3 changed (the real
+      requirements.yaml edits) + 7 added (3 new REQs + 4 externals) instead
+      of 503/354.
+
+      Acceptance:
+        - On a 2-commit fixture (one artifact edited, one added, one
+          untouched), `rivet impact --since HEAD~1 --format json` reports
+          exactly the edited id under `changed` and the new id under `added`;
+          the untouched artifact appears in neither.
+        - `cargo test -p rivet-cli --test cli_commands
+          impact_since_reports_only_real_changes` passes.
+
+      Residual (separate, smaller): externals are in the live store but not
+      loaded into the baseline by `load_project_full`, so external `prefix:id`
+      artifacts still show as "added". Tracked for follow-up.
+    tags: [bug, impact, parser-consistency, loud-fail, dogfooding, self-found, issue-403]
+    fields:
+      priority: must
+      category: functional
+      baseline: v0.15.0-track
+    links:
+      - type: traces-to
+        target: REQ-140

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -9427,209 +9427,65 @@ fn cmd_impact(
 
 /// Load a baseline store from a git ref by extracting artifact files at that ref.
 fn load_baseline_from_git(cli: &Cli, git_ref: &str) -> Result<Store> {
-    let config_path = cli.project.join("rivet.yaml");
-
-    // Read rivet.yaml at the git ref
-    let config_content = git_show_file(&cli.project, git_ref, "rivet.yaml")
-        .with_context(|| format!("reading rivet.yaml at ref '{git_ref}'"))?;
-
-    let config: rivet_core::model::ProjectConfig = serde_yaml::from_str(&config_content)
-        .with_context(|| format!("parsing rivet.yaml at ref '{git_ref}'"))?;
-
-    // We need the current schemas to parse — load them from the working tree
-    let schemas_dir = resolve_schemas_dir(cli);
-    let _schema = rivet_core::load_schemas(&config.project.schemas, &schemas_dir)
-        .context("loading schemas")?;
-
-    // For each source, list files at the git ref and parse them
-    let mut store = Store::new();
-
-    for source in &config.sources {
-        let source_path = &source.path;
-
-        // List files in the source directory at the given ref
-        let files = git_ls_tree_files(&cli.project, git_ref, source_path)
-            .with_context(|| format!("listing files in '{source_path}' at ref '{git_ref}'"))?;
-
-        for file_path in &files {
-            // Only process YAML files
-            if !file_path.ends_with(".yaml") && !file_path.ends_with(".yml") {
-                continue;
-            }
-
-            let content = match git_show_file(&cli.project, git_ref, file_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    log::warn!("could not read {file_path} at {git_ref}: {e}");
-                    continue;
-                }
-            };
-
-            // Parse using the appropriate adapter
-            let artifacts = match parse_yaml_content(&content, &source.format, file_path) {
-                Ok(a) => a,
-                Err(e) => {
-                    log::warn!("could not parse {file_path} at {git_ref}: {e}");
-                    continue;
-                }
-            };
-
-            for artifact in artifacts {
-                store.upsert(artifact);
-            }
+    // Materialize the ref's tracked tree into a temp dir and load it through
+    // the SAME canonical loader the live store uses
+    // (`load_project_full` -> `load_artifacts` per source). Earlier this used a
+    // bespoke per-file parser (`parse_yaml_content`) that handled only a couple
+    // of formats and represented artifacts differently from the live adapter —
+    // so `impact --since` reported hundreds of spurious added/changed artifacts
+    // (issue #403). Reusing the real loader makes the baseline exactly what the
+    // working tree would have produced at <ref>, so only genuine changes show.
+    let tmp = std::env::temp_dir().join(format!(
+        "rivet-baseline-{}-{}",
+        std::process::id(),
+        git_ref.replace(['/', '~', '^', ':', ' '], "_")
+    ));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp)
+        .with_context(|| format!("creating temp baseline dir {}", tmp.display()))?;
+    // Best-effort cleanup of the temp checkout on every exit path.
+    struct Cleanup(std::path::PathBuf);
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
         }
     }
+    let _guard = Cleanup(tmp.clone());
 
-    // Also try to load artifacts from the current config if the baseline
-    // config path doesn't exist at git ref (fallback for comparison)
-    if store.is_empty() && config_path.exists() {
-        log::warn!("no artifacts loaded from git ref '{git_ref}', baseline may be empty");
-    }
-
-    Ok(store)
-}
-
-/// Run `git show <ref>:<path>` to get file contents at a git ref.
-fn git_show_file(repo_dir: &std::path::Path, git_ref: &str, path: &str) -> Result<String> {
-    let output = std::process::Command::new("git")
-        .args(["show", &format!("{git_ref}:{path}")])
-        .current_dir(repo_dir)
+    // `git archive <ref> -o <tarball>` then extract — captures the exact tracked
+    // tree at the ref (gitignored build artifacts are not in the tree).
+    let tarball = tmp.join(".rivet-baseline.tar");
+    let archive = std::process::Command::new("git")
+        .args(["archive", "--format=tar", "-o"])
+        .arg(&tarball)
+        .arg(git_ref)
+        .current_dir(&cli.project)
         .output()
-        .context("running git show")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git show {git_ref}:{path} failed: {stderr}");
+        .context("running git archive for baseline")?;
+    if !archive.status.success() {
+        anyhow::bail!(
+            "git archive '{git_ref}' failed: {}",
+            String::from_utf8_lossy(&archive.stderr)
+        );
     }
-
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-}
-
-/// Run `git ls-tree` to list files in a directory at a git ref.
-fn git_ls_tree_files(
-    repo_dir: &std::path::Path,
-    git_ref: &str,
-    dir_path: &str,
-) -> Result<Vec<String>> {
-    let output = std::process::Command::new("git")
-        .args(["ls-tree", "-r", "--name-only", git_ref, dir_path])
-        .current_dir(repo_dir)
+    let untar = std::process::Command::new("tar")
+        .arg("-xf")
+        .arg(&tarball)
+        .arg("-C")
+        .arg(&tmp)
         .output()
-        .context("running git ls-tree")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git ls-tree failed: {stderr}");
+        .context("extracting baseline archive")?;
+    if !untar.status.success() {
+        anyhow::bail!(
+            "extracting baseline archive failed: {}",
+            String::from_utf8_lossy(&untar.stderr)
+        );
     }
+    let _ = std::fs::remove_file(&tarball);
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let files: Vec<String> = stdout.lines().map(|l| l.to_string()).collect();
-    Ok(files)
-}
-
-/// Parse YAML content into artifacts using the specified format adapter.
-fn parse_yaml_content(
-    content: &str,
-    format: &str,
-    file_path: &str,
-) -> Result<Vec<rivet_core::model::Artifact>> {
-    match format {
-        "generic" | "generic-yaml" => {
-            // Parse as generic YAML artifacts
-            let wrapper: GenericYamlWrapper =
-                serde_yaml::from_str(content).with_context(|| format!("parsing {file_path}"))?;
-            let artifacts = wrapper
-                .artifacts
-                .into_iter()
-                .map(|raw| rivet_core::model::Artifact {
-                    id: raw.id,
-                    artifact_type: raw.r#type,
-                    title: raw.title,
-                    description: raw.description,
-                    status: raw.status,
-                    tags: raw.tags,
-                    links: raw
-                        .links
-                        .into_iter()
-                        .map(|l| rivet_core::model::Link {
-                            link_type: l.r#type,
-                            target: l.target,
-                            external: None,
-                        })
-                        .collect(),
-                    fields: raw.fields,
-                    fields_per_variant: Default::default(),
-                    provenance: None,
-                    source_file: Some(std::path::PathBuf::from(file_path)),
-                })
-                .collect();
-            Ok(artifacts)
-        }
-        "stpa-yaml" => {
-            // For STPA, fall back to generic parsing of the YAML structure
-            let wrapper: GenericYamlWrapper =
-                serde_yaml::from_str(content).with_context(|| format!("parsing {file_path}"))?;
-            let artifacts = wrapper
-                .artifacts
-                .into_iter()
-                .map(|raw| rivet_core::model::Artifact {
-                    id: raw.id,
-                    artifact_type: raw.r#type,
-                    title: raw.title,
-                    description: raw.description,
-                    status: raw.status,
-                    tags: raw.tags,
-                    links: raw
-                        .links
-                        .into_iter()
-                        .map(|l| rivet_core::model::Link {
-                            link_type: l.r#type,
-                            target: l.target,
-                            external: None,
-                        })
-                        .collect(),
-                    fields: raw.fields,
-                    fields_per_variant: Default::default(),
-                    provenance: None,
-                    source_file: Some(std::path::PathBuf::from(file_path)),
-                })
-                .collect();
-            Ok(artifacts)
-        }
-        other => anyhow::bail!("unsupported format for git baseline: {other}"),
-    }
-}
-
-/// Raw YAML structure for parsing artifact files from git show output.
-#[derive(serde::Deserialize)]
-struct GenericYamlWrapper {
-    #[serde(default)]
-    artifacts: Vec<RawArtifact>,
-}
-
-#[derive(serde::Deserialize)]
-struct RawArtifact {
-    id: String,
-    #[serde(rename = "type")]
-    r#type: String,
-    title: String,
-    #[serde(default)]
-    description: Option<String>,
-    #[serde(default)]
-    status: Option<String>,
-    #[serde(default)]
-    tags: Vec<String>,
-    #[serde(default)]
-    links: Vec<RawLink>,
-    #[serde(default, flatten)]
-    fields: std::collections::BTreeMap<String, serde_yaml::Value>,
-}
-
-#[derive(serde::Deserialize)]
-struct RawLink {
-    #[serde(rename = "type")]
-    r#type: String,
-    target: String,
+    let loaded = rivet_core::load_project_full(&tmp)
+        .with_context(|| format!("loading baseline project at git ref '{git_ref}'"))?;
+    Ok(loaded.store)
 }
 
 /// Show built-in docs (no project load needed).

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5278,3 +5278,102 @@ fn quiet_suppresses_warn_preamble() {
         "--quiet must not alter stdout"
     );
 }
+
+/// #403: `rivet impact --since <ref>` must report only genuinely-changed
+/// artifacts, not the whole corpus. Regression for the bespoke baseline parser
+/// that diverged from the live loader and flagged hundreds of unchanged
+/// artifacts as added/changed. Here REQ-2 is untouched and must NOT appear.
+#[test]
+fn impact_since_reports_only_real_changes() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let git = |args: &[&str]| {
+        let o = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git");
+        assert!(
+            o.status.success(),
+            "git {:?}: {}",
+            args,
+            String::from_utf8_lossy(&o.stderr)
+        );
+    };
+    git(&["init", "-q", "-b", "main"]);
+    git(&["config", "user.email", "t@example.com"]);
+    git(&["config", "user.name", "T"]);
+    git(&["config", "commit.gpgsign", "false"]);
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: t\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    let reqs = dir.join("artifacts").join("reqs.yaml");
+    // Baseline: REQ-1, REQ-2.
+    std::fs::write(
+        &reqs,
+        "artifacts:\n  - id: REQ-1\n    type: requirement\n    title: One\n    status: draft\n  \
+         - id: REQ-2\n    type: requirement\n    title: Two\n    status: draft\n",
+    )
+    .unwrap();
+    git(&["add", "-A"]);
+    git(&["commit", "-q", "-m", "baseline"]);
+
+    // Change: REQ-1 title edited, REQ-3 added; REQ-2 untouched.
+    std::fs::write(
+        &reqs,
+        "artifacts:\n  - id: REQ-1\n    type: requirement\n    title: One CHANGED\n    status: draft\n  \
+         - id: REQ-2\n    type: requirement\n    title: Two\n    status: draft\n  \
+         - id: REQ-3\n    type: requirement\n    title: Three\n    status: draft\n",
+    )
+    .unwrap();
+    git(&["add", "-A"]);
+    git(&["commit", "-q", "-m", "change"]);
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "impact",
+            "--since",
+            "HEAD~1",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("rivet impact");
+    assert!(
+        out.status.success(),
+        "impact exit: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("impact JSON");
+
+    let changed: Vec<&str> = v["changed"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|c| c["id"].as_str())
+        .collect();
+    let added: Vec<&str> = v["added"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|a| a.as_str())
+        .collect();
+    // Exactly the real edit + the real add — and the untouched REQ-2 absent.
+    assert_eq!(
+        changed,
+        vec!["REQ-1"],
+        "only REQ-1 changed; got {changed:?}"
+    );
+    assert_eq!(added, vec!["REQ-3"], "only REQ-3 added; got {added:?}");
+    assert!(
+        !changed.contains(&"REQ-2") && !added.contains(&"REQ-2"),
+        "unchanged REQ-2 must not appear"
+    );
+}


### PR DESCRIPTION
Fixes #403 (self-found while dogfooding).

## Bug
`rivet impact --since HEAD~5` on the rivet repo reported **503 changed + 354 added** (1207 total) when the only real change over those 5 commits was ~7 new REQs in `requirements.yaml`. The output was misleading to the point of useless — `AI-SYS-001`, `ARCH-*`, `DD-*` etc. were all flagged though their files never changed.

## Root cause
`load_baseline_from_git` reconstructed the baseline with a **bespoke per-file parser** (`parse_yaml_content` + `GenericYamlWrapper`) — a third parse path inconsistent with the live `load_artifacts` adapter:
1. it only handled `generic-yaml`/`stpa-yaml` and skipped other source formats → those artifacts looked "added";
2. its artifact representation differed from the live load, so `impact::content_hash` differed for **unchanged** artifacts → every loaded baseline artifact showed as "changed".

(Same multiple-inconsistent-parse-paths family as REQ-140.)

## Fix
Materialise the ref's tracked tree with `git archive <ref> | tar` into a temp dir (Drop-guarded cleanup) and load it through `rivet_core::load_project_full` — the **same** `load_artifacts`-per-source path the live store uses — then diff. The bespoke helpers (`parse_yaml_content`, `git_show_file`, `git_ls_tree_files`, `GenericYamlWrapper`/`RawArtifact`/`RawLink`) are deleted.

## Verification
- `impact --since HEAD~5` now reports **3 changed** (the real `requirements.yaml` edits: REQ-128/134/149) + **7 added**, not 503/354.
- New `impact_since_reports_only_real_changes` integration test: a 2-commit fixture (REQ-1 edited, REQ-3 added, REQ-2 untouched) → `changed=[REQ-1]`, `added=[REQ-3]`, REQ-2 in neither.
- clippy `--all-targets` + fmt clean; `rivet validate` PASS (195), `rivet docs check` PASS.

## Known residual (smaller, separate)
Externals are in the live store but not loaded into the baseline by `load_project_full`, so external `prefix:id` artifacts still show as "added". Noted on REQ-153 for follow-up.

Fixes: REQ-153

🤖 Generated with [Claude Code](https://claude.com/claude-code)