### PR TITLE
chore(git): union-merge driver for CHANGELOG to cut parallel-PR conflicts (REQ-164, #422)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,13 @@
 # oracle; without this, the queries fall back to line-range logs which
 # re-include lines across refactors.
 *.rs diff=rust
+
+# REQ-164 / #422: every PR adds a CHANGELOG entry at the top of
+# `[Unreleased]`, so parallel PRs always conflict here. The built-in `union`
+# merge driver keeps BOTH sides' added lines instead of conflicting — safe for
+# an append-only prose log (worst case: an out-of-order entry, trivially
+# fixed). NOT applied to artifacts/*.yaml: union-concatenating conflicting
+# YAML hunks could silently produce malformed/misordered YAML, which is worse
+# than a conflict that forces a human to look — append REQs at EOF / use
+# `rivet add` there instead (#422).
+CHANGELOG.md merge=union

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4745,3 +4745,33 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-004
+
+  - id: REQ-164
+    type: requirement
+    title: "Reduce parallel-PR merge conflicts in append-only ledgers (CHANGELOG union driver)"
+    status: implemented
+    description: |
+      Self-found while landing several one-REQ-per-PR changes in one session
+      (#422): every PR conflicts in CHANGELOG.md (entries at the top of
+      `[Unreleased]`) and artifacts/requirements.yaml, forcing a manual
+      rebase+resolve each time.
+
+      Add `.gitattributes` `CHANGELOG.md merge=union` so git's built-in union
+      driver keeps both sides' added lines instead of conflicting — safe for an
+      append-only prose log. Deliberately NOT applied to artifacts/*.yaml:
+      union-concatenating conflicting YAML hunks can silently produce malformed
+      or misordered YAML, which is worse than a conflict that forces review;
+      the guidance there is to append REQs at EOF (as this very artifact does)
+      or use `rivet add`, never insert mid-file.
+
+      Acceptance:
+        - `.gitattributes` declares `CHANGELOG.md merge=union`.
+        - This REQ was appended at end-of-file (not inserted mid-file).
+        - `rivet validate` still PASSES.
+    tags: [chore, dx, git, dogfooding, self-found, issue-422]
+    fields:
+      priority: should
+      category: process
+    links:
+      - type: traces-to
+        target: REQ-007


### PR DESCRIPTION
Implements the safe half of #422 (a friction I hit repeatedly this session — resolving CHANGELOG/requirements conflicts on #419 and #421 within the same hour).

## What
- `.gitattributes`: **`CHANGELOG.md merge=union`** — git's built-in union driver keeps **both** sides' added lines instead of conflicting. Ideal for an append-only prose log; worst case is an out-of-order entry, trivially fixed.

## Deliberately NOT done
- `artifacts/*.yaml merge=union` — union-concatenating conflicting YAML hunks can **silently produce malformed/misordered YAML**, which is worse than a conflict that forces a human to look. The guidance there (per #422) is to **append REQs at EOF** (which REQ-164 in this PR does) or use `rivet add` (which already appends), never insert mid-file.

No CHANGELOG entry here on purpose — it's a `.gitattributes` chore, and adding one would create exactly the conflict this fixes.

`rivet validate` PASS.

Implements: REQ-164