### PR TITLE
ci(compliance): forward version-switcher + back-link inputs to the report action (REQ-163, #420)

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -11,13 +11,21 @@ on:
   workflow_call:
     inputs:
       version:
-        description: 'Version label for the report'
+        description: 'Version label shown in the report header + version switcher current entry'
         type: string
         default: ''
       homepage:
-        description: 'Homepage URL for navigation back-link'
+        description: 'Homepage URL for the report "back" navigation link'
         type: string
         default: ''
+      other-versions:
+        description: >
+          JSON array of OTHER report versions for the switcher dropdown, each
+          {"label","path"} — e.g. [{"label":"v0.1.0","path":"../v0.1.0/"}].
+          Required for the cross-version selector; the caller must enumerate
+          the published versions (a single run can't know them). REQ-163 / #420.
+        type: string
+        default: '[]'
       theme:
         description: 'Color theme (dark or light)'
         type: string
@@ -51,8 +59,11 @@ jobs:
         id: report
         uses: pulseengine/rivet/.github/actions/compliance@main
         with:
-          version: ${{ inputs.version }}
+          # The action's label input is `report-label`; passing `version`
+          # here was silently ignored (REQ-163 / #420).
+          report-label: ${{ inputs.version }}
           homepage: ${{ inputs.homepage }}
+          other-versions: ${{ inputs.other-versions }}
           theme: ${{ inputs.theme }}
           offline: ${{ inputs.offline }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,13 @@ jobs:
         uses: ./.github/actions/compliance
         with:
           theme: dark
+          # REQ-163 / #420: label the report with the release tag and give it
+          # a "back" navigation link, so even the GitHub-artifact bundle isn't
+          # nav-less. The cross-version switcher (`other-versions`) still has
+          # to come from the site-publishing pipeline, which is the only layer
+          # that knows the full set of published versions.
+          report-label: ${{ github.ref_name }}
+          homepage: https://pulseengine.eu/projects/
           # REQ-090: ship the full audit-deliverable bundle, not the
           # single-page nav-shell form. Multi-page emission is now
           # ~50 MB total on the rivet corpus (REQ-088's shared-assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 
 ### Fixed
 
+- **REQ-163 / #420 — compliance CI now forwards the version-switcher + back-link
+  inputs.** The published report for 0.15.0 lost the version selector and "back"
+  nav that 0.1.0 has. `rivet export` still supports them (`--homepage`,
+  `--versions`, `--version-label`), but the CI didn't pass them: the reusable
+  `compliance.yml` sent `version:` (ignored — the action input is `report-label`)
+  and never exposed `other-versions`, and `release.yml` passed no homepage.
+  `compliance.yml` now maps `version → report-label` + adds an `other-versions`
+  passthrough, and `release.yml` labels with the tag and sets a default homepage.
+  (The cross-version switcher needs the full version list, which only the
+  pulseengine.eu site pipeline knows — root-cause fix tracked on #420.)
+
 - **REQ-160 / #415 — deterministic `list` / export / migrate output.**
   `query::execute` (behind `rivet list`, the MCP query tool, and `{{query:…}}`
   embeds) now returns results sorted by id — `rivet list`'s default path

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4695,3 +4695,42 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-159
+
+  - id: REQ-163
+    type: requirement
+    title: "Compliance CI must forward the version switcher + back-link inputs to the report action"
+    status: implemented
+    description: |
+      Maintainer reported (#420) that the published compliance report for
+      0.15.0 lost the version selector and the "back" navigation that 0.1.0
+      has. Root cause traced: `rivet export --format html` still supports
+      `--homepage` (back-link), `--versions` (switcher), and `--version-label`,
+      and the compliance action exposes them as `homepage` / `other-versions` /
+      `report-label`. But the CI never supplied them:
+        - the reusable `compliance.yml` workflow passed `version:` (not an
+          action input — silently ignored; the action's label input is
+          `report-label`) and never exposed `other-versions`, so any caller
+          using it could not produce a switcher;
+        - `release.yml`'s compliance step passed no `homepage`/`report-label`.
+
+      Fix (this repo's part): `compliance.yml` now maps `version ->
+      report-label` and adds an `other-versions` passthrough input; `release.yml`
+      labels the report with the release tag and sets a default `homepage`.
+      The cross-version switcher inherently needs the full published-version
+      list, which only the pulseengine.eu site-publishing pipeline knows — that
+      remains the root-cause fix for the live regression (tracked on #420, plus
+      the expired site TLS cert).
+
+      Acceptance:
+        - `compliance.yml` exposes an `other-versions` input and passes
+          `report-label` + `other-versions` to the action.
+        - `release.yml` passes `report-label` + `homepage` to the compliance
+          action.
+        - Both workflow files parse as valid YAML.
+    tags: [ci, compliance, reporting, dx, issue-420, maintainer-reported]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-090


### PR DESCRIPTION
The in-repo half of #420 (the maintainer's compliance-report regression).

## Why
The published 0.15.0 compliance report lost the **version selector** and **"back" navigation** that 0.1.0 has. `rivet export --format html` still supports `--homepage` (back-link), `--versions` (switcher), `--version-label`, and the compliance action exposes them as `homepage` / `other-versions` / `report-label` — but the CI never passed them:
- **`compliance.yml`** sent `version:` (not an action input → **silently ignored**; the label input is `report-label`) and **never exposed `other-versions`**, so any caller using the reusable workflow couldn't produce a switcher.
- **`release.yml`** passed no `homepage`/`report-label`.

## Fix
- `compliance.yml`: map `version → report-label`, add an `other-versions` passthrough input, forward both to the action.
- `release.yml`: label the report with the release tag (`github.ref_name`) and set a default `homepage`.

Both workflow files parse as valid YAML. Only trusted inputs are forwarded (no event data into `run:`).

## Out of scope (root-cause, tracked on #420)
The cross-version switcher inherently needs the **full published-version list**, which only the **pulseengine.eu site-publishing pipeline** knows — that's where the live regression must be fixed (re-publish 0.15.0 passing `--versions`). Also flagged on #420: the site's **TLS cert is expired**.

Implements: REQ-163