### PR TITLE
fix(validate): emit the per-file parse-error skip WARN once, not twice (REQ-157, #406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **REQ-157 / #406 — `rivet validate` no longer prints the per-file `skipping
+  <file>` parse-error WARN twice.** It loaded each source once for validation
+  and again for the REQ-075 duplicate-id re-scan, and both loads emitted the
+  per-file WARN. The re-scan now uses a new quiet loader
+  (`load_artifacts_with_report_quiet`), so the WARN fires once while the hard
+  `artifact-parse-error` ERROR diagnostic and `Result: FAIL` are unchanged. The
+  public `load_artifacts` signature is untouched; other commands' per-file WARN
+  is preserved. Regression test
+  `validate_emits_single_skip_warn_for_malformed_source`.
+
 ### Changed
 
 - **REQ-156 / #410 — schema-level consistency checks now route through a single

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4528,3 +4528,47 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-146
+
+  - id: REQ-157
+    type: requirement
+    title: "rivet validate must emit the per-file parse-error skip WARN once, not twice"
+    status: implemented
+    description: |
+      From GitHub issue #406 (self-found while dogfooding REQ-154). `rivet
+      validate` printed the per-file `skipping <file>: YAML parse error …`
+      WARN twice for a single malformed `generic-yaml` source. Root cause:
+      `cmd_validate` loads the project once via `ProjectContext::load`
+      (load_artifacts -> import_generic_directory -> WARN #1), then re-scans
+      every source with `load_artifacts_with_report` for the REQ-075
+      duplicate-id / REQ-062 skip pass, which calls `load_artifacts` again ->
+      a second `import_generic_directory` -> WARN #2.
+
+      Decision (maintainer, on #406): option A (narrow) — kill the duplicate on
+      the validate path only; leave the per-file WARN intact for other
+      commands (get/trace/matrix/export still rely on it and aren't covered by
+      `warn_parse_error_skips()`).
+
+      Fix: thread a `warn_skips: bool` into `GenericYamlAdapter` /
+      `import_generic_directory`; add `load_artifacts_quiet` +
+      `load_artifacts_with_report_quiet` (the public `load_artifacts` signature
+      is untouched). `cmd_validate`'s re-scan uses the quiet report loader, so
+      the WARN fires once (from the initial load) but the skips/duplicates —
+      and the hard `artifact-parse-error` / `duplicate-artifact-id` ERROR
+      diagnostics derived from them — are unchanged.
+
+      Acceptance:
+        - On a fixture with one malformed `generic-yaml` source,
+          `rivet validate 2>&1 | grep -c "skipping ./…/reqs.yaml"` returns 1
+          (was 2).
+        - The hard `artifact-parse-error` ERROR still fires and `Result: FAIL`.
+        - `list`/`stats` REQ-154 skip-summary unaffected; rivet repo validate
+          still PASS.
+        - `cargo test -p rivet-cli --test cli_commands
+          validate_emits_single_skip_warn_for_malformed_source` passes.
+    tags: [bug, ux, noise, dogfooding, self-found, issue-406]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-062

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -4703,7 +4703,12 @@ fn cmd_validate(
     let mut parse_error_skips: Vec<rivet_core::SkippedFile> = Vec::new();
     let mut loaded_for_dup_check: Vec<rivet_core::model::Artifact> = Vec::new();
     for source in &config.sources {
-        match rivet_core::load_artifacts_with_report(source, &cli.project, &schema) {
+        // REQ-157 / #406: use the *quiet* report loader — `ProjectContext::load`
+        // already loaded these sources and emitted any per-file `skipping …`
+        // WARN once; re-emitting it here printed every such line twice. The
+        // skips/duplicates (and the hard ERROR diagnostics derived from them)
+        // are unchanged.
+        match rivet_core::load_artifacts_with_report_quiet(source, &cli.project, &schema) {
             Ok(report) => {
                 for skip in report.skipped {
                     if skip.kind == rivet_core::SkipKind::ParseError {

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5441,3 +5441,55 @@ fn list_reports_parse_error_skipped_sources() {
         "a clean project must not emit a skip block; stderr: {clean_err}"
     );
 }
+
+/// REQ-157 / #406: `rivet validate` must emit the per-file `skipping <file>`
+/// WARN exactly ONCE for a malformed `generic-yaml` source — it used to print
+/// twice (once from `ProjectContext::load`, once from the duplicate-id
+/// re-scan). The hard `artifact-parse-error` ERROR must still fire (FAIL).
+#[test]
+fn validate_emits_single_skip_warn_for_malformed_source() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: t\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    // Valid `artifacts:` list plus a stray top-level key -> whole file is a
+    // ParseError skip.
+    std::fs::write(
+        dir.join("artifacts").join("reqs.yaml"),
+        "loss-coverage:\n  - foo\nartifacts:\n  - id: REQ-1\n    type: requirement\n    \
+         title: One\n    status: draft\n",
+    )
+    .unwrap();
+
+    let out = Command::new(rivet_bin())
+        .args(["--project", dir.to_str().unwrap(), "validate"])
+        .output()
+        .expect("rivet validate");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let skip_warns = combined
+        .lines()
+        .filter(|l| l.contains("skipping") && l.contains("reqs.yaml"))
+        .count();
+    assert_eq!(
+        skip_warns, 1,
+        "the per-file skip WARN must print exactly once (was 2); output:\n{combined}"
+    );
+    assert!(
+        combined.contains("failed to parse"),
+        "the hard artifact-parse-error ERROR must still fire; output:\n{combined}"
+    );
+    assert!(
+        !out.status.success(),
+        "validate must FAIL on a malformed artifact source"
+    );
+}

--- a/rivet-core/src/formats/generic.rs
+++ b/rivet-core/src/formats/generic.rs
@@ -71,13 +71,26 @@ use crate::model::{Artifact, Link, Provenance};
 
 pub struct GenericYamlAdapter {
     supported: Vec<String>,
+    /// Whether a malformed *artifact* file encountered during a directory
+    /// import emits a per-file `skipping <file>` WARN. Default `true`.
+    /// `rivet validate` re-loads each source for the REQ-075 duplicate-id
+    /// pass after `ProjectContext::load` already loaded+warned; that re-load
+    /// uses a quiet adapter so the WARN isn't printed twice (REQ-157 / #406).
+    warn_skips: bool,
 }
 
 impl GenericYamlAdapter {
     pub fn new() -> Self {
         Self {
             supported: vec![], // accepts all types
+            warn_skips: true,
         }
+    }
+
+    /// Builder: set whether per-file skip WARNs are emitted (REQ-157 / #406).
+    pub fn with_warn_skips(mut self, warn_skips: bool) -> Self {
+        self.warn_skips = warn_skips;
+        self
     }
 }
 
@@ -104,7 +117,7 @@ impl Adapter for GenericYamlAdapter {
     ) -> Result<Vec<Artifact>, Error> {
         match source {
             AdapterSource::Path(path) => import_generic_file(path),
-            AdapterSource::Directory(dir) => import_generic_directory(dir),
+            AdapterSource::Directory(dir) => import_generic_directory(dir, self.warn_skips),
             AdapterSource::Bytes(bytes) => {
                 let content = std::str::from_utf8(bytes)
                     .map_err(|e| Error::Adapter(format!("invalid UTF-8: {}", e)))?;
@@ -209,7 +222,7 @@ fn import_generic_file(path: &Path) -> Result<Vec<Artifact>, Error> {
     parse_generic_yaml(&content, Some(path))
 }
 
-fn import_generic_directory(dir: &Path) -> Result<Vec<Artifact>, Error> {
+fn import_generic_directory(dir: &Path, warn_skips: bool) -> Result<Vec<Artifact>, Error> {
     let mut artifacts = Vec::new();
     let entries =
         std::fs::read_dir(dir).map_err(|e| Error::Io(format!("{}: {}", dir.display(), e)))?;
@@ -234,16 +247,20 @@ fn import_generic_directory(dir: &Path) -> Result<Vec<Artifact>, Error> {
                     // signal. `rivet validate` still re-scans and surfaces the
                     // ParseError case as a hard `artifact-parse-error`
                     // diagnostic, so suppressing the noisy case loses nothing.
+                    //
+                    // REQ-157 / #406: `warn_skips` is false when this is the
+                    // validate duplicate-id re-scan (the source was already
+                    // loaded+warned once), so the WARN isn't printed twice.
                     let is_parse_error = std::fs::read_to_string(&path)
                         .map(|c| classify_skip(&c) == SkipKind::ParseError)
                         .unwrap_or(true); // unreadable -> surface it
-                    if is_parse_error {
+                    if warn_skips && is_parse_error {
                         log::warn!("skipping {}: {}", path.display(), e);
                     }
                 }
             }
         } else if path.is_dir() {
-            artifacts.extend(import_generic_directory(&path)?);
+            artifacts.extend(import_generic_directory(&path, warn_skips)?);
         }
     }
 
@@ -550,7 +567,8 @@ Artifacts:
         )
         .unwrap();
 
-        let arts = import_generic_directory(dir.path()).expect("directory import must not error");
+        let arts =
+            import_generic_directory(dir.path(), true).expect("directory import must not error");
         let ids: Vec<&str> = arts.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(
             ids,

--- a/rivet-core/src/lib.rs
+++ b/rivet-core/src/lib.rs
@@ -224,6 +224,33 @@ pub fn load_artifacts(
     base_dir: &Path,
     schema: &schema::Schema,
 ) -> Result<Vec<model::Artifact>, Error> {
+    load_artifacts_inner(source, base_dir, schema, true)
+}
+
+/// Like [`load_artifacts`], but suppresses the per-file `skipping <file>`
+/// WARN that a `generic`/`generic-yaml` directory import emits for a
+/// malformed *artifact* file.
+///
+/// Use when re-loading a source that has *already* been loaded (and warned
+/// about) once — notably `rivet validate`'s REQ-075 duplicate-id re-scan,
+/// which runs after `ProjectContext::load` already loaded+warned. Without
+/// this the same `skipping …` line printed twice (REQ-157 / #406). The hard
+/// `artifact-parse-error` ERROR is unaffected — it derives from
+/// [`LoadReport::skipped`], not from this log line.
+pub fn load_artifacts_quiet(
+    source: &model::SourceConfig,
+    base_dir: &Path,
+    schema: &schema::Schema,
+) -> Result<Vec<model::Artifact>, Error> {
+    load_artifacts_inner(source, base_dir, schema, false)
+}
+
+fn load_artifacts_inner(
+    source: &model::SourceConfig,
+    base_dir: &Path,
+    schema: &schema::Schema,
+    warn_skips: bool,
+) -> Result<Vec<model::Artifact>, Error> {
     let path = base_dir.join(&source.path);
 
     let adapter_config = adapter::AdapterConfig {
@@ -242,7 +269,7 @@ pub fn load_artifacts(
             import_with_schema(&source_input, schema)
         }
         "generic" | "generic-yaml" => {
-            let adapter = formats::generic::GenericYamlAdapter::new();
+            let adapter = formats::generic::GenericYamlAdapter::new().with_warn_skips(warn_skips);
             adapter::Adapter::import(&adapter, &source_input, &adapter_config)
         }
         "reqif" => {
@@ -360,6 +387,31 @@ pub fn load_artifacts_with_report(
     schema: &schema::Schema,
 ) -> Result<LoadReport, Error> {
     let artifacts = load_artifacts(source, base_dir, schema)?;
+    let skipped = scan_source_skips(source, base_dir);
+    let duplicates = detect_duplicate_ids(&artifacts);
+    Ok(LoadReport {
+        artifacts,
+        skipped,
+        duplicates,
+    })
+}
+
+/// Like [`load_artifacts_with_report`], but loads via [`load_artifacts_quiet`]
+/// so the per-file `skipping <file>` WARN is not re-emitted.
+///
+/// `rivet validate` calls this for its REQ-075 duplicate-id / REQ-062 skip
+/// re-scan, which runs *after* `ProjectContext::load` already loaded the same
+/// sources (and emitted the WARN once). Using the noisy
+/// [`load_artifacts_with_report`] there printed every malformed-file WARN
+/// twice (REQ-157 / #406). The returned `skipped` / `duplicates` — and thus
+/// the hard `artifact-parse-error` / `duplicate-artifact-id` ERROR
+/// diagnostics — are identical to the noisy variant.
+pub fn load_artifacts_with_report_quiet(
+    source: &model::SourceConfig,
+    base_dir: &Path,
+    schema: &schema::Schema,
+) -> Result<LoadReport, Error> {
+    let artifacts = load_artifacts_quiet(source, base_dir, schema)?;
     let skipped = scan_source_skips(source, base_dir);
     let duplicates = detect_duplicate_ids(&artifacts);
     Ok(LoadReport {


### PR DESCRIPTION
Fixes #406. Implements the maintainer's decision on that issue (**option A — narrow**).

## Bug
`rivet validate` printed the per-file `skipping <file>: YAML parse error …` WARN **twice** for one malformed `generic-yaml` source:
```
[WARN] skipping ./reqs/requirements.yaml: YAML parse error: unknown field `loss-coverage`...
[WARN] skipping ./reqs/requirements.yaml: YAML parse error: unknown field `loss-coverage`...
```
`cmd_validate` loads the project once via `ProjectContext::load` (WARN #1), then re-scans every source with `load_artifacts_with_report` for the REQ-075 duplicate-id / REQ-062 skip pass — a second `load_artifacts → import_generic_directory → WARN #2`.

## Fix (option A — narrow)
Per the #406 decision: kill the duplicate **on the validate path only**; other commands (`get`/`trace`/`matrix`/`export`) keep their per-file WARN, since they aren't covered by `warn_parse_error_skips()` yet.

- Thread `warn_skips: bool` into `GenericYamlAdapter` (`with_warn_skips`) and `import_generic_directory`.
- Add `load_artifacts_quiet` + `load_artifacts_with_report_quiet` — the **public `load_artifacts` signature is untouched** (semver-stable), per the AC.
- `cmd_validate`'s re-scan uses the quiet report loader.

The skips/duplicates — and the hard `artifact-parse-error` / `duplicate-artifact-id` ERROR diagnostics derived from them — are byte-identical; only the redundant log line is gone.

## Verification (matches the AC)
- On the #406 fixture: `rivet validate 2>&1 | grep -c "skipping …reqs.yaml"` → **1** (was 2).
- The hard `artifact-parse-error` ERROR still fires; `Result: FAIL`.
- `list`/`stats` REQ-154 skip-summary unaffected; rivet repo `validate` still **PASS (200)**, 0 skip warns.
- New regression test `validate_emits_single_skip_warn_for_malformed_source`; 1104 rivet-core lib + 111 cli_commands tests pass; clippy `--all-targets` + fmt clean; docs check PASS.

Fixes: REQ-157

🤖 Generated with [Claude Code](https://claude.com/claude-code)