### PR TITLE
fix(list,stats): loudly report sources skipped by parse errors (REQ-154, #353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ### Fixed
 
+- **REQ-154 / #353 — `rivet list` and `rivet stats` now loudly flag artifact
+  sources dropped by a parse error.** A single stray top-level key (e.g.
+  `unknown field 'loss-coverage', expected 'artifacts'`) drops a whole file —
+  including its valid `artifacts:` list — from the graph. `rivet validate`
+  already surfaced this as a hard `artifact-parse-error` ERROR, but `list`/
+  `stats` returned a silently-smaller graph whose only signal was a `WARN`
+  preamble line an agent could pipe away. They now print a consolidated
+  "N artifact source(s) skipped due to parse errors" block to stderr naming
+  each dropped file and pointing at `rivet validate`. Clean projects emit
+  nothing new. Regression test (`list_reports_parse_error_skipped_sources`).
 - **REQ-153 / #403 — `rivet impact --since` no longer massively over-reports.**
   The baseline was reconstructed with a bespoke per-file parser inconsistent
   with the live loader, so `impact --since` flagged hundreds of unchanged

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4394,3 +4394,47 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-140
+
+  - id: REQ-154
+    type: requirement
+    title: "Enumeration commands (list/stats) must loudly report sources skipped by parse errors, not silently return fewer artifacts"
+    status: implemented
+    description: |
+      Self-found while triaging GitHub issue #353 (an agent driving rivet on
+      the `meld` project). A single stray top-level key in an artifact file
+      (`unknown field 'loss-coverage', expected 'artifacts'`) causes the
+      ENTIRE file — including its valid `artifacts:` list — to be dropped from
+      the graph, and the only signal is a `log::warn!` preamble line.
+
+      `rivet validate` already handles this correctly: it surfaces the file as
+      a hard `artifact-parse-error` ERROR diagnostic (verified). The gap is the
+      enumeration commands: `rivet list` prints "0 artifacts" and `rivet stats`
+      its counts with NO indication that a whole source was dropped. An agent
+      that pipes the WARN preamble to /dev/null (or runs under a future
+      `--quiet`) silently operates on a partial graph — a loud-fail (F2)
+      violation for the read path. Issue #353 explicitly asks to "surface
+      skipped sources in the validate/stats summary (e.g. '1 source skipped')".
+
+      Fix: after loading, `list` and `stats` re-scan sources for
+      `SkipKind::ParseError` skips (the existing REQ-062
+      `load_artifacts_with_skips` channel) and, if any, print a concise loud
+      block to stderr naming each dropped file + the parse error and pointing
+      at `rivet validate`. Emitted regardless of log level (it signals data
+      loss, not noise).
+
+      Acceptance:
+        - In a project whose `generic-yaml` source contains a file with a
+          valid `artifacts:` list plus one unknown top-level key, `rivet list`
+          exits 0 but prints to stderr a line matching
+          `source(s) skipped` naming that file; `rivet stats` does likewise.
+        - A project with no skipped sources prints no such block (no
+          regression in the clean case).
+        - `cargo test -p rivet-cli --test cli_commands
+          list_reports_parse_error_skipped_sources` passes.
+    tags: [bug, loud-fail, ux, dogfooding, self-found, issue-353]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-062

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -6001,6 +6001,9 @@ fn cmd_list(
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let ctx = ProjectContext::load(cli)?;
+    // REQ-154 / #353: loudly flag any source dropped by a parse error so a
+    // smaller-than-expected listing isn't mistaken for an empty/complete one.
+    ctx.warn_parse_error_skips(cli);
     let store = apply_baseline_scope(ctx.store, baseline_name, &ctx.config);
 
     // Resolve `--variant` once for display + per-artifact field merge.
@@ -6142,6 +6145,9 @@ fn cmd_stats(
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let ctx = ProjectContext::load(cli)?;
+    // REQ-154 / #353: loudly flag any source dropped by a parse error so the
+    // reported counts aren't silently computed over a partial graph.
+    ctx.warn_parse_error_skips(cli);
     let mut store = apply_baseline_scope(ctx.store, baseline_name, &ctx.config);
     let mut graph = if baseline_name.is_some() {
         LinkGraph::build(&store, &ctx.schema)
@@ -13239,6 +13245,49 @@ struct ProjectContext {
 }
 
 impl ProjectContext {
+    /// REQ-154 / #353: enumeration commands must loudly flag artifact sources
+    /// dropped by a parse error. `rivet validate` already surfaces these as
+    /// hard `artifact-parse-error` ERROR diagnostics, but read commands like
+    /// `list`/`stats` would otherwise return a silently-smaller graph — a
+    /// single stray top-level key drops a whole file (valid `artifacts:` and
+    /// all), and the only signal is a `log::warn!` preamble an agent may pipe
+    /// away. This re-scans the `generic` sources for `SkipKind::ParseError`
+    /// skips (the existing REQ-062 channel) and prints a concise loud block to
+    /// stderr pointing at `rivet validate`. No-op when nothing was skipped;
+    /// emitted regardless of log level because it signals data loss.
+    fn warn_parse_error_skips(&self, cli: &Cli) {
+        // Re-walk each `generic` source's directory and classify failed files
+        // via `scan_skipped_files` directly (rather than
+        // `load_artifacts_with_skips`, which would re-run `load_artifacts` and
+        // re-emit its per-file `log::warn!`). This adds the consolidated
+        // summary without doubling the existing warning noise.
+        let mut skips: Vec<rivet_core::SkippedFile> = Vec::new();
+        for source in &self.config.sources {
+            if !matches!(source.format.as_str(), "generic" | "generic-yaml") {
+                continue;
+            }
+            let path = cli.project.join(&source.path);
+            if path.is_dir() {
+                skips.extend(
+                    rivet_core::formats::generic::scan_skipped_files(&path)
+                        .into_iter()
+                        .filter(|s| s.kind == rivet_core::SkipKind::ParseError),
+                );
+            }
+        }
+        if skips.is_empty() {
+            return;
+        }
+        eprintln!(
+            "warning: {} artifact source(s) skipped due to parse errors — \
+             those artifacts are NOT loaded. Run `rivet validate` for details:",
+            skips.len()
+        );
+        for s in &skips {
+            eprintln!("  - {}: {}", s.path.display(), s.reason);
+        }
+    }
+
     /// Load project with artifacts, schema, and link graph.
     fn load(cli: &Cli) -> Result<Self> {
         let config_path = cli.project.join("rivet.yaml");

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5377,3 +5377,67 @@ fn impact_since_reports_only_real_changes() {
         "unchanged REQ-2 must not appear"
     );
 }
+
+/// REQ-154 / #353: a `generic-yaml` source file with a valid `artifacts:`
+/// list plus one unknown top-level key is dropped whole. `rivet list` (and
+/// `stats`) must then print a loud "source(s) skipped" block to stderr
+/// instead of silently returning a smaller graph — while a clean project
+/// emits no such block.
+#[test]
+fn list_reports_parse_error_skipped_sources() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: t\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    let reqs = dir.join("artifacts").join("reqs.yaml");
+
+    // A stray top-level key alongside a valid `artifacts:` list — the whole
+    // file is dropped from the graph.
+    std::fs::write(
+        &reqs,
+        "loss-coverage:\n  - foo\nartifacts:\n  - id: REQ-1\n    type: requirement\n    \
+         title: One\n    status: draft\n",
+    )
+    .unwrap();
+
+    let run = |sub: &str| {
+        Command::new(rivet_bin())
+            .args(["--project", dir.to_str().unwrap(), sub])
+            .output()
+            .expect("rivet")
+    };
+
+    let list = run("list");
+    assert!(list.status.success(), "list must still exit 0");
+    let list_err = String::from_utf8_lossy(&list.stderr);
+    assert!(
+        list_err.contains("source(s) skipped") && list_err.contains("reqs.yaml"),
+        "list must loudly name the dropped source; stderr: {list_err}"
+    );
+
+    let stats = run("stats");
+    let stats_err = String::from_utf8_lossy(&stats.stderr);
+    assert!(
+        stats_err.contains("source(s) skipped") && stats_err.contains("reqs.yaml"),
+        "stats must loudly name the dropped source; stderr: {stats_err}"
+    );
+
+    // Clean case: a well-formed file emits no skip block.
+    std::fs::write(
+        &reqs,
+        "artifacts:\n  - id: REQ-1\n    type: requirement\n    title: One\n    status: draft\n",
+    )
+    .unwrap();
+    let clean = run("list");
+    assert!(clean.status.success());
+    let clean_err = String::from_utf8_lossy(&clean.stderr);
+    assert!(
+        !clean_err.contains("source(s) skipped"),
+        "a clean project must not emit a skip block; stderr: {clean_err}"
+    );
+}


### PR DESCRIPTION
Triaged from #353 — an agent driving rivet on the **meld** project hit this and filed it.

## Bug (verified)
A single stray top-level key in a `generic-yaml` artifact file drops the **entire file** — including its valid `artifacts:` list — from the graph. Reproduced:

```
$ rivet list                       # source: reqs/ with one file: loss-coverage + valid artifacts:
[WARN  rivet_core::formats::generic] skipping ./reqs/requirements.yaml: YAML parse error: unknown field `loss-coverage`, expected `artifacts`
0 artifacts                         # ← silently empty
```

`rivet validate` **already** handles this correctly — it surfaces the file as a hard `artifact-parse-error` ERROR diagnostic. The gap is the **enumeration commands**: `list`/`stats` return a silently-smaller graph whose only signal is a `WARN` preamble line an agent can (and #353's did) pipe away → it operates on a partial graph and doesn't know it. That's an F2 "loud-fail over silent-success" violation on the read path. #353 asks explicitly to *"surface skipped sources in the validate/stats summary (e.g. '1 source skipped')."*

## Fix
`list` and `stats` re-scan `generic`/`generic-yaml` sources for `SkipKind::ParseError` skips through the existing REQ-062 `scan_skipped_files` channel — chosen over `load_artifacts_with_skips` so we don't re-run `load_artifacts` and double its per-file WARN — and print a consolidated loud block to stderr:

```
warning: 1 artifact source(s) skipped due to parse errors — those artifacts are NOT loaded. Run `rivet validate` for details:
  - ./reqs/requirements.yaml: YAML parse error: unknown field `loss-coverage`, expected `artifacts`
```

Emitted regardless of log level (it signals data loss). No-op on clean projects.

## Verification
- Reproduced the #353 case; both `list` and `stats` now name the dropped file on stderr while still exiting 0.
- Clean project emits no skip block (no regression).
- New integration test `list_reports_parse_error_skipped_sources`.
- clippy `--all-targets` + fmt clean; `rivet validate` PASS (195), `docs check` PASS.

## Scope note
Targeted at the two enumeration commands #353 names. Other read commands (`get`, `trace`, `matrix`) could adopt the same `ctx.warn_parse_error_skips()` helper in a follow-up; `validate` deliberately keeps its authoritative hard-ERROR path and is not double-reported.

Implements: REQ-154

🤖 Generated with [Claude Code](https://claude.com/claude-code)