### PR TITLE
feat(cli): add `rivet trace <id>` + deterministic explain ordering (REQ-167, #426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
 
 ### Fixed
 
+- **REQ-167 / #426 — `rivet trace <id>`.** Added the discoverable namesake
+  verb for the per-artifact traceability view (rules satisfied/missing, incoming
+  + outgoing links, diagnostics) — previously reachable only via the
+  non-obvious `rivet validate --explain <id>` (which stays as an alias). Also
+  made that view **deterministic**: incoming links and the rule-satisfier
+  representative were HashMap-ordered (varied per run); both now sort by
+  (source, link-type), so `trace`/`--explain` output is reproducible audit
+  evidence (#415).
+
 - **REQ-166 / #402 — `rivet matrix` infers direction + link from the from/to
   pair.** `--direction` is now optional; omit it and the command probes the
   graph for the direction and link type that actually connect `--from` to

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4942,3 +4942,42 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-152
+
+  - id: REQ-167
+    type: requirement
+    title: "rivet trace <id>: discoverable per-artifact traceability view (+ deterministic link ordering)"
+    status: implemented
+    description: |
+      Self-found while dogfooding (#426): `rivet`'s tagline is "SDLC artifact
+      traceability and validation", yet `rivet trace <id>` was an unrecognised
+      subcommand. The per-artifact neighbourhood view (rules satisfied/missing,
+      incoming + outgoing links, diagnostics) existed only under the
+      non-obvious `rivet validate --explain <id>` — nobody runs `validate` to
+      navigate traceability.
+
+      Add `rivet trace <id>` as a first-class command that renders that view
+      (it calls the same `cmd_explain`; `validate --explain` stays as an alias).
+
+      While verifying, found the view itself was nondeterministic: incoming
+      links (`graph.backlinks_to`, HashMap order) and the rule-satisfier
+      representative ("...from <X>") varied per run — bad for audit evidence
+      (#415 footgun). Both now sort by (source, link-type), so `trace` /
+      `validate --explain` output is reproducible.
+
+      Acceptance:
+        - `rivet trace REQ-001` exits 0 and prints the artifact + "Incoming
+          links:"; output is byte-identical to `rivet validate --explain
+          REQ-001` and identical across repeated runs.
+        - `rivet trace <missing-id>` reports "not found" (clean, not a clap
+          error).
+        - `cargo test -p rivet-cli --test cli_commands
+          trace_command_renders_and_is_deterministic` passes; the existing
+          `validate_explain_shows_rule_status` test still passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [feature, dx, traceability, determinism, dogfooding, self-found, issue-426, issue-415]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-125

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -417,6 +417,16 @@ enum Command {
         format: String,
     },
 
+    /// Trace one artifact: its traceability rules (satisfied/missing, with the
+    /// link type + source types that satisfy each), plus its incoming and
+    /// outgoing links and its own diagnostics. The per-artifact view of the
+    /// trace graph — answers "what connects to/from <ID>, and is it covered?".
+    /// (Same view as `validate --explain <ID>`; REQ-167 / #426.)
+    Trace {
+        /// Artifact ID to trace
+        id: String,
+    },
+
     /// Bundle an artifact and its link-graph closure as a single pasteable document
     Bundle {
         /// Root artifact ID
@@ -2026,6 +2036,10 @@ fn run(cli: Cli) -> Result<bool> {
             *rank_by_backlinks,
         ),
         Command::Get { id, format } => cmd_get(&cli, id, format),
+        // REQ-167 / #426: `trace` is the discoverable namesake verb for the
+        // per-artifact traceability view; it renders the same as
+        // `validate --explain <id>` (which stays as an alias).
+        Command::Trace { id } => cmd_explain(&cli, id),
         Command::Bundle { id, depth, format } => cmd_bundle(&cli, id, *depth, format),
         Command::Stats {
             filter,
@@ -5781,10 +5795,14 @@ fn cmd_explain(cli: &Cli, id: &str) -> Result<bool> {
             println!("  {} -> {}", l.link_type, l.target);
         }
     }
-    let incoming = ctx.graph.backlinks_to(id);
+    let mut incoming = ctx.graph.backlinks_to(id).to_vec();
+    // REQ-167 / #415: backlinks come back in graph (HashMap) order, which
+    // varies per process. Sort by (source, link-type) so `trace` / `explain`
+    // output is reproducible — it's audit evidence, not a scratch dump.
+    incoming.sort_by(|a, b| a.source.cmp(&b.source).then(a.link_type.cmp(&b.link_type)));
     if !incoming.is_empty() {
         println!("\nIncoming links:");
-        for bl in incoming {
+        for bl in &incoming {
             match &bl.inverse_type {
                 Some(inv) => println!("  {} <- {} ({})", inv, bl.source, bl.link_type),
                 None => println!("  {} <- {}", bl.link_type, bl.source),
@@ -5848,7 +5866,11 @@ fn explain_rule(
     } else if let Some(req) = &rule.required_backlink {
         // Backward: some artifact must link IN via `req` (or its inverse, or an
         // alternate backlink) from an allowed from-type.
-        let bls = graph.backlinks_to(id);
+        // REQ-167 / #415: sort backlinks by source so the satisfying
+        // representative ("...from <X>") is deterministic across runs, not
+        // whichever the graph's HashMap happened to yield first.
+        let mut bls = graph.backlinks_to(id).to_vec();
+        bls.sort_by(|a, b| a.source.cmp(&b.source).then(a.link_type.cmp(&b.link_type)));
         let find = |name: &str, froms: &[String]| -> Option<String> {
             bls.iter()
                 .filter(|bl| bl.source.as_str() != id)

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5714,3 +5714,49 @@ fn validate_structural_gates_on_structural_only() {
         String::from_utf8_lossy(&s2.stdout)
     );
 }
+
+/// REQ-167 / #426: `rivet trace <id>` is the discoverable namesake verb for the
+/// per-artifact traceability view — it must exit 0, render the artifact + its
+/// links, produce the SAME output as `validate --explain <id>`, and be
+/// deterministic across runs (REQ-167 / #415 sort fix on the link lists).
+#[test]
+fn trace_command_renders_and_is_deterministic() {
+    let root = project_root();
+    let run = |args: &[&str]| {
+        let mut a = vec!["--project", root.to_str().unwrap()];
+        a.extend_from_slice(args);
+        Command::new(rivet_bin()).args(&a).output().expect("rivet")
+    };
+
+    let t1 = run(&["trace", "REQ-001"]);
+    assert!(t1.status.success(), "rivet trace must exit 0");
+    let s1 = String::from_utf8_lossy(&t1.stdout);
+    assert!(
+        s1.contains("REQ-001") && s1.contains("Incoming links:"),
+        "trace output must show the artifact and its links; got:\n{s1}"
+    );
+
+    // Deterministic across runs (link lists sorted, not HashMap-ordered).
+    let t2 = run(&["trace", "REQ-001"]);
+    assert_eq!(
+        s1,
+        String::from_utf8_lossy(&t2.stdout),
+        "rivet trace output must be reproducible run-to-run"
+    );
+
+    // Same view as `validate --explain` (trace wraps cmd_explain).
+    let explain = run(&["validate", "--explain", "REQ-001"]);
+    assert_eq!(
+        s1,
+        String::from_utf8_lossy(&explain.stdout),
+        "rivet trace must match validate --explain"
+    );
+
+    // Unknown subcommand previously; now a real command — unknown ID is a
+    // clean not-found, not a clap error.
+    let missing = run(&["trace", "NOPE-999"]);
+    assert!(
+        String::from_utf8_lossy(&missing.stderr).contains("not found"),
+        "trace of a missing id should report not-found"
+    );
+}


### PR DESCRIPTION
Closes #426 — found by dogfooding.

## Problem
`rivet`'s tagline is *"SDLC artifact **traceability** and validation"*, yet:
```
$ rivet trace REQ-001
error: unrecognized subcommand 'trace'
```
The per-artifact neighborhood view existed only under the non-obvious `rivet validate --explain <id>` — you don't run *validate* to *navigate traceability*.

## Fix
- **`rivet trace <id>`** — a first-class, discoverable command rendering that view (rules satisfied/missing, incoming + outgoing links, diagnostics). It calls the same `cmd_explain`; `validate --explain` stays as an alias.
- **Determinism bonus (#415):** verifying `trace == validate --explain` revealed the view was *nondeterministic* — incoming links (`graph.backlinks_to`, HashMap order) and the rule-satisfier representative (`…from <X>`) varied run-to-run. Bad for audit evidence. Both now sort by `(source, link-type)`, so the output is reproducible.

## Verify
- `rivet trace REQ-001` exits 0, shows the artifact + "Incoming links:", is **byte-identical to `validate --explain REQ-001`** and **identical across repeated runs**.
- `rivet trace NOPE-999` → clean "not found".
- New test `trace_command_renders_and_is_deterministic`; existing `validate_explain_shows_rule_status` still passes; 115 cli_commands + embeds_help green; clippy `--all-targets` + fmt clean; `rivet validate` PASS, docs PASS.

Implements: REQ-167