### PR TITLE
refactor(validate): single chokepoint for schema-level consistency checks (REQ-156, #410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **REQ-156 / #410 — schema-level consistency checks now route through a single
+  `Schema::consistency_diagnostics()` chokepoint.** Both the salsa (default
+  `rivet validate`) and `--direct` paths call exactly one method instead of
+  hand-registering each check at three call sites, so a future schema-level
+  check can't land on some surfaces but not others — closing the salsa/direct
+  divergence class REQ-146 just fixed for status-gate rules. Pure refactor:
+  diagnostic output is unchanged (`validate` and `validate --direct` produce
+  identical results on the rivet repo). Unit test asserts the chokepoint
+  surfaces both conditional-rule and coverage-rule consistency diagnostics.
+
 ### Fixed
 
 - **REQ-148 / #350 — new `coverage-rule-consistency` schema check flags a

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4487,3 +4487,44 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-004
+
+  - id: REQ-156
+    type: requirement
+    title: "Single chokepoint for schema-level consistency checks so salsa and --direct cannot diverge"
+    status: implemented
+    description: |
+      Self-found while landing REQ-148 (#410). Adding a schema-level
+      consistency check (one that inspects the schema, not artifacts) required
+      hand-registering the same call in THREE validation entrypoints:
+      `validate::validate_with_externals_and_variant` (direct path) and the two
+      salsa queries in `db.rs` (`evaluate_conditional_rules`,
+      `evaluate_conditional_rules_with_extras`). If a future check is added to
+      only some sites, `rivet validate` (salsa, the default) and
+      `validate --direct` silently disagree — the exact divergence class
+      REQ-146 just fixed for status-gate rules.
+
+      Fix: hoist all schema-level consistency checks behind a single
+      `Schema::consistency_diagnostics()` method (conditional-rule dup/overlap
+      + coverage-rule reachability). All three entrypoints now call exactly
+      that one method, so a new check is a one-line edit there that cannot be
+      partially applied. Pure refactor — diagnostic output is unchanged.
+
+      Acceptance:
+        - All three validation entrypoints call `schema.consistency_diagnostics()`
+          and nothing calls `check_conditional_consistency` /
+          `check_coverage_rule_consistency` directly outside that method and
+          tests.
+        - `rivet validate` and `rivet validate --direct` on the rivet repo
+          produce identical Result lines (PASS, same warning count).
+        - Unit test asserts `consistency_diagnostics()` surfaces BOTH a
+          conditional-rule-consistency and a coverage-rule-consistency
+          diagnostic for a schema that trips each.
+        - `cargo test -p rivet-core` green; `rivet validate` on the rivet repo
+          still PASS.
+    tags: [refactor, validation, salsa-parity, maintainability, dogfooding, self-found, issue-410]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-146

--- a/rivet-core/src/db.rs
+++ b/rivet-core/src/db.rs
@@ -417,13 +417,11 @@ pub fn evaluate_conditional_rules(
 
     let mut diagnostics = Vec::new();
 
-    // Check rule consistency first (duplicate names, overlapping requirements)
-    diagnostics.extend(crate::schema::check_conditional_consistency(
-        &schema.conditional_rules,
-    ));
-    // Coverage-rule consistency (REQ-148 / #350) — kept on the salsa path too
-    // so it never diverges from `validate --direct` (cf. REQ-146).
-    diagnostics.extend(schema.check_coverage_rule_consistency());
+    // Schema-level consistency checks (conditional-rule dup/overlap +
+    // coverage-rule reachability). REQ-156 / #410: the single
+    // `consistency_diagnostics()` chokepoint shared with the direct path so
+    // the salsa and `--direct` surfaces never diverge (cf. REQ-146).
+    diagnostics.extend(schema.consistency_diagnostics());
 
     // Evaluate each conditional rule against each artifact (pre-compile regexes)
     for rule in &schema.conditional_rules {
@@ -460,13 +458,11 @@ pub fn evaluate_conditional_rules_with_extras(
 
     let mut diagnostics = Vec::new();
 
-    // Check rule consistency first (duplicate names, overlapping requirements)
-    diagnostics.extend(crate::schema::check_conditional_consistency(
-        &schema.conditional_rules,
-    ));
-    // Coverage-rule consistency (REQ-148 / #350) — kept on the salsa path too
-    // so it never diverges from `validate --direct` (cf. REQ-146).
-    diagnostics.extend(schema.check_coverage_rule_consistency());
+    // Schema-level consistency checks (conditional-rule dup/overlap +
+    // coverage-rule reachability). REQ-156 / #410: the single
+    // `consistency_diagnostics()` chokepoint shared with the direct path so
+    // the salsa and `--direct` surfaces never diverge (cf. REQ-146).
+    diagnostics.extend(schema.consistency_diagnostics());
 
     // Evaluate each conditional rule against each artifact (pre-compile regexes)
     for rule in &schema.conditional_rules {

--- a/rivet-core/src/schema.rs
+++ b/rivet-core/src/schema.rs
@@ -1198,6 +1198,20 @@ impl Schema {
         issues
     }
 
+    /// REQ-156 / #410: the single source of truth for *schema-level*
+    /// (artifact-independent) consistency diagnostics. Both the salsa
+    /// (`db.rs`) and direct (`validate::validate*`) validation paths MUST call
+    /// exactly this, so a new schema-level check lands on every surface at
+    /// once and can never diverge between `rivet validate` and
+    /// `validate --direct` (the bug class REQ-146 / #355 just fixed for
+    /// status-gate rules). Adding a future check is a one-line edit here that
+    /// cannot be partially applied across call sites.
+    pub fn consistency_diagnostics(&self) -> Vec<crate::validate::Diagnostic> {
+        let mut diagnostics = check_conditional_consistency(&self.conditional_rules);
+        diagnostics.extend(self.check_coverage_rule_consistency());
+        diagnostics
+    }
+
     /// REQ-148 / #350: flag a `required-backlink` coverage rule that
     /// advertises a `from-type` the schema's own link rules can never let
     /// form the backlink — the "advertises an unsatisfiable satisfier" class.
@@ -2192,6 +2206,69 @@ mod tests {
         assert!(
             msg.contains("unit-verification") && !msg.contains("'sw-verification'"),
             "must flag unit-verification (the unreachable one), not sw-verification: {msg}"
+        );
+    }
+
+    #[test]
+    fn consistency_diagnostics_aggregates_conditional_and_coverage_checks() {
+        // REQ-156 / #410: the single chokepoint both validation paths call
+        // must surface BOTH schema-level check families. Build a schema that
+        // trips each: a duplicated conditional rule name (conditional-rule-
+        // consistency) and an unsatisfiable coverage from-type
+        // (coverage-rule-consistency).
+        let mut file = mk_schema_file(
+            "both",
+            vec![
+                mk_type("sw-req", vec![], vec![]),
+                mk_type("sw-detail-design", vec![], vec![]),
+                verifier_type("unit-verification", &["sw-detail-design"]),
+            ],
+        );
+        file.link_types.push(LinkTypeDef {
+            name: "verifies".into(),
+            inverse: None,
+            description: "verifies".into(),
+            source_types: vec![],
+            target_types: vec![],
+        });
+        file.traceability_rules.push(TraceabilityRule {
+            name: "swe1-has-verification".into(),
+            description: "every sw-req is verified".into(),
+            source_type: "sw-req".into(),
+            required_link: None,
+            required_backlink: Some("verifies".into()),
+            target_types: vec![],
+            from_types: vec!["unit-verification".into()],
+            severity: Severity::Warning,
+            alternate_backlinks: vec![],
+        });
+        let dup = ConditionalRule {
+            name: "dup-rule".into(),
+            description: None,
+            condition: None,
+            when: Condition::Equals {
+                field: "status".into(),
+                value: "active".into(),
+            },
+            then: Requirement::RequiredFields {
+                fields: vec!["x".into()],
+            },
+            severity: Severity::Warning,
+        };
+        file.conditional_rules.push(dup.clone());
+        file.conditional_rules.push(dup);
+        let schema = Schema::merge(&[file]);
+
+        let diags = schema.consistency_diagnostics();
+        let rules: std::collections::HashSet<&str> =
+            diags.iter().map(|d| d.rule.as_str()).collect();
+        assert!(
+            rules.contains("conditional-rule-consistency"),
+            "chokepoint must include conditional-rule checks, got {rules:?}"
+        );
+        assert!(
+            rules.contains("coverage-rule-consistency"),
+            "chokepoint must include coverage-rule checks, got {rules:?}"
         );
     }
 

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -350,14 +350,11 @@ pub fn validate_with_externals_and_variant(
     let mut diagnostics =
         validate_structural_with_externals_and_variant(store, schema, graph, externals, variant);
 
-    // 0. Check conditional rule consistency (schema-level)
-    diagnostics.extend(crate::schema::check_conditional_consistency(
-        &schema.conditional_rules,
-    ));
-
-    // 0b. Check coverage-rule consistency (REQ-148 / #350): a required-backlink
-    // rule whose from-types include a type that can never form the backlink.
-    diagnostics.extend(schema.check_coverage_rule_consistency());
+    // 0. Schema-level consistency checks (conditional-rule dup/overlap +
+    // coverage-rule reachability). REQ-156 / #410: routed through the single
+    // `consistency_diagnostics()` chokepoint shared with the salsa path so the
+    // two never diverge.
+    diagnostics.extend(schema.consistency_diagnostics());
 
     // 8. Check conditional rules (pre-compile regexes to avoid re-compilation per artifact).
     //


### PR DESCRIPTION
Closes #410 — self-found while landing #409 (REQ-148).

## Problem
Adding a *schema-level* consistency check (one that inspects the schema, not artifacts) required hand-registering the same call in **three** validation entrypoints:
- `rivet-core/src/validate.rs` — direct path (`validate_with_externals_and_variant`)
- `rivet-core/src/db.rs` ×2 — salsa `evaluate_conditional_rules` + `evaluate_conditional_rules_with_extras`

If a future check is added to only some of them, `rivet validate` (salsa, the default) and `validate --direct` silently disagree — the **exact divergence class REQ-146 / #355 just fixed** for status-gate rules (salsa skipped phase 9). Nothing structurally prevents re-introducing it.

## Fix
Hoist all schema-level consistency checks behind a single method:

```rust
impl Schema {
    pub fn consistency_diagnostics(&self) -> Vec<Diagnostic> {
        let mut d = check_conditional_consistency(&self.conditional_rules);
        d.extend(self.check_coverage_rule_consistency());
        d
    }
}
```

All three entrypoints now call only `schema.consistency_diagnostics()`. Adding a future check is a one-line edit there that can't be partially applied.

## Verification
- **Pure refactor — output unchanged.** `rivet validate` and `validate --direct` on the rivet repo both `PASS (198)` with identical Result lines.
- New unit test `consistency_diagnostics_aggregates_conditional_and_coverage_checks` builds a schema that trips *both* families (duplicate conditional rule + unsatisfiable coverage from-type) and asserts the chokepoint surfaces both `conditional-rule-consistency` and `coverage-rule-consistency`.
- 1104 rivet-core lib tests pass; clippy `--all-targets` + fmt clean; docs check PASS.

Implements: REQ-156

🤖 Generated with [Claude Code](https://claude.com/claude-code)