### PR TITLE
fix(validate): suppress prose-mention warning when no link type can connect the types (REQ-155, #353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 
 ### Fixed
 
+- **REQ-155 / #353 — `prose-mention-without-typed-link` no longer fires an
+  unactionable warning (or pressures a false trace).** When an artifact's
+  prose names an id-shaped token that resolves to an artifact its own type
+  cannot link to under the schema, `validate` used to advise "add a link in
+  `links:`" — impossible when no such link type exists, and dangerous when
+  the token is a coincidental id collision (following the advice fabricates a
+  wrong trace; reported on the `sigil` project). The diagnostic is now
+  suppressed when the schema permits no link type connecting the mentioning
+  type to the mentioned type. Link types with empty `source-types`/
+  `target-types` ("any → any") are unaffected, so only fully-constrained
+  schemas change behaviour. Unit test
+  `prose_mention_suppressed_when_no_schema_valid_link_type`.
 - **REQ-154 / #353 — `rivet list` and `rivet stats` now loudly flag artifact
   sources dropped by a parse error.** A single stray top-level key (e.g.
   `unknown field 'loss-coverage', expected 'artifacts'`) drops a whole file —

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4438,3 +4438,52 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-062
+
+  - id: REQ-155
+    type: requirement
+    title: "prose-mention-without-typed-link must suppress when no schema-valid link type connects the two artifact types"
+    status: implemented
+    description: |
+      From a cross-project agent report on issue #353 (the `sigil` project,
+      "finding B"). After an agent edited a `cybersecurity-design` artifact's
+      description to mention "UCA-4" as rationale, `rivet validate` raised:
+
+        WARN: [CD-22] prose mentions 'UCA-4' but no typed link to it;
+              add a link in `links:` or remove the mention
+
+      Two defects:
+        1. Unactionable remediation. `cybersecurity-design` only permits
+           `satisfies -> cybersecurity-req`; the schema defines NO link type
+           that could connect a design to a `uca`. The advised fix ("add a
+           link in `links:`") is therefore impossible — the warning can only
+           ever be cleared by rewording prose.
+        2. False-trace pressure. The prose "UCA-4" referred to a local STPA
+           report's numbering, but `UCA-4` happens to resolve to an
+           unrelated artifact. Following the warning's advice would have
+           created a wrong, fabricated trace link.
+
+      Fix: in the prose-mention pass, suppress the diagnostic when the
+      project schema permits no link type whose `source-types` allows the
+      mentioning artifact's type AND whose `target-types` allows the
+      mentioned artifact's type. A link type with empty `source-types` /
+      `target-types` means "any -> any", so permissive schemas are
+      unaffected; only fully-constrained schemas ever trigger suppression.
+      When a link IS schema-valid, the warning fires unchanged.
+
+      Acceptance:
+        - In a schema whose only link type is `design -> requirement`, a
+          `design` artifact whose prose mentions both a `uca` (unlinkable)
+          and a `requirement` (linkable) yields exactly ONE
+          prose-mention-without-typed-link warning — for the requirement,
+          not the uca.
+        - `cargo test -p rivet-core --lib
+          prose_mention_suppressed_when_no_schema_valid_link_type` passes,
+          and the existing `prose_mention_*` tests still pass.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [bug, diagnostics, false-positive, ux, dogfooding, issue-353]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-004

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -1137,6 +1137,27 @@ pub fn validate_structural_with_externals_and_variant(
                 if linked_targets.contains(mentioned) {
                     continue;
                 }
+                // sigil finding B (#353): suppress when the schema permits NO
+                // link type between the mentioning artifact's type and the
+                // mentioned artifact's type. The only remediation this rule
+                // offers is "add a link in `links:`" — impossible when no such
+                // link type exists, and nagging the author to link an
+                // id-shaped token that resolves to an *unrelated* artifact
+                // (a coincidental id collision) pressures a FALSE trace.
+                // A link type with empty `source-types`/`target-types` means
+                // "any -> any", so permissive schemas are unaffected; only
+                // fully-constrained schemas (every link type names its source
+                // and target) ever trigger the suppression.
+                let from_type = artifact.artifact_type.as_str();
+                let to_type = store.get(mentioned).map(|a| a.artifact_type.as_str());
+                let link_type_exists = schema.link_types.values().any(|lt| {
+                    (lt.source_types.is_empty() || lt.source_types.iter().any(|s| s == from_type))
+                        && (lt.target_types.is_empty()
+                            || to_type.is_some_and(|t| lt.target_types.iter().any(|x| x == t)))
+                });
+                if !link_type_exists {
+                    continue;
+                }
                 if !warned.insert(mentioned.to_string()) {
                     continue;
                 }
@@ -3190,9 +3211,21 @@ then:
         a_fields: Vec<(&str, &str)>,
         a_links: Vec<Link>,
     ) -> Vec<Diagnostic> {
+        use crate::schema::LinkTypeDef;
         use crate::store::Store;
 
-        let schema_file = minimal_schema("test");
+        // A `relates` link type that permits test -> test, so that for these
+        // same-type fixtures a typed link *is* possible — otherwise the
+        // prose-mention rule now (correctly) suppresses when no link type
+        // could connect the two artifact types (sigil finding B, #353).
+        let mut schema_file = minimal_schema("test");
+        schema_file.link_types.push(LinkTypeDef {
+            name: "relates".into(),
+            inverse: None,
+            description: "test relation".into(),
+            source_types: vec!["test".into()],
+            target_types: vec!["test".into()],
+        });
         let schema = Schema::merge(&[schema_file]);
 
         let a = make_artifact("A-1", "test", None, description_of_a, a_fields, a_links);
@@ -3252,6 +3285,65 @@ then:
         assert!(
             diags.is_empty(),
             "self-id mention must not warn, got {diags:?}"
+        );
+    }
+
+    // rivet: verifies REQ-155
+    #[test]
+    fn prose_mention_suppressed_when_no_schema_valid_link_type() {
+        // sigil finding B (#353): a `design` artifact mentions a `uca`
+        // artifact, but the schema's only link type connects design ->
+        // requirement. There is NO link type that could connect design ->
+        // uca, so "add a link in `links:`" is impossible — the warning must
+        // be suppressed rather than pressure a false trace. The control
+        // (mentioning a `requirement`, which design CAN link to) still warns.
+        use crate::schema::LinkTypeDef;
+        use crate::store::Store;
+
+        let mut schema_file = minimal_schema("test");
+        schema_file.link_types.push(LinkTypeDef {
+            name: "satisfies".into(),
+            inverse: None,
+            description: "design satisfies a requirement".into(),
+            source_types: vec!["design".into()],
+            target_types: vec!["requirement".into()],
+        });
+        let schema = Schema::merge(&[schema_file]);
+
+        // A design that mentions both an unrelatable `uca` and a linkable
+        // `requirement` in its prose, with no typed links of its own.
+        let a = make_artifact(
+            "DD-1",
+            "design",
+            None,
+            Some("Mitigates UCA-1; satisfies REQ-1."),
+            vec![],
+            vec![],
+        );
+        let uca = make_artifact("UCA-1", "uca", None, None, vec![], vec![]);
+        let req = make_artifact("REQ-1", "requirement", None, None, vec![], vec![]);
+
+        let mut store = Store::new();
+        store.insert(a).unwrap();
+        store.insert(uca).unwrap();
+        store.insert(req).unwrap();
+        let graph = LinkGraph::build(&store, &schema);
+
+        let diags: Vec<_> = crate::validate::validate(&store, &schema, &graph)
+            .into_iter()
+            .filter(|d| d.rule == "prose-mention-without-typed-link")
+            .collect();
+
+        // Exactly one warning — for REQ-1 (linkable), NOT for UCA-1.
+        assert_eq!(
+            diags.len(),
+            1,
+            "expected exactly one prose-mention warning (REQ-1 only), got {diags:?}"
+        );
+        let msg = &diags[0].message;
+        assert!(
+            msg.contains("REQ-1") && !msg.contains("UCA-1"),
+            "warning must be for the linkable REQ-1, not the unrelatable UCA-1: {msg}"
         );
     }
 


### PR DESCRIPTION
Triaged from the #353 thread — the **sigil** project's *"finding B"* (cross-project agent report).

## Bug (verified)
After an agent edited a `cybersecurity-design` artifact's description to mention `UCA-4` as rationale, `rivet validate` raised:

```
WARN: [CD-22] prose mentions 'UCA-4' but no typed link to it; add a link in `links:` or remove the mention
```

Two defects:
1. **Unactionable remediation.** `cybersecurity-design` only permits `satisfies → cybersecurity-req`; the schema defines **no** link type that could connect a design to a `uca`. The advised *"add a link in `links:`"* is impossible — the warning can only be cleared by rewording prose.
2. **False-trace pressure.** The prose `UCA-4` referred to a local STPA report's own numbering, but `UCA-4` happens to resolve to an *unrelated* artifact. Following the warning's advice would have fabricated a **wrong trace link** — the opposite of what traceability tooling should encourage.

## Fix
In the prose-mention pass, suppress the diagnostic when the project schema permits **no** link type whose `source-types` allows the mentioning artifact's type **and** whose `target-types` allows the mentioned artifact's type.

Link types with empty `source-types`/`target-types` mean *"any → any"*, so **permissive schemas are unaffected** — only fully-constrained schemas (every link type names its source and target, like sigil's) ever trigger suppression. When a link IS schema-valid, the warning fires unchanged.

## Verification
- New unit test `prose_mention_suppressed_when_no_schema_valid_link_type`: a `design` whose prose mentions both an unlinkable `uca` and a linkable `requirement` → **exactly one** warning, for the requirement, not the uca.
- Existing `prose_mention_*` fixtures updated to declare a permitting link type so the warn-path still warns (the old fixtures used a degenerate zero-link-type schema). All 7 prose-mention tests + 105 validate unit tests pass.
- `rivet validate` on the rivet repo still PASS; clippy `--all-targets` + fmt clean; docs check PASS.

## Note
This is the narrow, clearly-correct half of the broader "diagnostics that can't be acted on" theme. The `validate` structural-vs-coverage gate idea (also raised in #353) is a categorization-policy call I've left for maintainer direction.

Fixes: REQ-155

🤖 Generated with [Claude Code](https://claude.com/claude-code)