### PR TITLE
feat(validate): add coverage-rule-consistency schema check (REQ-148, #350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 
 ### Fixed
 
+- **REQ-148 / #350 — new `coverage-rule-consistency` schema check flags a
+  `required-backlink` rule that advertises an unsatisfiable satisfier.** When a
+  coverage rule lists a `from-type` in `from-types` that the schema's own
+  link-target rules can never let form the backlink (aspice
+  `swe1-has-verification` lists `unit-verification`, whose `verifies`
+  link-field targets only `sw-detail-design`, not `sw-req`), authors hit a
+  confusing wall: the rule says "add a `verifies` from a unit-verification" but
+  authoring that link is rejected by `link-target-type`. `validate` now emits a
+  schema-level warning naming the rule, the unreachable from-type, what its
+  link-field actually targets, and the fix (widen the target-types or drop the
+  from-type). Runs on both the salsa and `--direct` paths (no divergence, cf.
+  REQ-146); conservative (only flags a *declared* link-field that demonstrably
+  excludes the target). Unit tests `coverage_rule_flags_unsatisfiable_from_type`
+  / `coverage_rule_silent_when_all_from_types_linkable`. Whether the aspice
+  `from-types` themselves are right is a separate compliance call (#350/#355).
 - **REQ-155 / #353 — `prose-mention-without-typed-link` no longer fires an
   unactionable warning (or pressures a false trace).** When an artifact's
   prose names an id-shaped token that resolves to an artifact its own type

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4143,7 +4143,7 @@ artifacts:
   - id: REQ-148
     type: requirement
     title: "Schema-consistency check: flag a required-backlink rule whose from-types cannot form the link"
-    status: draft
+    status: implemented
     description: |
       Surfaced verifying #350 against the aspice schema. The coverage rule
       `swe1-has-verification` declares `source-type: sw-req`,

--- a/rivet-core/src/db.rs
+++ b/rivet-core/src/db.rs
@@ -421,6 +421,9 @@ pub fn evaluate_conditional_rules(
     diagnostics.extend(crate::schema::check_conditional_consistency(
         &schema.conditional_rules,
     ));
+    // Coverage-rule consistency (REQ-148 / #350) — kept on the salsa path too
+    // so it never diverges from `validate --direct` (cf. REQ-146).
+    diagnostics.extend(schema.check_coverage_rule_consistency());
 
     // Evaluate each conditional rule against each artifact (pre-compile regexes)
     for rule in &schema.conditional_rules {
@@ -461,6 +464,9 @@ pub fn evaluate_conditional_rules_with_extras(
     diagnostics.extend(crate::schema::check_conditional_consistency(
         &schema.conditional_rules,
     ));
+    // Coverage-rule consistency (REQ-148 / #350) — kept on the salsa path too
+    // so it never diverges from `validate --direct` (cf. REQ-146).
+    diagnostics.extend(schema.check_coverage_rule_consistency());
 
     // Evaluate each conditional rule against each artifact (pre-compile regexes)
     for rule in &schema.conditional_rules {

--- a/rivet-core/src/schema.rs
+++ b/rivet-core/src/schema.rs
@@ -1198,6 +1198,109 @@ impl Schema {
         issues
     }
 
+    /// REQ-148 / #350: flag a `required-backlink` coverage rule that
+    /// advertises a `from-type` the schema's own link rules can never let
+    /// form the backlink — the "advertises an unsatisfiable satisfier" class.
+    ///
+    /// A `required-backlink: <RB>` rule on `source-type: <ST>` with
+    /// `from-types: [F, …]` claims an artifact of type `F` satisfies the rule
+    /// by forming an outgoing `<RB>` link to the `<ST>` artifact. But if `F`'s
+    /// type declares an `<RB>` link-field whose `target-types` excludes `<ST>`,
+    /// the `link-target-type` rule rejects that very link, so `F` can never
+    /// satisfy the rule. (aspice `swe1-has-verification` lists
+    /// `unit-verification`, whose `verifies` link-field targets only
+    /// `sw-detail-design`, not `sw-req` — exactly the detour reported on #350.)
+    ///
+    /// Conservative — prefers false-negatives. Only flags when `F` *declares*
+    /// an `<RB>` link-field whose targets demonstrably exclude `<ST>`. If `F`
+    /// declares no `<RB>` link-field at all the link is target-unconstrained
+    /// (the `link-target-type` rule never fires), so it is not flagged.
+    /// Whether the right fix is to widen the link-field or drop the from-type
+    /// is a schema-author decision; this check only surfaces the contradiction.
+    /// `alternate-backlinks` are checked against their own link type.
+    pub fn check_coverage_rule_consistency(&self) -> Vec<crate::validate::Diagnostic> {
+        let mut diagnostics = Vec::new();
+        for rule in &self.traceability_rules {
+            let Some(backlink) = rule.required_backlink.as_deref() else {
+                continue;
+            };
+            let st = rule.source_type.as_str();
+            // (link-type, from-types) pairs: the primary backlink + alternates.
+            let mut checks: Vec<(&str, &[String])> = vec![(backlink, rule.from_types.as_slice())];
+            for alt in &rule.alternate_backlinks {
+                checks.push((alt.link_type.as_str(), alt.from_types.as_slice()));
+            }
+            for (link_type, from_types) in checks {
+                for from in from_types {
+                    if let Some(allowed) = self.unsatisfiable_backlink_targets(from, link_type, st)
+                    {
+                        diagnostics.push(crate::validate::Diagnostic {
+                            source_file: None,
+                            line: None,
+                            column: None,
+                            severity: Severity::Warning,
+                            artifact_id: None,
+                            rule: "coverage-rule-consistency".to_string(),
+                            message: format!(
+                                "coverage rule '{}' lists from-type '{}' as a '{}' satisfier for \
+                                 '{}', but '{}'s '{}' link-field only targets {:?} — it can never \
+                                 form '{}' --{}--> '{}', so that satisfier is unreachable (widen \
+                                 the link-field's target-types or drop the from-type)",
+                                rule.name,
+                                from,
+                                link_type,
+                                st,
+                                from,
+                                link_type,
+                                allowed,
+                                from,
+                                link_type,
+                                st
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        diagnostics
+    }
+
+    /// Helper for [`Self::check_coverage_rule_consistency`]. Returns
+    /// `Some(allowed_targets)` when type `from` declares a `link_type`
+    /// link-field that demonstrably cannot target `to` (backlink
+    /// unsatisfiable); `None` when it can, is unconstrained, or `from`
+    /// declares no such link-field.
+    fn unsatisfiable_backlink_targets(
+        &self,
+        from: &str,
+        link_type: &str,
+        to: &str,
+    ) -> Option<Vec<String>> {
+        let td = self.artifact_types.get(from)?;
+        let matching: Vec<&LinkFieldDef> = td
+            .link_fields
+            .iter()
+            .filter(|lf| lf.link_type == link_type)
+            .collect();
+        if matching.is_empty() {
+            // No declared link-field for this link type -> target-unconstrained.
+            return None;
+        }
+        let satisfiable = matching
+            .iter()
+            .any(|lf| lf.target_types.is_empty() || lf.target_types.iter().any(|t| t == to));
+        if satisfiable {
+            return None;
+        }
+        let mut allowed: Vec<String> = matching
+            .iter()
+            .flat_map(|lf| lf.target_types.iter().cloned())
+            .collect();
+        allowed.sort();
+        allowed.dedup();
+        Some(allowed)
+    }
+
     /// Look up an artifact type definition by name.
     #[inline]
     pub fn artifact_type(&self, name: &str) -> Option<&ArtifactTypeDef> {
@@ -2022,6 +2125,109 @@ mod tests {
             lt.inverse,
             Some("derived-into".into()),
             "base inverse survives when overlay doesn't redeclare it"
+        );
+    }
+
+    // ── coverage-rule consistency (REQ-148 / #350) ──────────────────────────
+
+    /// Helper: an artifact type whose `verifies` link-field targets exactly
+    /// `targets` (empty = any).
+    fn verifier_type(name: &str, targets: &[&str]) -> ArtifactTypeDef {
+        let mut td = mk_type(name, vec![], vec![]);
+        td.link_fields = vec![LinkFieldDef {
+            name: "verifies".into(),
+            link_type: "verifies".into(),
+            target_types: targets.iter().map(|s| (*s).into()).collect(),
+            required: false,
+            cardinality: Cardinality::ZeroOrMany,
+            description: None,
+        }];
+        td
+    }
+
+    #[test]
+    fn coverage_rule_flags_unsatisfiable_from_type() {
+        // Mirrors aspice `swe1-has-verification`: sw-req needs an incoming
+        // `verifies` from [sw-verification, unit-verification], but
+        // unit-verification's `verifies` link-field only targets
+        // sw-detail-design — it can never verifies a sw-req.
+        let mut file = mk_schema_file(
+            "aspice-mini",
+            vec![
+                mk_type("sw-req", vec![], vec![]),
+                mk_type("sw-detail-design", vec![], vec![]),
+                verifier_type("sw-verification", &["sw-req"]),
+                verifier_type("unit-verification", &["sw-detail-design"]),
+            ],
+        );
+        file.link_types.push(LinkTypeDef {
+            name: "verifies".into(),
+            inverse: None,
+            description: "verifies".into(),
+            source_types: vec![],
+            target_types: vec![],
+        });
+        file.traceability_rules.push(TraceabilityRule {
+            name: "swe1-has-verification".into(),
+            description: "every sw-req is verified".into(),
+            source_type: "sw-req".into(),
+            required_link: None,
+            required_backlink: Some("verifies".into()),
+            target_types: vec![],
+            from_types: vec!["sw-verification".into(), "unit-verification".into()],
+            severity: Severity::Warning,
+            alternate_backlinks: vec![],
+        });
+        let schema = Schema::merge(&[file]);
+
+        let diags = schema.check_coverage_rule_consistency();
+        assert_eq!(
+            diags.len(),
+            1,
+            "exactly one unsatisfiable satisfier (unit-verification), got: {:#?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+        assert_eq!(diags[0].rule, "coverage-rule-consistency");
+        let msg = &diags[0].message;
+        assert!(
+            msg.contains("unit-verification") && !msg.contains("'sw-verification'"),
+            "must flag unit-verification (the unreachable one), not sw-verification: {msg}"
+        );
+    }
+
+    #[test]
+    fn coverage_rule_silent_when_all_from_types_linkable() {
+        // Both verifiers can target sw-req -> no diagnostic.
+        let mut file = mk_schema_file(
+            "aspice-ok",
+            vec![
+                mk_type("sw-req", vec![], vec![]),
+                verifier_type("sw-verification", &["sw-req"]),
+                verifier_type("alt-verification", &[]), // empty = any target
+            ],
+        );
+        file.link_types.push(LinkTypeDef {
+            name: "verifies".into(),
+            inverse: None,
+            description: "verifies".into(),
+            source_types: vec![],
+            target_types: vec![],
+        });
+        file.traceability_rules.push(TraceabilityRule {
+            name: "swe1-has-verification".into(),
+            description: "every sw-req is verified".into(),
+            source_type: "sw-req".into(),
+            required_link: None,
+            required_backlink: Some("verifies".into()),
+            target_types: vec![],
+            from_types: vec!["sw-verification".into(), "alt-verification".into()],
+            severity: Severity::Warning,
+            alternate_backlinks: vec![],
+        });
+        let schema = Schema::merge(&[file]);
+        assert!(
+            schema.check_coverage_rule_consistency().is_empty(),
+            "all from-types can form the backlink -> no diagnostic"
         );
     }
 }

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -355,6 +355,10 @@ pub fn validate_with_externals_and_variant(
         &schema.conditional_rules,
     ));
 
+    // 0b. Check coverage-rule consistency (REQ-148 / #350): a required-backlink
+    // rule whose from-types include a type that can never form the backlink.
+    diagnostics.extend(schema.check_coverage_rule_consistency());
+
     // 8. Check conditional rules (pre-compile regexes to avoid re-compilation per artifact).
     //
     // When a variant is active, `matches_artifact_for_variant_with` and


### PR DESCRIPTION
Triaged from #350 — an agent marking a `sw-req` verified hit a confusing wall, and the maintainer filed REQ-148 for a generic check.

## The problem
The aspice coverage rule `swe1-has-verification` advertises:
```yaml
source-type: sw-req
required-backlink: verifies
from-types: [sw-verification, unit-verification, sw-integration-verification]
```
But the per-type link-fields only let **`sw-verification`** form `verifies → sw-req`:
- `unit-verification`'s `verifies` link-field targets `[sw-detail-design]`
- `sw-integration-verification`'s targets `[sw-arch-component, sw-detail-design]`

So two of the three advertised satisfiers **can never** form that backlink. The #350 agent dutifully authored a `unit-verification → sw-req` link, got it rejected by `link-target-type`, and had nothing explaining the contradiction.

## The check
A generic schema-consistency meta-check (sibling of `conditional-rule-consistency`): for each `required-backlink` rule, flag any `from-type` whose declared link-field for that link type demonstrably excludes the rule's `source-type`. Emits a `coverage-rule-consistency` warning:

```
WARN: coverage rule 'swe1-has-verification' lists from-type 'unit-verification' as a 'verifies'
satisfier for 'sw-req', but 'unit-verification's 'verifies' link-field only targets
["sw-detail-design"] — it can never form 'unit-verification' --verifies--> 'sw-req', so that
satisfier is unreachable (widen the link-field's target-types or drop the from-type)
```

`alternate-backlinks` are checked against their own link type. **Conservative** — only flags when the from-type *declares* a matching link-field that excludes the target; a from-type with no such link-field (target-unconstrained) is not flagged (prefers false-negatives).

## Salsa/direct parity
Wired into all three validation entrypoints — direct (`validate_with_externals_and_variant`) and both salsa queries in `db.rs` — so `rivet validate` (default salsa) and `validate --direct` never diverge (the exact bug class REQ-146 just fixed).

## Verification
- On a temp project loading the aspice schema: **both** default and `--direct` emit exactly 2 coverage-rule-consistency warnings (unit-verification + sw-integration-verification), none for the reachable `sw-verification`.
- **rivet repo itself still PASS (197 warnings, unchanged)** — it doesn't load aspice, so no new noise / no regression.
- Unit tests `coverage_rule_flags_unsatisfiable_from_type` + `coverage_rule_silent_when_all_from_types_linkable`; 1103 rivet-core lib tests pass; clippy `--all-targets` + fmt clean; docs check PASS.

## Scope
This is the generic *check*. Whether the aspice `from-types` are themselves wrong (ASPICE intent: SWE.6 verifies sw-reqs; unit/integration verify design layers) is a maintainer/compliance call, tracked on #350/#355 — once this check ships, the aspice schema can be fixed to clear the two warnings it now surfaces.

Implements: REQ-148

🤖 Generated with [Claude Code](https://claude.com/claude-code)