### PR TITLE
fix(add): deterministic near-duplicate note + correct REQ-158 self-count (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,17 @@
   say the same thing under different ids — so a backlog accreted near-dups.
   A new shared `rivet_core::similarity` signal (Jaccard overlap of significant,
   stopword-stripped title tokens, bounded `[0,1]`, threshold 0.6 — calibrated
-  to **zero** false positives on the rivet repo's own 158 requirements) now
-  backs two surfaces: `rivet validate` emits a non-blocking `near-duplicate-intent`
+  so the rivet repo's own 158 *requirements* produce zero pairs) now backs two
+  surfaces: `rivet validate` emits a non-blocking `near-duplicate-intent`
   **INFO** diagnostic for each same-type pair at/above threshold (on both the
   salsa and `--direct` paths), and `rivet add` prints a non-blocking
-  `note: intent is N% similar to <ID> …` before adding. Per-rule suppression in
-  `rivet.yaml` is a noted follow-up (no diagnostic-suppression config exists
-  yet; INFO keeps it non-disruptive meanwhile).
+  `note: intent is N% similar to <ID> …` before adding. Across *all* types the
+  rivet repo surfaces 10 such pairs — all genuine near-duplicates (e.g. two
+  `feature`s both titled "Property-based tests (proptest)"; two
+  `system-constraint`s stating identical-results-to-full-validation) — INFO, so
+  `validate` still PASSes. Per-rule suppression in `rivet.yaml` is a noted
+  follow-up (no diagnostic-suppression config exists yet; INFO keeps it
+  non-disruptive meanwhile).
 
 ### Fixed
 

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4607,8 +4607,10 @@ artifacts:
         - `rivet add` with a title similar to an existing same-type artifact
           prints a `note: intent is N% similar to …` to stderr and still
           succeeds; a distinct title prints no note.
-        - `rivet validate` on the rivet repo emits zero `near-duplicate-intent`
-          diagnostics and still PASS.
+        - The rivet repo's 158 `requirement`s produce zero
+          `near-duplicate-intent` diagnostics; across all types the repo
+          surfaces only true-positive pairs (e.g. two `feature`s sharing a
+          title), all INFO, so `rivet validate` still PASS.
         - `cargo test -p rivet-core --lib similarity` and `cargo test -p
           rivet-cli --test cli_commands near_duplicate_intent_validate_and_add`
           pass.

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -13962,9 +13962,19 @@ fn cmd_add(
                 continue;
             }
             let sim = intent_similarity(title, &other.title);
-            if sim >= NEAR_DUPLICATE_INTENT_THRESHOLD
-                && best.as_ref().is_none_or(|(b, _, _)| sim > *b)
-            {
+            if sim < NEAR_DUPLICATE_INTENT_THRESHOLD {
+                continue;
+            }
+            // Pick the most-similar existing artifact; break ties by lowest id
+            // so the note is DETERMINISTIC. `store.iter()` is HashMap order, so
+            // without an explicit tie-break two equally-similar artifacts (e.g.
+            // titles identical after stopword-stripping) would surface
+            // unpredictably across runs (REQ-158 regression caught in CI).
+            let better = match best {
+                None => true,
+                Some((b_sim, b_id, _)) => sim > b_sim || (sim == b_sim && other.id.as_str() < b_id),
+            };
+            if better {
                 best = Some((sim, other.id.as_str(), other.title.as_str()));
             }
         }


### PR DESCRIPTION
Two corrections to #413 (REQ-158), one of which **de-flakes `main`**.

## 1. Nondeterminism bug (caught by CI — de-flakes main)
The proptest job (which runs the full `cli_commands` suite) failed on my new `near_duplicate_intent_validate_and_add` test:
```
add must emit a near-duplicate note naming REQ-1; stderr: note: intent is 100% similar to existing REQ-2 …
```
Root cause: the `rivet add` near-duplicate note picked the most-similar existing artifact via a strict `>` over `store.iter()` (HashMap order). When two artifacts are **equally** similar (the fixture's REQ-1/REQ-2 have identical tokens after stopword-stripping), it named whichever the hash yielded first — **nondeterministic**. Passed locally (REQ-1), failed in CI (REQ-2), same code.

Fix: break ties by **lowest id**, so the note is reproducible. The `validate` near-duplicate pass already sorts by id and was never affected. Verified stable across 5 local runs.

Since #413 is already merged, this test is flaky on `main` right now — merging this fixes it.

## 2. Doc correction (the original purpose of this PR)
I'd claimed `rivet validate` "emits zero near-duplicate-intent" on the rivet repo — a verification error (grepped the rule id in *text* output, where it only appears in JSON). Actual count: **10**, all true positives (e.g. `TEST-006`/`FEAT-013`, both type `feature`, identical title; `SC-LSP-008`/`SC-11`, same `system-constraint`). All INFO, `validate` still PASSes. CHANGELOG + REQ-158 acceptance corrected to match.

clippy `--all-targets` + fmt clean; the near-duplicate test now stable 5/5.

Fixes: REQ-158

🤖 Generated with [Claude Code](https://claude.com/claude-code)