### PR TITLE
feat(validate,add): near-duplicate-intent detection (REQ-158, #397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- **REQ-158 / #397 — near-duplicate-intent detection.** `rivet add` rejects a
+  duplicate *id* but nothing flagged a duplicate *intent* — two artifacts that
+  say the same thing under different ids — so a backlog accreted near-dups.
+  A new shared `rivet_core::similarity` signal (Jaccard overlap of significant,
+  stopword-stripped title tokens, bounded `[0,1]`, threshold 0.6 — calibrated
+  to **zero** false positives on the rivet repo's own 158 requirements) now
+  backs two surfaces: `rivet validate` emits a non-blocking `near-duplicate-intent`
+  **INFO** diagnostic for each same-type pair at/above threshold (on both the
+  salsa and `--direct` paths), and `rivet add` prints a non-blocking
+  `note: intent is N% similar to <ID> …` before adding. Per-rule suppression in
+  `rivet.yaml` is a noted follow-up (no diagnostic-suppression config exists
+  yet; INFO keeps it non-disruptive meanwhile).
+
 ### Fixed
 
 - **REQ-157 / #406 — `rivet validate` no longer prints the per-file `skipping

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4572,3 +4572,54 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-062
+
+  - id: REQ-158
+    type: requirement
+    title: "Detect near-duplicate intent: flag same-type artifacts with highly similar titles"
+    status: implemented
+    description: |
+      From GitHub issue #397: `rivet add` rejects a duplicate *id* but nothing
+      flags a duplicate *intent* — two artifacts that say the same thing under
+      different ids — so a long-lived backlog accretes near-duplicate
+      requirements.
+
+      Signal (bounded + explainable, per the bounded-composite-score doctrine):
+      Jaccard overlap of significant title tokens (lowercase, alphanumeric
+      split, stopwords + sub-3-char tokens removed), in [0,1]. Threshold 0.6,
+      empirically calibrated against the rivet repo's own 158 requirements,
+      which produce ZERO pairs at 0.6 (1 at 0.5) — the default does not flood a
+      well-differentiated backlog.
+
+      Two surfaces, one shared `rivet_core::similarity` implementation so they
+      can't disagree:
+        - `rivet validate` emits a `near-duplicate-intent` INFO diagnostic for
+          each same-type, non-external artifact pair at/above threshold
+          (within-type O(n^2), titles tokenized once). INFO never blocks. Lives
+          in the shared `validate_structural*` pass so it runs on both the
+          salsa and --direct paths (same-surface parity).
+        - `rivet add` emits a non-blocking `note:` when the new title is similar
+          to an existing same-type artifact, then adds anyway.
+
+      Acceptance:
+        - In a project with REQ-1/REQ-2 (near-identical titles) and REQ-3
+          (distinct), `rivet validate --direct --format json` yields exactly
+          one `near-duplicate-intent` diagnostic, on REQ-2; REQ-3 is not named.
+        - `rivet add` with a title similar to an existing same-type artifact
+          prints a `note: intent is N% similar to …` to stderr and still
+          succeeds; a distinct title prints no note.
+        - `rivet validate` on the rivet repo emits zero `near-duplicate-intent`
+          diagnostics and still PASS.
+        - `cargo test -p rivet-core --lib similarity` and `cargo test -p
+          rivet-cli --test cli_commands near_duplicate_intent_validate_and_add`
+          pass.
+
+      Deferred (noted on #397): per-rule `allow:` suppression in rivet.yaml —
+      rivet has no general diagnostic-suppression config yet; INFO severity
+      keeps the diagnostic non-disruptive until that infra exists.
+    tags: [feature, validation, backlog-hygiene, dx, issue-397]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-004

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -13948,6 +13948,37 @@ fn cmd_add(
     // Validate before writing (DD-028)
     mutate::validate_add(&artifact, &store, &schema).context("validation failed")?;
 
+    // REQ-158 / #397: non-blocking near-duplicate-intent note. `rivet add`
+    // already rejects a duplicate *id*; this nudges on a duplicate *intent*
+    // (a same-type artifact with a highly similar title) so a backlog doesn't
+    // accrete near-duplicates — but still adds (it's advisory, not an error).
+    // Uses the same Jaccard signal as the `near-duplicate-intent` validate
+    // diagnostic, so the two surfaces agree.
+    {
+        use rivet_core::similarity::{NEAR_DUPLICATE_INTENT_THRESHOLD, intent_similarity};
+        let mut best: Option<(f64, &str, &str)> = None;
+        for other in store.iter() {
+            if other.artifact_type != artifact_type {
+                continue;
+            }
+            let sim = intent_similarity(title, &other.title);
+            if sim >= NEAR_DUPLICATE_INTENT_THRESHOLD
+                && best.as_ref().is_none_or(|(b, _, _)| sim > *b)
+            {
+                best = Some((sim, other.id.as_str(), other.title.as_str()));
+            }
+        }
+        if let Some((sim, oid, otitle)) = best {
+            eprintln!(
+                "note: intent is {}% similar to existing {} \"{}\" — adding anyway; \
+                 consolidate or differentiate if it's a duplicate",
+                (sim * 100.0).round() as u32,
+                oid,
+                otitle
+            );
+        }
+    }
+
     // Determine target file
     let target_file = if let Some(f) = file {
         cli.project.join(f)

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5493,3 +5493,101 @@ fn validate_emits_single_skip_warn_for_malformed_source() {
         "validate must FAIL on a malformed artifact source"
     );
 }
+
+/// REQ-158 / #397: `rivet validate` emits a `near-duplicate-intent` INFO for a
+/// pair of same-type artifacts with highly similar titles, and NOT for a
+/// distinct one. `rivet add` emits a non-blocking note for a similar new title.
+#[test]
+fn near_duplicate_intent_validate_and_add() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: t\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    std::fs::write(
+        dir.join("artifacts").join("r.yaml"),
+        "artifacts:\n  \
+         - id: REQ-1\n    type: requirement\n    title: \"Export must bundle JavaScript for offline viewing\"\n    status: draft\n  \
+         - id: REQ-2\n    type: requirement\n    title: \"Export should bundle the JavaScript for offline viewing\"\n    status: draft\n  \
+         - id: REQ-3\n    type: requirement\n    title: \"Parser builds a lossless concrete syntax tree\"\n    status: draft\n",
+    )
+    .unwrap();
+
+    // validate --format json: exactly one near-duplicate-intent diagnostic,
+    // on REQ-2 (the later of the similar pair), none mentioning REQ-3.
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "validate",
+            "--direct",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("rivet validate");
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("validate JSON");
+    let dups: Vec<&serde_json::Value> = v["diagnostics"]
+        .as_array()
+        .expect("diagnostics array")
+        .iter()
+        .filter(|d| d["rule"] == "near-duplicate-intent")
+        .collect();
+    assert_eq!(
+        dups.len(),
+        1,
+        "exactly one near-duplicate-intent diagnostic expected, got {dups:?}"
+    );
+    assert_eq!(dups[0]["artifact_id"], "REQ-2");
+
+    // rivet add with a similar title -> non-blocking note on stderr, still adds.
+    let add_dup = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "add",
+            "--type",
+            "requirement",
+            "--title",
+            "Export should bundle the javascript for offline viewing",
+            "--status",
+            "draft",
+        ])
+        .output()
+        .expect("rivet add");
+    assert!(
+        add_dup.status.success(),
+        "add must still succeed (advisory)"
+    );
+    let add_err = String::from_utf8_lossy(&add_dup.stderr);
+    assert!(
+        add_err.contains("intent is") && add_err.contains("REQ-1"),
+        "add must emit a near-duplicate note naming REQ-1; stderr: {add_err}"
+    );
+
+    // rivet add with a distinct title -> no note.
+    let add_ok = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "add",
+            "--type",
+            "requirement",
+            "--title",
+            "Salsa incremental recomputation invalidates only changed inputs",
+            "--status",
+            "draft",
+        ])
+        .output()
+        .expect("rivet add");
+    let ok_err = String::from_utf8_lossy(&add_ok.stderr);
+    assert!(
+        !ok_err.contains("intent is"),
+        "a distinct title must not emit a near-duplicate note; stderr: {ok_err}"
+    );
+}

--- a/rivet-core/src/lib.rs
+++ b/rivet-core/src/lib.rs
@@ -80,6 +80,7 @@ pub mod runs;
 pub mod schema;
 pub mod sexpr;
 pub mod sexpr_eval;
+pub mod similarity;
 pub mod snapshot;
 pub mod store;
 pub mod templates;

--- a/rivet-core/src/similarity.rs
+++ b/rivet-core/src/similarity.rs
@@ -1,0 +1,117 @@
+//! Title "intent" similarity — REQ-158 / #397.
+//!
+//! `rivet add` already rejects a *duplicate id*, but nothing flags a
+//! *duplicate intent*: two artifacts that say the same thing under different
+//! ids. Over a long-lived backlog these accrete (the #397 report). This module
+//! provides a cheap, explainable, bounded similarity signal used by both
+//! `rivet validate` (a `near-duplicate-intent` INFO diagnostic) and `rivet add`
+//! (a non-blocking "similar to <ID>" note) — one shared implementation so the
+//! two surfaces never disagree.
+//!
+//! The signal is **Jaccard overlap of significant title tokens**: lowercase,
+//! split on non-alphanumerics, drop stopwords and tokens shorter than 3 chars,
+//! then `|A ∩ B| / |A ∪ B|`. It is inherently bounded to `[0, 1]` and every
+//! component is inspectable (the shared/total token counts), per the
+//! bounded-composite-score doctrine — no opaque fuzzy number.
+//!
+//! Empirically calibrated: on the rivet repo's own 158 requirements the
+//! [`NEAR_DUPLICATE_INTENT_THRESHOLD`] of 0.6 yields **zero** pairs, so the
+//! default does not flood a real, well-differentiated backlog.
+
+use std::collections::BTreeSet;
+
+/// Title-intent Jaccard at/above which two same-type artifacts are flagged as
+/// near-duplicates. Calibrated against the rivet repo (0 false positives).
+pub const NEAR_DUPLICATE_INTENT_THRESHOLD: f64 = 0.6;
+
+/// Common English function words plus a few rivet-domain filler words that
+/// carry no "intent" signal. Kept small and explicit on purpose.
+const STOPWORDS: &[&str] = &[
+    "the", "a", "an", "and", "or", "of", "to", "for", "is", "are", "be", "must", "should", "no",
+    "not", "with", "via", "from", "into", "on", "in", "by", "at", "as", "it", "its", "this",
+    "that", "when", "then", "than", "only", "also", "new", "per", "each", "both", "vs", "so",
+    "but", "if", "we", "do", "does", "any", "all", "can", "use", "used",
+];
+
+/// Significant tokens of a title: lowercased, alphanumeric-split, stopwords and
+/// sub-3-char tokens removed. Deterministic (a `BTreeSet`).
+pub fn intent_tokens(title: &str) -> BTreeSet<String> {
+    title
+        .split(|c: char| !c.is_alphanumeric())
+        .map(|w| w.to_ascii_lowercase())
+        .filter(|w| w.len() > 2 && !STOPWORDS.contains(&w.as_str()))
+        .collect()
+}
+
+/// Jaccard overlap of two titles' significant-token sets, in `[0, 1]`.
+/// Returns 0.0 when either title has no significant tokens (cannot judge
+/// intent from stopwords alone — never a false "duplicate").
+pub fn intent_similarity(a: &str, b: &str) -> f64 {
+    similarity_of(&intent_tokens(a), &intent_tokens(b))
+}
+
+/// Jaccard of two pre-computed token sets — lets callers tokenize once when
+/// comparing one title against many (e.g. the O(n²) validate pass).
+pub fn similarity_of(a: &BTreeSet<String>, b: &BTreeSet<String>) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let inter = a.intersection(b).count();
+    let union = a.union(b).count();
+    inter as f64 / union as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_titles_are_fully_similar() {
+        assert_eq!(
+            intent_similarity(
+                "Export must be self-contained",
+                "Export must be self-contained"
+            ),
+            1.0
+        );
+    }
+
+    #[test]
+    fn near_duplicates_exceed_threshold() {
+        let s = intent_similarity(
+            "rivet validate must reject typo'd statuses",
+            "rivet validate should reject a typo status",
+        );
+        assert!(
+            s >= NEAR_DUPLICATE_INTENT_THRESHOLD,
+            "expected near-duplicate (>= {NEAR_DUPLICATE_INTENT_THRESHOLD}), got {s}"
+        );
+    }
+
+    #[test]
+    fn distinct_intents_stay_below_threshold() {
+        // Deliberately overlapping-but-distinct, like REQ-001 / REQ-002.
+        let s = intent_similarity(
+            "Parser builds a lossless concrete syntax tree",
+            "HTML export bundles JavaScript for offline viewing",
+        );
+        assert!(
+            s < NEAR_DUPLICATE_INTENT_THRESHOLD,
+            "distinct intents must stay below threshold, got {s}"
+        );
+    }
+
+    #[test]
+    fn stopword_only_titles_never_match() {
+        // No significant tokens -> never a false duplicate.
+        assert_eq!(intent_similarity("the of a to", "and or for is"), 0.0);
+    }
+
+    #[test]
+    fn tokens_strip_stopwords_and_short_words() {
+        let t = intent_tokens("The rivet CLI is OK");
+        // "the","is" stopwords; "ok" len 2 dropped; "cli" kept; "rivet" kept.
+        assert!(t.contains("rivet") && t.contains("cli"));
+        assert!(!t.contains("the") && !t.contains("is") && !t.contains("ok"));
+    }
+}

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -1187,6 +1187,61 @@ pub fn validate_structural_with_externals_and_variant(
         }
     }
 
+    // 11. Near-duplicate intent (REQ-158 / #397).
+    //
+    // `rivet add` rejects a duplicate *id* but nothing flags a duplicate
+    // *intent* — two same-type artifacts that say the same thing under
+    // different ids. Over a long-lived backlog these accrete. Flag a pair of
+    // same-type, non-external artifacts whose titles share at least
+    // `NEAR_DUPLICATE_INTENT_THRESHOLD` of their significant tokens. Severity
+    // is INFO — it never blocks `validate`; it's a hygiene nudge. The same
+    // Jaccard signal backs `rivet add`'s "similar to <ID>" note, so the two
+    // surfaces always agree. Comparison is within-type only (an O(n²) pass
+    // over each type bucket; each title tokenized once).
+    {
+        use crate::similarity::{NEAR_DUPLICATE_INTENT_THRESHOLD, intent_tokens, similarity_of};
+        use std::collections::BTreeSet;
+
+        let mut by_type: BTreeMap<&str, Vec<(&str, BTreeSet<String>)>> = BTreeMap::new();
+        for artifact in store.iter() {
+            if is_external_artifact(artifact) {
+                continue;
+            }
+            let tokens = intent_tokens(&artifact.title);
+            if tokens.is_empty() {
+                continue;
+            }
+            by_type
+                .entry(artifact.artifact_type.as_str())
+                .or_default()
+                .push((artifact.id.as_str(), tokens));
+        }
+        for items in by_type.values_mut() {
+            items.sort_by(|a, b| a.0.cmp(b.0));
+            for i in 0..items.len() {
+                for j in (i + 1)..items.len() {
+                    let sim = similarity_of(&items[i].1, &items[j].1);
+                    if sim >= NEAR_DUPLICATE_INTENT_THRESHOLD {
+                        let pct = (sim * 100.0).round() as u32;
+                        diagnostics.push(Diagnostic {
+                            source_file: None,
+                            line: None,
+                            column: None,
+                            severity: Severity::Info,
+                            artifact_id: Some(items[j].0.to_string()),
+                            rule: "near-duplicate-intent".to_string(),
+                            message: format!(
+                                "title intent is {pct}% similar to '{}' — consolidate the two, \
+                                 differentiate the titles, or ignore if genuinely distinct",
+                                items[i].0
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
     diagnostics
 }
 


### PR DESCRIPTION
Implements #397. The AC the auto-triage drafted, with one empirically-driven refinement and one scoped deferral.

## Problem
`rivet add` rejects a duplicate **id** but nothing flags a duplicate **intent** — two artifacts that say the same thing under different ids — so a long-lived backlog accretes near-duplicate requirements.

## Heuristic — empirically calibrated first
Jaccard overlap of significant title tokens (lowercase, alphanumeric split, stopwords + sub-3-char tokens dropped), bounded `[0,1]`, threshold **0.6**. Before implementing I measured the false-positive rate on the rivet repo's own **158 requirements**: **0 pairs at 0.6** (1 at 0.5). So the default doesn't flood a well-differentiated backlog — confirmed on a real corpus, not just asserted.

Every component is inspectable (the shared/total token counts) — no opaque fuzzy number.

## Two surfaces, one shared implementation
New `rivet_core::similarity` module backs both so they can't disagree:
- **`rivet validate`** — a `near-duplicate-intent` **INFO** diagnostic per same-type, non-external artifact pair at/above threshold. INFO never blocks `validate`. Placed in the shared `validate_structural*` pass, so it runs on **both** the salsa and `--direct` paths (REQ-156 parity — no divergence).
- **`rivet add`** — a non-blocking `note: intent is N% similar to <ID> "<title>" — adding anyway` when the new title is similar to an existing same-type artifact; still adds.

## Verification (per AC)
- Fixture REQ-1/REQ-2 (near-identical) + REQ-3 (distinct) → `validate --direct --format json` yields **exactly one** `near-duplicate-intent`, on REQ-2; REQ-3 not named.
- `add` of a similar title → note on stderr + still succeeds (REQ-2); a distinct title → no note.
- rivet repo `validate` emits **0** `near-duplicate-intent` and still **PASS (204)**.
- `similarity` unit tests (5) + `near_duplicate_intent_validate_and_add` integration test; 1109 rivet-core lib + 112 cli_commands tests pass; clippy `--all-targets` + fmt clean; docs check PASS.

## Scoped deferral
The AC's per-rule `allow:` suppression in `rivet.yaml` is **deferred** (noted on #397): rivet has **no general diagnostic-suppression config** today, so that's net-new infra. INFO severity keeps the diagnostic non-disruptive in the meantime. Flagging rather than silently dropping it.

Implements: REQ-158

🤖 Generated with [Claude Code](https://claude.com/claude-code)