### PR TITLE
feat(store): deterministic iter_sorted() + document iter() nondeterminism (REQ-159, #415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### Added
 
+- **REQ-159 / #415 — `Store::iter_sorted()` for deterministic iteration.**
+  `Store::iter()` is `HashMap`-ordered (nondeterministic per process), which is
+  how the REQ-158 `rivet add` note picked a different artifact in CI than
+  locally and made the proptest job flaky. `iter()` now documents that its
+  order is unspecified and points at the new `iter_sorted()` (ascending by id)
+  for callers that produce stable output or select a representative. Migrating
+  existing call sites and an ordered-map backing are tracked as follow-ups on
+  #415.
+
 - **REQ-158 / #397 — near-duplicate-intent detection.** `rivet add` rejects a
   duplicate *id* but nothing flagged a duplicate *intent* — two artifacts that
   say the same thing under different ids — so a backlog accreted near-dups.

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4625,3 +4625,38 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-004
+
+  - id: REQ-159
+    type: requirement
+    title: "Store::iter() order is nondeterministic — provide a deterministic iter_sorted() and document the footgun"
+    status: implemented
+    description: |
+      Self-found while landing REQ-158 (#415). `Store::iter()` returns
+      `HashMap::values()`, whose order varies per process. Any caller that
+      produces stable output or selects one representative among ties over
+      `store.iter()` is silently nondeterministic — which is exactly how the
+      REQ-158 `rivet add` near-duplicate note picked REQ-1 locally but REQ-2 in
+      CI (same code, different hash seed), making the proptest job flaky on main
+      until #414 added an explicit tie-break.
+
+      Minimal, non-breaking hardening: document on `iter()` that order is
+      unspecified and add `Store::iter_sorted()` (ascending by id) so the
+      deterministic path is the easy one. Migrating existing
+      `store.iter().collect::<Vec>()` output sites and the larger "back the
+      store with an ordered map" option are deferred to #415 (each needs a
+      per-site audit; some already sort downstream).
+
+      Acceptance:
+        - `Store::iter_sorted()` yields artifacts ascending by `id` regardless
+          of insertion order.
+        - `iter()`'s doc-comment states the order is nondeterministic and
+          points at `iter_sorted()`.
+        - `cargo test -p rivet-core --lib iter_sorted_is_deterministic_by_id`
+          passes; `rivet validate` on the rivet repo still PASS.
+    tags: [refactor, determinism, footgun, dogfooding, self-found, issue-415]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-158

--- a/rivet-core/src/store.rs
+++ b/rivet-core/src/store.rs
@@ -120,10 +120,28 @@ impl Store {
             .unwrap_or(&[])
     }
 
-    /// Iterate over all artifacts.
+    /// Iterate over all artifacts in **unspecified, nondeterministic order**.
+    ///
+    /// The backing store is a `HashMap`, so iteration order varies between
+    /// processes. Any caller that produces stable output (a printed list, an
+    /// export) or selects a single representative when several tie (e.g.
+    /// "the most-similar artifact") MUST sort or tie-break explicitly —
+    /// otherwise the result is silently nondeterministic and flaky in CI.
+    /// See [`Self::iter_sorted`] for the common "iterate by id" case and
+    /// issue #415 (REQ-159) for the footgun this prevents.
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &Artifact> {
         self.artifacts.values()
+    }
+
+    /// Iterate over all artifacts in a **deterministic** order — ascending by
+    /// `id`. Prefer this over [`Self::iter`] whenever the iteration feeds
+    /// user-facing output or a representative-selection, so results are
+    /// reproducible across runs (REQ-159 / #415).
+    pub fn iter_sorted(&self) -> impl Iterator<Item = &Artifact> {
+        let mut artifacts: Vec<&Artifact> = self.artifacts.values().collect();
+        artifacts.sort_by(|a, b| a.id.cmp(&b.id));
+        artifacts.into_iter()
     }
 
     /// Total number of artifacts.
@@ -371,6 +389,24 @@ mod tests {
         assert!(
             !populated.is_empty(),
             "Store with one inserted artifact must report non-empty",
+        );
+    }
+
+    /// REQ-159 / #415: `iter_sorted` yields artifacts ascending by id
+    /// regardless of insertion order, so callers that need deterministic
+    /// output/selection can rely on it (unlike the HashMap-ordered `iter`).
+    #[test]
+    fn iter_sorted_is_deterministic_by_id() {
+        let mut store = Store::new();
+        // Insert out of order.
+        for id in ["REQ-010", "REQ-002", "REQ-100", "REQ-001", "REQ-020"] {
+            store.upsert(minimal_artifact(id, "requirement"));
+        }
+        let ids: Vec<&str> = store.iter_sorted().map(|a| a.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["REQ-001", "REQ-002", "REQ-010", "REQ-020", "REQ-100"],
+            "iter_sorted must be ascending by id"
         );
     }
 }


### PR DESCRIPTION
Implements #415 (the safe, non-breaking core). Self-found while landing #413/#414.

## Why
`Store::iter()` returns `HashMap::values()` — nondeterministic order per process. Any caller producing stable output or selecting one representative among ties is silently nondeterministic. Concrete proof: the REQ-158 `rivet add` near-duplicate note picked `REQ-1` locally but `REQ-2` in CI (same code, different hash seed), making the Proptest job **flaky on main** until #414 added a lowest-id tie-break.

## What
- **Document** on `iter()` that order is unspecified and output/selection callers must sort.
- **Add `Store::iter_sorted()`** (ascending by id) so the deterministic path is the easy one.

Non-breaking (additive). Migrating the existing `store.iter().collect::<Vec>()` sites (e.g. `query.rs:89`) and the larger "back the store with an ordered map" option are deferred to #415 — each needs a per-site audit and some already sort downstream.

## Verify
- New unit test `iter_sorted_is_deterministic_by_id` (insert out of order → ascending by id).
- `rivet validate` on the rivet repo PASS; docs check PASS; clippy `--all-targets` + fmt clean.

Implements: REQ-159

🤖 Generated with [Claude Code](https://claude.com/claude-code)