### PR TITLE
fix(query,export,migrate): deterministic order over the HashMap-backed store (REQ-160, #415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **REQ-160 / #415 — deterministic `list` / export / migrate output.**
+  `query::execute` (behind `rivet list`, the MCP query tool, and `{{query:…}}`
+  embeds) now returns results sorted by id — `rivet list`'s default path
+  previously didn't sort, so order was nondeterministic. `rivet export`
+  (ReqIF/Zola) and `rivet schema migrate` likewise sort before emitting, so
+  exports and generated migrations are byte-reproducible across runs. Built on
+  REQ-159's `iter_sorted()`.
+
 ### Added
 
 - **REQ-159 / #415 — `Store::iter_sorted()` for deterministic iteration.**

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4660,3 +4660,38 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-158
+
+  - id: REQ-160
+    type: requirement
+    title: "Make query/export/migrate output deterministic by sorting the Store::iter() consumers"
+    status: implemented
+    description: |
+      Follow-up to REQ-159 (#415): migrate the `store.iter().collect()` sites
+      that produce ordered, user-facing output so they are reproducible across
+      runs (the store is HashMap-ordered).
+
+      Audited every site. Order-irrelevant ones (collected into `HashSet<id>`
+      membership sets) were left as-is; `render/externals.rs` already sorted.
+      The output-producing sites fixed:
+        - `query::execute` now returns results ascending by `id` — this is the
+          shared result set behind `rivet list` (whose default path did NOT
+          sort), the MCP query tool, and `{{query:…}}` embeds, so all of them
+          become deterministic at one chokepoint.
+        - `cmd_export` (ReqIF/etc.) and `cmd_export_zola` sort by id before
+          emitting, so exports are byte-reproducible.
+        - `rivet schema migrate` sorts artifacts before computing the rewrite
+          map so the generated migration is reproducible.
+
+      Acceptance:
+        - `rivet list --format json` produces identical id order across runs.
+        - `cargo test -p rivet-core --lib execute_returns_results_sorted_by_id`
+          passes; export_reqif_roundtrip / export_zola / migrate_integration
+          suites still pass.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [refactor, determinism, reproducibility, issue-415]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-159

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -7786,7 +7786,9 @@ fn cmd_export(
 
     let ctx = ProjectContext::load(cli)?;
     let store = apply_baseline_scope(ctx.store, baseline_name, &ctx.config);
-    let artifacts: Vec<_> = store.iter().cloned().collect();
+    // Sorted by id so the exported artifact (ReqIF/etc.) is byte-reproducible
+    // across runs (REQ-159 / #415; the store is HashMap-ordered).
+    let artifacts: Vec<_> = store.iter_sorted().cloned().collect();
     let config = AdapterConfig::default();
 
     let bytes = match format {
@@ -7845,8 +7847,9 @@ fn cmd_export_zola(
     let doc_store = ctx.doc_store.unwrap_or_default();
     let graph = rivet_core::links::LinkGraph::build(&store, &ctx.schema);
 
-    // Apply s-expression filter if provided.
-    let artifacts: Vec<&rivet_core::model::Artifact> = if let Some(filter_src) = sexpr_filter {
+    // Apply s-expression filter if provided. Sorted by id so the exported
+    // site is reproducible across runs (REQ-159 / #415; store is HashMap-order).
+    let mut artifacts: Vec<&rivet_core::model::Artifact> = if let Some(filter_src) = sexpr_filter {
         let expr = rivet_core::sexpr_eval::parse_filter(filter_src).map_err(|errs| {
             let msgs: Vec<String> = errs.iter().map(|e| e.to_string()).collect();
             anyhow::anyhow!("invalid filter: {}", msgs.join("; "))
@@ -7858,6 +7861,7 @@ fn cmd_export_zola(
     } else {
         store.iter().collect()
     };
+    artifacts.sort_by(|a, b| a.id.cmp(&b.id));
 
     // Slugs of the artifacts that actually get a page in this export. Used to
     // decide whether a cross-link / wiki-link can be emitted as a Zola internal

--- a/rivet-cli/src/migrate_cmd.rs
+++ b/rivet-cli/src/migrate_cmd.rs
@@ -214,8 +214,10 @@ pub fn cmd_plan(
     let target_schema = rivet_core::load_schemas(&target_schemas, schemas_dir)
         .with_context(|| format!("loading target schemas {target_schemas:?}"))?;
 
-    // 4. Compute the rewrite map.
-    let artifacts: Vec<rivet_core::model::Artifact> = project.store.iter().cloned().collect();
+    // 4. Compute the rewrite map. Sorted by id so the generated migration
+    // (.rivet/migrations/<ts>/) is reproducible across runs (REQ-159 / #415).
+    let artifacts: Vec<rivet_core::model::Artifact> =
+        project.store.iter_sorted().cloned().collect();
     let rewrite = migrate::diff_artifacts(recipe, &artifacts, Some(&target_schema));
 
     // 5. Persist to .rivet/migrations/<ts>/.

--- a/rivet-core/src/query.rs
+++ b/rivet-core/src/query.rs
@@ -85,8 +85,15 @@ impl Query {
 }
 
 /// Execute a query against the store.
+///
+/// Results are returned in a deterministic order — ascending by `id` — so
+/// `rivet list`, the MCP query tool, and `{{query:…}}` embeds produce stable,
+/// reproducible output across runs (the store itself is HashMap-ordered;
+/// REQ-159 / #415).
 pub fn execute<'a>(store: &'a Store, query: &Query) -> Vec<&'a Artifact> {
-    store.iter().filter(|a| query.matches(a)).collect()
+    let mut results: Vec<&Artifact> = store.iter().filter(|a| query.matches(a)).collect();
+    results.sort_by(|a, b| a.id.cmp(&b.id));
+    results
 }
 
 // ── S-expression query execution ────────────────────────────────────────
@@ -193,6 +200,22 @@ mod tests {
         let schema = Schema::merge(&[]);
         let graph = LinkGraph::build(&store, &schema);
         (store, schema, graph)
+    }
+
+    #[test]
+    fn execute_returns_results_sorted_by_id() {
+        // REQ-159 / #415: deterministic order regardless of insertion order.
+        let (store, _schema, _graph) = build(vec![
+            plain("REQ-030", "requirement", None, &[]),
+            plain("REQ-002", "requirement", None, &[]),
+            plain("REQ-100", "requirement", None, &[]),
+            plain("REQ-001", "requirement", None, &[]),
+        ]);
+        let ids: Vec<&str> = execute(&store, &Query::default())
+            .iter()
+            .map(|a| a.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["REQ-001", "REQ-002", "REQ-030", "REQ-100"]);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #416 (REQ-159) — the site-migration half of #415.

## What
Audited every `store.iter().collect()` site. Order-irrelevant ones (`HashSet<id>` membership) left as-is; `render/externals.rs` already sorted. Fixed the **output-producing** sites:

- **`query::execute`** → returns results ascending by `id`. This is the shared set behind `rivet list` (whose **default path did not sort** → nondeterministic order), the MCP query tool, and `{{query:…}}` embeds — so all become deterministic at one chokepoint.
- **`cmd_export`** (ReqIF/etc.) + **`cmd_export_zola`** → sort by id before emitting → byte-reproducible exports (matters for diffing/CI).
- **`rivet schema migrate`** → sorts before computing the rewrite map → reproducible generated migration.

## Verify
- `rivet list --format json` id order identical across runs.
- New `execute_returns_results_sorted_by_id` unit test.
- Order-sensitive integration suites still pass: `export_reqif_roundtrip` (2), `export_zola` (2), `migrate_integration` (11); rivet-core query (19) + cli_commands (112) green.
- `rivet validate` PASS; docs check PASS; clippy `--all-targets` + fmt clean.

With this, #415 is fully addressed (core + sites); the optional "back the store with an ordered map" remains as a possible future simplification but isn't needed now.

Implements: REQ-160

🤖 Generated with [Claude Code](https://claude.com/claude-code)