### PR TITLE
fix(aspice): verification gates accept forward target status (REQ-165, #355 Finding 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
 
 ### Fixed
 
+- **REQ-165 / #355 Finding 2 — ASPICE verification gates accept forward target
+  status.** The three `V-*-verification-needs-approved-*` status gates hardcoded
+  `(forall-linked "verifies" (= status "approved"))`, so an approved/released
+  verifier mis-fired when the req/design it verifies had moved *past* approved
+  (implemented / verified / released) — promoting `approved → implemented`
+  wrongly re-raised "needs an approved design". Each consequent now accepts
+  approved-or-beyond `(or approved implemented verified released)`; a target
+  still below approved (draft/proposed) correctly still fires. Schema-only;
+  regression test `aspice_status_gate_accepts_forward_target_status`.
+
 - **REQ-163 / #420 — compliance CI now forwards the version-switcher + back-link
   inputs.** The published report for 0.15.0 lost the version selector and "back"
   nav that 0.1.0 has. `rivet export` still supports them (`--homepage`,

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4814,3 +4814,43 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-165
+    type: requirement
+    title: "ASPICE verification gates must accept a target that moved forward past approved"
+    status: implemented
+    description: |
+      #355 Finding 2: the three ASPICE verification status-gates
+      (V-sys/sw/unit-verification-needs-approved-*) hardcode
+      `(forall-linked "verifies" (= status "approved"))` in the consequent, so
+      a verifier that is approved/released mis-fires when the requirement or
+      design it verifies has moved FORWARD past approved (implemented /
+      verified / released). The antecedent already recognises
+      `(or approved released)`, but the consequent did not — promoting a
+      verified `sw-detail-design` from approved -> implemented wrongly
+      re-raised "needs an approved design".
+
+      Fix (schema-only): expand each consequent to accept approved-or-beyond —
+      `(or (= status "approved") (= status "implemented")
+           (= status "verified") (= status "released"))` — matching the
+      canonical lifecycle ordering (the status base-field set). A target still BELOW approved
+      (draft / proposed) correctly still fires. No s-expr engine change; a
+      `status-at-least` predicate over the ordering remains a possible future
+      simplification.
+
+      Acceptance:
+        - An approved `sys-verification` that verifies an `implemented`
+          system-req does NOT raise
+          `V-sys-verification-needs-approved-req`; one that verifies a `draft`
+          system-req still does.
+        - `cargo test -p rivet-core --test schema_validation_rules
+          aspice_status_gate_accepts_forward_target_status` passes, and the
+          existing `aspice_status_gate_rules_loaded_and_fire` still passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [schema, aspice, status-lifecycle, bug, issue-355, issue-350]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-135

--- a/rivet-core/tests/schema_validation_rules.rs
+++ b/rivet-core/tests/schema_validation_rules.rs
@@ -131,6 +131,49 @@ fn aspice_status_gate_rules_loaded_and_fire() {
     );
 }
 
+/// REQ-165 / #355 Finding 2: the verification status-gate consequent must
+/// accept a target that has moved FORWARD past `approved` (implemented /
+/// verified / released), not only the literal `approved`. Promoting a
+/// verified requirement/design from approved -> implemented must not
+/// re-fire "needs an approved req/design"; only a target still BELOW
+/// approved (draft / proposed) should.
+#[test]
+fn aspice_status_gate_accepts_forward_target_status() {
+    let schema = Schema::merge(&[parse_schema("aspice")]);
+
+    let mut store = Store::default();
+    // approved sys-verification -> implemented system-req (forward of approved)
+    store.upsert(artifact("REQ-IMPL", "system-req", "implemented", &[]));
+    store.upsert(artifact(
+        "V-FWD",
+        "sys-verification",
+        "approved",
+        &[("verifies", "REQ-IMPL")],
+    ));
+    // control: approved sys-verification -> draft system-req (below approved)
+    store.upsert(artifact("REQ-DRAFT", "system-req", "draft", &[]));
+    store.upsert(artifact(
+        "V-BAD",
+        "sys-verification",
+        "approved",
+        &[("verifies", "REQ-DRAFT")],
+    ));
+
+    let graph = LinkGraph::build(&store, &schema);
+    let gate: Vec<_> = validate(&store, &schema, &graph)
+        .into_iter()
+        .filter(|d| d.rule == "V-sys-verification-needs-approved-req")
+        .collect();
+
+    // Exactly one violation — on V-BAD (draft target), NOT V-FWD (implemented).
+    assert_eq!(
+        gate.len(),
+        1,
+        "only the draft-target verifier should fire; got {gate:#?}"
+    );
+    assert_eq!(gate[0].artifact_id.as_deref(), Some("V-BAD"));
+}
+
 /// All status-gate rules across every shipped preset must have a well-
 /// formed s-expression body. Catches typos in rule bodies before they
 /// ship — a malformed `rule:` would otherwise surface only as a runtime

--- a/schemas/aspice.yaml
+++ b/schemas/aspice.yaml
@@ -562,7 +562,9 @@ validation-rules:
       (implies
         (and (= type "sys-verification")
              (or (= status "approved") (= status "released")))
-        (forall-linked "verifies" (= status "approved")))
+        (forall-linked "verifies"
+          (or (= status "approved") (= status "implemented")
+              (= status "verified") (= status "released"))))
     on-unresolved: skip
     severity: error
     message: |
@@ -577,7 +579,9 @@ validation-rules:
       (implies
         (and (= type "sw-verification")
              (or (= status "approved") (= status "released")))
-        (forall-linked "verifies" (= status "approved")))
+        (forall-linked "verifies"
+          (or (= status "approved") (= status "implemented")
+              (= status "verified") (= status "released"))))
     on-unresolved: skip
     severity: error
     message: |
@@ -593,7 +597,9 @@ validation-rules:
       (implies
         (and (= type "unit-verification")
              (or (= status "approved") (= status "released")))
-        (forall-linked "verifies" (= status "approved")))
+        (forall-linked "verifies"
+          (or (= status "approved") (= status "implemented")
+              (= status "verified") (= status "released"))))
     on-unresolved: skip
     severity: error
     message: |


### PR DESCRIPTION
Closes the last open piece of #355 (Finding 2).

## Bug
The three ASPICE verification status-gates — `V-sys-verification-needs-approved-req`, `V-sw-verification-needs-approved-req`, `V-unit-verification-needs-approved-design` — hardcode the consequent:
```lisp
(forall-linked "verifies" (= status "approved"))
```
So an approved/released verifier **mis-fires** when the req/design it verifies has moved *forward* past `approved` (to `implemented`/`verified`/`released`). Promoting a verified `sw-detail-design` from `approved → implemented` wrongly re-raised "needs an approved design". The maintainer flagged the asymmetry: the **antecedent** already accepts `(or approved released)`, but the consequent didn't.

## Fix (schema-only)
Each consequent now accepts **approved-or-beyond**:
```lisp
(forall-linked "verifies"
  (or (= status "approved") (= status "implemented")
      (= status "verified") (= status "released")))
```
matching the canonical lifecycle ordering. A target still **below** approved (`draft`/`proposed`) correctly still fires. No s-expr engine change — a `status-at-least` predicate over the ordering remains a possible future simplification.

## Verify
- Behavioral: approved `sys-verification` → `implemented` system-req → **no** violation; → `draft` system-req → **fires**.
- New regression test `aspice_status_gate_accepts_forward_target_status`; existing `aspice_status_gate_rules_loaded_and_fire` still passes (5/5 in the suite).
- `rivet validate` PASS; docs check PASS. (The rivet repo doesn't load aspice, so no repo-side change.)

Independent of #419 (uses status string literals, not the enum declaration), so it can land in either order.

Fixes: REQ-165