### PR TITLE
feat(matrix): infer direction + link when --direction omitted (REQ-166, #402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
 
 ### Fixed
 
+- **REQ-166 / #402 — `rivet matrix` infers direction + link from the from/to
+  pair.** `--direction` is now optional; omit it and the command probes the
+  graph for the direction and link type that actually connect `--from` to
+  `--to`, so `rivet matrix --from design-decision --to requirement` renders the
+  real `satisfies` matrix instead of the old empty `backward` default. Explicit
+  `--direction forward`/`backward` is byte-identical to before — inference only
+  affects the omitted path. (CLI command only; the `{{matrix:from:to}}` embed is
+  a separate follow-up.) Test `matrix_infers_direction_when_omitted`.
+
 - **REQ-165 / #355 Finding 2 — ASPICE verification gates accept forward target
   status.** The three `V-*-verification-needs-approved-*` status gates hardcoded
   `(forall-linked "verifies" (= status "approved"))`, so an approved/released

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4898,3 +4898,47 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-135
+
+  - id: REQ-166
+    type: requirement
+    title: "rivet matrix infers traversal direction (and link) from the from/to pair when --direction is omitted"
+    status: implemented
+    description: |
+      From #402: `rivet matrix --from X --to Y` required the user to also know
+      the right `--direction` (the default `backward` silently rendered an
+      all-empty matrix for a forward relationship like
+      `design-decision --satisfies--> requirement`). REQ-152 added a hint, but
+      the user still had to re-run.
+
+      Make `--direction` optional. When omitted, infer the direction + link
+      type that actually connect `from` -> `to` by probing the graph (the
+      declared source-/target-types on common links like `satisfies` are
+      usually empty, so metadata alone can't decide). Candidate links: the one
+      given via `--link`, else every distinct link type on a from-/to-type
+      artifact; each is scored in both directions and the highest-coverage
+      non-empty pair wins (ties break Forward-first then link name, for
+      determinism). When `--direction` IS given, behaviour is byte-identical to
+      before — inference only affects the omitted path.
+
+      Scope: the CLI `rivet matrix` command. The `{{matrix:from:to}}` embed and
+      the serve render path derive direction from schema rules and are left as
+      a separate follow-up.
+
+      Acceptance:
+        - `rivet matrix --from design-decision --to requirement` (no
+          --direction) is NON-empty and reports `link_type: satisfies`
+          (inferred forward), not the old empty backward default.
+        - `rivet matrix --direction backward …` and `--direction forward …`
+          produce byte-identical output to before (explicit path unchanged).
+        - `cargo test -p rivet-cli --test cli_commands
+          matrix_infers_direction_when_omitted` passes, and the existing
+          matrix tests (incl. the empty-hint test, now using explicit
+          `--direction backward`) still pass.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [feature, matrix, dx, traceability, issue-402]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-152

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -565,9 +565,11 @@ enum Command {
         #[arg(long)]
         link: Option<String>,
 
-        /// Direction: "forward" or "backward"
-        #[arg(long, default_value = "backward")]
-        direction: String,
+        /// Direction: "forward" or "backward". Omit to infer the direction
+        /// (and link type) that actually connects --from to --to (REQ-166 /
+        /// #402) — so `--from design-decision --to requirement` just works.
+        #[arg(long)]
+        direction: Option<String>,
 
         /// Output format: "text" (default) or "json"
         #[arg(short, long, default_value = "text")]
@@ -2071,7 +2073,14 @@ fn run(cli: Cli) -> Result<bool> {
             link,
             direction,
             format,
-        } => cmd_matrix(&cli, from, to, link.as_deref(), direction, format),
+        } => cmd_matrix(
+            &cli,
+            from,
+            to,
+            link.as_deref(),
+            direction.as_deref(),
+            format,
+        ),
         Command::Diff { base, head, format } => {
             cmd_diff(&cli, base.as_deref(), head.as_deref(), format)
         }
@@ -7641,31 +7650,106 @@ fn cmd_coverage_matrix_aggregate(format: &str, paths: &[PathBuf]) -> Result<bool
 }
 
 /// Generate a traceability matrix.
+/// REQ-166 / #402: infer the matrix direction + link type that actually
+/// connect `from` -> `to`, by probing the graph (the declared
+/// `source-types`/`target-types` on a link are usually empty for common links
+/// like `satisfies`, so metadata alone can't decide — the graph can).
+///
+/// Candidate links: the one given via `--link`, else every distinct link type
+/// that appears on a `from`- or `to`-type artifact. For each candidate, both
+/// directions are scored by coverage; the highest-coverage non-empty pair wins
+/// (ties break Forward-first, then link name, for determinism). If nothing
+/// connects, falls back to forward + the given/`traces-to` link so the
+/// all-empty hint below still fires.
+fn infer_matrix_direction(
+    store: &rivet_core::store::Store,
+    graph: &LinkGraph,
+    from: &str,
+    to: &str,
+    link_type: Option<&str>,
+) -> (Direction, String) {
+    let candidates: Vec<String> = match link_type {
+        Some(l) => vec![l.to_string()],
+        None => {
+            let mut set: std::collections::BTreeSet<String> = Default::default();
+            for ty in [from, to] {
+                for id in store.by_type(ty) {
+                    if let Some(a) = store.get(id) {
+                        for l in &a.links {
+                            set.insert(l.link_type.clone());
+                        }
+                    }
+                }
+            }
+            set.into_iter().collect()
+        }
+    };
+
+    let mut best: Option<(usize, Direction, String)> = None;
+    for link in &candidates {
+        for dir in [Direction::Forward, Direction::Backward] {
+            let covered = matrix::compute_matrix(store, graph, from, to, link, dir).covered;
+            if covered == 0 {
+                continue;
+            }
+            let take = match &best {
+                None => true,
+                // Strictly higher coverage wins; equal coverage keeps the
+                // earlier candidate (Forward precedes Backward; links iterate
+                // in sorted order), so the choice is deterministic.
+                Some((bc, _, _)) => covered > *bc,
+            };
+            if take {
+                best = Some((covered, dir, link.clone()));
+            }
+        }
+    }
+
+    match best {
+        Some((_, dir, link)) => (dir, link),
+        None => (
+            Direction::Forward,
+            link_type.unwrap_or("traces-to").to_string(),
+        ),
+    }
+}
+
 fn cmd_matrix(
     cli: &Cli,
     from: &str,
     to: &str,
     link_type: Option<&str>,
-    direction: &str,
+    direction: Option<&str>,
     format: &str,
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let ctx = ProjectContext::load(cli)?;
     let (store, graph) = (ctx.store, ctx.graph);
 
-    let dir = match direction {
-        "forward" | "fwd" => Direction::Forward,
-        "backward" | "back" | "bwd" => Direction::Backward,
-        _ => anyhow::bail!("direction must be 'forward' or 'backward'"),
+    // REQ-166 / #402: when `--direction` is given, behave exactly as before
+    // (byte-identical). When omitted, INFER the direction + link type that
+    // actually connect `from` -> `to` in the graph, so `--from X --to Y`
+    // just works instead of silently rendering an all-empty matrix in the
+    // wrong default direction.
+    let (dir, link): (Direction, String) = match direction {
+        Some(d) => {
+            let dir = match d {
+                "forward" | "fwd" => Direction::Forward,
+                "backward" | "back" | "bwd" => Direction::Backward,
+                _ => anyhow::bail!("direction must be 'forward' or 'backward'"),
+            };
+            let link = link_type
+                .unwrap_or(match dir {
+                    Direction::Forward => "traces-to",
+                    Direction::Backward => "verifies",
+                })
+                .to_string();
+            (dir, link)
+        }
+        None => infer_matrix_direction(&store, &graph, from, to, link_type),
     };
 
-    // Auto-detect link type if not specified
-    let link = link_type.unwrap_or(match dir {
-        Direction::Forward => "traces-to",
-        Direction::Backward => "verifies",
-    });
-
-    let result = matrix::compute_matrix(&store, &graph, from, to, link, dir);
+    let result = matrix::compute_matrix(&store, &graph, from, to, &link, dir);
 
     if format == "json" {
         let rows_json: Vec<serde_json::Value> = result
@@ -7719,6 +7803,10 @@ fn cmd_matrix(
     // actionable hint (stderr, so text/JSON stdout stays clean). If flipping
     // the direction would surface links, say so precisely.
     if result.covered == 0 && result.total > 0 {
+        let dir_name = match dir {
+            Direction::Forward => "forward",
+            Direction::Backward => "backward",
+        };
         let opp = match dir {
             Direction::Forward => Direction::Backward,
             Direction::Backward => Direction::Forward,
@@ -7727,10 +7815,10 @@ fn cmd_matrix(
             Direction::Forward => "forward",
             Direction::Backward => "backward",
         };
-        let opp_result = matrix::compute_matrix(&store, &graph, from, to, link, opp);
+        let opp_result = matrix::compute_matrix(&store, &graph, from, to, &link, opp);
         if opp_result.covered > 0 {
             eprintln!(
-                "note: 0 of {} {from} link to any {to} via '{link}' ({direction}), \
+                "note: 0 of {} {from} link to any {to} via '{link}' ({dir_name}), \
                  but {} do with `--direction {opp_name}`. The relationship runs the \
                  other way — re-run with `--direction {opp_name}`.",
                 result.total, opp_result.covered,

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1991,8 +1991,10 @@ fn matrix_empty_emits_direction_hint() {
             .expect("rivet matrix")
     };
 
-    // design-decision --satisfies--> requirement is a FORWARD link; the
-    // default `--direction backward` therefore yields an empty matrix.
+    // design-decision --satisfies--> requirement is a FORWARD link, so the
+    // EXPLICIT `--direction backward` yields an empty matrix and must emit the
+    // hint. (Omitting --direction now infers forward — REQ-166 / #402 — so the
+    // explicit flag is required to exercise the empty-matrix hint path.)
     let empty = run(&[
         "--from",
         "design-decision",
@@ -2000,6 +2002,8 @@ fn matrix_empty_emits_direction_hint() {
         "requirement",
         "--link",
         "satisfies",
+        "--direction",
+        "backward",
     ]);
     assert!(empty.status.success());
     let err = String::from_utf8_lossy(&empty.stderr);
@@ -2024,6 +2028,67 @@ fn matrix_empty_emits_direction_hint() {
     assert!(
         !ok_err.contains("runs the other way"),
         "a matrix with links must not emit the empty-direction hint; stderr: {ok_err}"
+    );
+}
+
+/// REQ-166 / #402: with `--direction` omitted, `rivet matrix` infers the
+/// direction + link type that actually connect from -> to. `design-decision`
+/// satisfies `requirement` (a forward link), so `--from design-decision --to
+/// requirement` (no flag) must produce a NON-empty matrix via `satisfies` —
+/// not the old empty `backward` default. Explicit `--direction` is unchanged.
+#[test]
+fn matrix_infers_direction_when_omitted() {
+    let root = project_root();
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            root.to_str().unwrap(),
+            "matrix",
+            "--from",
+            "design-decision",
+            "--to",
+            "requirement",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("rivet matrix");
+    assert!(out.status.success());
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("matrix JSON");
+    assert_eq!(
+        v["link_type"], "satisfies",
+        "should infer the satisfies link"
+    );
+    assert!(
+        v["covered"].as_u64().unwrap_or(0) > 0,
+        "inferred matrix must be non-empty; got {v}"
+    );
+
+    // Explicit --direction backward stays the old (empty) behavior — proving
+    // inference only changes the omitted path.
+    let backward = Command::new(rivet_bin())
+        .args([
+            "--project",
+            root.to_str().unwrap(),
+            "matrix",
+            "--from",
+            "design-decision",
+            "--to",
+            "requirement",
+            "--direction",
+            "backward",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("rivet matrix");
+    let vb: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&backward.stdout)).expect("matrix JSON");
+    assert_eq!(
+        vb["covered"].as_u64().unwrap_or(99),
+        0,
+        "explicit backward must be unchanged (empty)"
     );
 }
 


### PR DESCRIPTION
Implements #402 (the auto-triage AC).

## Problem
`rivet matrix --from X --to Y` made you *also* know the right `--direction`. The default `backward` silently rendered an **all-empty matrix** for a forward relationship like `design-decision --satisfies--> requirement`. REQ-152 added a stderr hint, but you still had to re-run.

## Fix
`--direction` is now **optional**. When omitted, the command **infers** the direction + link type that actually connect `--from` to `--to` by probing the graph:
- Candidate links: the `--link` value, else every distinct link type on a from-/to-type artifact.
- Each candidate is scored in both directions; the **highest-coverage non-empty** pair wins (ties break Forward-first then link name → deterministic).
- Fallback (nothing connects) keeps the all-empty hint firing.

When `--direction` **is** given, the behaviour is **byte-identical** to before (separate code path) — inference only changes the omitted path, so the regression bar in the AC holds.

## Verify
- `rivet matrix --from design-decision --to requirement` (no `--direction`) → **non-empty**, `link_type: satisfies` (inferred forward), instead of the old empty backward default.
- `--direction backward`/`forward` → unchanged (the new test asserts explicit backward stays empty).
- New test `matrix_infers_direction_when_omitted`; the REQ-152 empty-hint test updated to force the empty case with explicit `--direction backward` (its premise — backward *default* being empty — is now obsoleted by inference, which is the win). 114 cli_commands + embeds_help green; clippy `--all-targets` + fmt clean; `rivet validate` PASS, docs check PASS.

## Scope
CLI `rivet matrix` only. The `{{matrix:from:to}}` embed + serve render path derive direction from schema rules — separate follow-up, noted on REQ-166.

Implements: REQ-166