### PR TITLE
feat(validate): --structural gates on integrity only, via Diagnostic::is_structural() (REQ-161, #408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- **REQ-161 / #408 — `rivet validate --structural`.** Gates only on
+  structural-integrity diagnostics (broken links, duplicate ids, parse errors,
+  bad link targets, cardinality, schema-rule inconsistencies), hiding
+  coverage/lint findings (missing/extra/typo'd fields, orphans, prose-mention,
+  near-duplicates). This gives bulk-edit and status-promotion workflows a
+  meaningful "did I break the graph?" check independent of coverage noise —
+  what spar/sigil hand-rolled as a `0 broken cross-refs` gate. Backed by a new
+  `Diagnostic::is_structural()` classification (explicit allowlist; a unit test
+  enumerates every built-in rule). The rivet repo `validate --structural`
+  PASSes with 0 shown.
+
 ### Fixed
 
 - **REQ-160 / #415 — deterministic `list` / export / migrate output.**

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4695,3 +4695,53 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-159
+
+  - id: REQ-161
+    type: requirement
+    title: "rivet validate --structural: gate on graph/parse/type integrity only, separate from coverage/lint"
+    status: implemented
+    description: |
+      From issue #408 (and the recurring #353/#355 ask): `rivet validate`'s
+      FAIL/PASS lumps structural integrity (broken graph) together with
+      coverage/lint findings (incomplete/non-compliant), so a bulk status-flip
+      or edit can't tell "did I break the graph?" from "the project is still
+      incomplete". spar and sigil both hand-rolled a `0 broken cross-refs` gate
+      for exactly this.
+
+      Add `Diagnostic::is_structural()` — an explicit allowlist of the
+      structural rule ids: artifact-parse-error, duplicate-artifact-id,
+      known-type, unknown-link-type, link-target-type, cardinality, broken-link,
+      doc-broken-ref, yaml-type-coercion, conditional-rule-consistency,
+      coverage-rule-consistency. Everything else — including required-field,
+      unknown-field, status-allowed-values, prose-mention, near-duplicate-intent,
+      orphan, and all schema-defined coverage/status-gate rules — is coverage/
+      lint. (The three borderline rules required-field / unknown-field /
+      status-allowed-values are classified coverage by design: an
+      incomplete/extra/typo'd field doesn't break the graph.)
+
+      `rivet validate --structural` retains only structural diagnostics before
+      counting/display, so the shown set, counts, and PASS/FAIL exit all reflect
+      structural-only. The classification is a method on Diagnostic (no rename
+      of validate_structural*, per the #408 option-b).
+
+      Acceptance:
+        - `Diagnostic::is_structural()` returns true for exactly the structural
+          rule ids; a unit test enumerates every built-in rule and asserts its
+          class.
+        - On a project whose only error is a broken link, `rivet validate
+          --structural` FAILs and shows the broken-link diagnostic; on a project
+          whose only issues are coverage/lint, `--structural` PASSes.
+        - `rivet validate --structural` on the rivet repo PASSes with 0
+          diagnostics shown (its 200+ warnings are all coverage/lint).
+        - Unit test `is_structural_classifies_every_builtin_rule` + CLI test
+          `validate_structural_gates_on_structural_only` pass.
+
+      Deferred: a per-rule `allow:` config and any rename of the
+      `validate_structural*` functions (their name is unrelated to this gate).
+    tags: [feature, validation, gating, dx, issue-408, issue-353, issue-355]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-004

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -394,6 +394,17 @@ enum Command {
         /// checking.
         #[arg(long = "with-externals-validate")]
         with_externals_validate: bool,
+
+        /// Gate on STRUCTURAL integrity only — show and fail on just the
+        /// diagnostics that mean the graph/parse/type model is broken
+        /// (broken links, duplicate ids, parse errors, bad link targets,
+        /// cardinality, schema-rule inconsistencies), hiding coverage/lint
+        /// findings (missing fields, orphans, prose-mention, near-duplicates,
+        /// status enums). A status flip or coverage gap can't change the
+        /// structural set, so this is the "did I break the graph?" gate for
+        /// bulk-edit workflows (#408).
+        #[arg(long)]
+        structural: bool,
     },
 
     /// Show a single artifact by ID
@@ -1963,6 +1974,7 @@ fn run(cli: Cli) -> Result<bool> {
             check_remote_sources,
             strict_orphans,
             with_externals_validate,
+            structural,
         } => {
             // REQ-125: `--explain <ID>` is a focused single-artifact view,
             // not a full validate run.
@@ -1987,6 +1999,7 @@ fn run(cli: Cli) -> Result<bool> {
                     *check_remote_sources,
                     *strict_orphans,
                     *with_externals_validate,
+                    *structural,
                 )
             }
         }
@@ -4665,6 +4678,7 @@ fn cmd_validate(
     check_remote_sources: bool,
     strict_orphans: bool,
     with_externals_validate: bool,
+    structural_only: bool,
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let fail_on_threshold = parse_fail_on(fail_on)?;
@@ -5178,6 +5192,15 @@ fn cmd_validate(
     // ID and is correctly kept; `artifact-parse-error` diagnostics carry
     // no artifact_id and are kept.
     diagnostics.retain(|d| !d.artifact_id.as_deref().is_some_and(|id| id.contains(':')));
+
+    // REQ-161 / #408: `--structural` gates on graph/parse/type integrity only.
+    // Retain just the structural diagnostics BEFORE counting/display, so the
+    // shown set, the error/warning counts, and the PASS/FAIL exit all reflect
+    // structural-only. Coverage/lint findings (missing fields, orphans,
+    // prose-mention, near-duplicates, status enums) are dropped from this view.
+    if structural_only {
+        diagnostics.retain(|d| d.is_structural());
+    }
 
     let errors = diagnostics
         .iter()
@@ -9040,6 +9063,7 @@ fn cmd_diff(
                     check_remote_sources: false,
                     strict_orphans: false,
                     with_externals_validate: false,
+                    structural: false,
                 },
             };
             let head_cli = Cli {
@@ -9066,6 +9090,7 @@ fn cmd_diff(
                     check_remote_sources: false,
                     strict_orphans: false,
                     with_externals_validate: false,
+                    structural: false,
                 },
             };
             let bc = ProjectContext::load(&base_cli)?;

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5591,3 +5591,59 @@ fn near_duplicate_intent_validate_and_add() {
         "a distinct title must not emit a near-duplicate note; stderr: {ok_err}"
     );
 }
+
+/// REQ-161 / #408: `rivet validate --structural` gates only on structural
+/// integrity. A broken link (structural) makes it FAIL; a project whose only
+/// problems are coverage/lint (a missing required field) PASSes `--structural`
+/// while normal validate FAILs.
+#[test]
+fn validate_structural_gates_on_structural_only() {
+    let mk = |body: &str| {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let dir = tmp.path().to_path_buf();
+        std::fs::write(
+            dir.join("rivet.yaml"),
+            "project:\n  name: t\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+             sources:\n  - path: artifacts\n    format: generic-yaml\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+        std::fs::write(dir.join("artifacts").join("r.yaml"), body).unwrap();
+        (tmp, dir)
+    };
+    let run = |dir: &std::path::Path, args: &[&str]| {
+        let mut a = vec!["--project", dir.to_str().unwrap(), "validate", "--direct"];
+        a.extend_from_slice(args);
+        Command::new(rivet_bin())
+            .args(&a)
+            .output()
+            .expect("validate")
+    };
+
+    // (a) A broken link is STRUCTURAL -> --structural still FAILs.
+    let (_t1, d1) = mk("artifacts:\n  - id: REQ-1\n    type: requirement\n    \
+         title: One\n    status: draft\n    links:\n      - type: traces-to\n        target: GHOST-1\n");
+    let s1 = run(&d1, &["--structural"]);
+    assert!(
+        !s1.status.success(),
+        "a broken link must FAIL --structural; stdout:\n{}",
+        String::from_utf8_lossy(&s1.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&s1.stdout).contains("does not exist"),
+        "the broken-link diagnostic must be shown under --structural"
+    );
+
+    // (b) A schema-typed missing required field is COVERAGE/LINT. Use a type
+    // with a required field; omit it. --structural PASSes even if normal fails.
+    // (Use an undeclared field which is the unknown-field coverage rule —
+    // simplest cross-schema case that is non-structural by our taxonomy.)
+    let (_t2, d2) = mk("artifacts:\n  - id: REQ-1\n    type: requirement\n    \
+         title: One\n    status: draft\n    fields:\n      bogus_undeclared: x\n");
+    let s2 = run(&d2, &["--structural"]);
+    assert!(
+        s2.status.success(),
+        "a project whose only issues are coverage/lint must PASS --structural; stdout:\n{}",
+        String::from_utf8_lossy(&s2.stdout)
+    );
+}

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -149,6 +149,43 @@ impl Diagnostic {
             column: None,
         }
     }
+
+    /// REQ-161 / #408: whether this diagnostic reflects a **structural**
+    /// integrity problem (a malformed graph / parse / type — the artifact set
+    /// is broken) as opposed to a **coverage/lint** finding (the project is
+    /// merely incomplete or non-compliant).
+    ///
+    /// Structural failures are the ones a status flip or a coverage gap can
+    /// never touch: a broken link, a duplicate id, an unparseable file, a link
+    /// to a forbidden target type, a cardinality violation, a schema-rule
+    /// inconsistency. `rivet validate --structural` gates only on these, so a
+    /// bulk-edit / status-promotion workflow has a meaningful "did I break the
+    /// graph?" check independent of the coverage/lint noise it can't fix in one
+    /// pass (spar/sigil both hand-rolled a `0 broken cross-refs` gate for
+    /// exactly this — see #353/#355).
+    ///
+    /// This is an explicit allowlist: everything else — including all
+    /// schema-defined coverage/status-gate rules (whose `rule` is the rule's
+    /// own name) — is treated as coverage/lint. `required-field`,
+    /// `unknown-field`, and `status-allowed-values` are deliberately
+    /// classified as coverage (an incomplete/extra/typo'd field doesn't break
+    /// the graph); revisit if a project wants them gated.
+    pub fn is_structural(&self) -> bool {
+        matches!(
+            self.rule.as_str(),
+            "artifact-parse-error"
+                | "duplicate-artifact-id"
+                | "known-type"
+                | "unknown-link-type"
+                | "link-target-type"
+                | "cardinality"
+                | "broken-link"
+                | "doc-broken-ref"
+                | "yaml-type-coercion"
+                | "conditional-rule-consistency"
+                | "coverage-rule-consistency"
+        )
+    }
 }
 
 impl std::fmt::Display for Diagnostic {
@@ -3296,6 +3333,49 @@ then:
             .into_iter()
             .filter(|d| d.rule == "prose-mention-without-typed-link")
             .collect()
+    }
+
+    // rivet: verifies REQ-161
+    #[test]
+    fn is_structural_classifies_every_builtin_rule() {
+        let mk = |rule: &str| Diagnostic::new(Severity::Error, None, rule, "x");
+
+        // STRUCTURAL — a broken graph/parse/type model.
+        for rule in [
+            "artifact-parse-error",
+            "duplicate-artifact-id",
+            "known-type",
+            "unknown-link-type",
+            "link-target-type",
+            "cardinality",
+            "broken-link",
+            "doc-broken-ref",
+            "yaml-type-coercion",
+            "conditional-rule-consistency",
+            "coverage-rule-consistency",
+        ] {
+            assert!(mk(rule).is_structural(), "{rule} must be structural");
+        }
+
+        // COVERAGE / LINT — incomplete or non-compliant, not malformed.
+        for rule in [
+            "required-field",
+            "unknown-field",
+            "allowed-values",
+            "status-allowed-values",
+            "prose-mention-without-typed-link",
+            "near-duplicate-intent",
+            "orphan-artifact",
+            // schema-defined coverage / status-gate rules carry their own
+            // rule name, e.g.:
+            "swe1-has-verification",
+            "must-needs-rationale",
+        ] {
+            assert!(
+                !mk(rule).is_structural(),
+                "{rule} must be classified coverage/lint, not structural"
+            );
+        }
     }
 
     // rivet: verifies REQ-004


### PR DESCRIPTION
Implements #408. You delegated the 3 borderline classifications — I went with my recommendation (all coverage/lint), documented inline.

## Why
`rivet validate`'s PASS/FAIL lumps **structural integrity** (a broken graph) with **coverage/lint** (incomplete/non-compliant). A bulk status-flip or edit can't tell "did I break the graph?" from "still incomplete". spar and sigil both hand-rolled a `0 broken cross-refs` gate for exactly this (#353/#355).

## What
- **`Diagnostic::is_structural()`** — explicit allowlist: `artifact-parse-error`, `duplicate-artifact-id`, `known-type`, `unknown-link-type`, `link-target-type`, `cardinality`, `broken-link`, `doc-broken-ref`, `yaml-type-coercion`, `conditional-rule-consistency`, `coverage-rule-consistency`. Everything else (including all schema-defined coverage/status-gate rules) is coverage/lint.
- **Borderline calls (you delegated):** `required-field`, `unknown-field`, `status-allowed-values` → **coverage/lint** (an incomplete/extra/typo'd field doesn't break the graph). Easy to flip later if you disagree — they're one line in the allowlist.
- **`rivet validate --structural`** retains only structural diagnostics before counting/display, so shown set + counts + PASS/FAIL all reflect structural-only.
- **No rename** of `validate_structural*` (option b) — the classification is a `Diagnostic` method, decoupled from that misnamed function.

## Verify
- rivet repo `validate --structural` → **PASS, 0 shown** (its 207 warnings are all coverage/lint).
- Broken-link fixture → `--structural` FAILs and shows it; coverage-only fixture → `--structural` PASSes.
- `is_structural_classifies_every_builtin_rule` (enumerates every built-in rule) + `validate_structural_gates_on_structural_only` CLI test.
- clippy `--all-targets` + fmt clean; docs check PASS. `--help` documents the flag.

## Deferred
Per-rule `allow:` config (net-new infra) and any `validate_structural*` rename.

Implements: REQ-161

🤖 Generated with [Claude Code](https://claude.com/claude-code)