### PR TITLE
feat(bundle): --incoming follows backlinks so sinks bundle their realizers (REQ-168, #428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@
 
 ### Fixed
 
+- **REQ-168 / #428 — `rivet bundle --incoming`.** `bundle` built the closure
+  from *outgoing* links only, so bundling a requirement (a graph sink —
+  everything links *to* it, it links *out* to nothing) returned just the bare
+  artifact, dropping the realizing DDs/features/tests you actually want for LLM
+  context. `--incoming` now also follows backlinks (sorted, so the bundle is
+  reproducible — #415). `bundle()` stays outgoing-only for API/MCP stability.
+
 - **REQ-167 / #426 — `rivet trace <id>`.** Added the discoverable namesake
   verb for the per-artifact traceability view (rules satisfied/missing, incoming
   + outgoing links, diagnostics) — previously reachable only via the

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -4981,3 +4981,37 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-125
+
+  - id: REQ-168
+    type: requirement
+    title: "rivet bundle --incoming: follow backlinks so bundling a sink (requirement) includes what realizes it"
+    status: implemented
+    description: |
+      Self-found while dogfooding (#428). `rivet bundle` builds an artifact's
+      link-graph closure for LLM context (#206), but traversed OUTGOING links
+      only. A requirement is a graph SINK — everything links TO it (satisfies /
+      verifies / allocated-to), it links OUT to nothing — so `rivet bundle
+      REQ-001` returned just the bare artifact (count=1), dropping exactly the
+      realizing design-decisions / features / tests you want as context.
+
+      Add `bundle_with_graph(store, graph, root, depth, include_incoming)` and a
+      `rivet bundle --incoming` flag. With it, each node's backlink sources are
+      enqueued too (depth +1). `bundle()` stays outgoing-only (API + MCP
+      stability). Backlink sources are visited in sorted order so the bundle is
+      reproducible across runs (the backlink store is HashMap-backed; cf. #415).
+
+      Acceptance:
+        - `rivet bundle REQ-001` (no flag) is unchanged (just the root for a
+          sink); `rivet bundle REQ-001 --incoming` includes the artifacts that
+          link to it (count > 1) and is byte-identical across runs.
+        - `cargo test -p rivet-core --lib
+          incoming_includes_backlink_sources_deterministically` passes; the
+          existing bundle tests still pass.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [feature, bundle, dx, llm-context, determinism, dogfooding, self-found, issue-428, issue-415]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -439,6 +439,12 @@ enum Command {
         /// Output format: "yaml" (default) or "jsonl"
         #[arg(long = "as", default_value = "yaml")]
         format: String,
+
+        /// Also follow INCOMING links (backlinks), not just outgoing — so
+        /// bundling a graph sink like a requirement includes the
+        /// design-decisions / features / tests that realize it (REQ-168 / #428).
+        #[arg(long)]
+        incoming: bool,
     },
 
     /// List artifacts, optionally filtered by type
@@ -2040,7 +2046,12 @@ fn run(cli: Cli) -> Result<bool> {
         // per-artifact traceability view; it renders the same as
         // `validate --explain <id>` (which stays as an alias).
         Command::Trace { id } => cmd_explain(&cli, id),
-        Command::Bundle { id, depth, format } => cmd_bundle(&cli, id, *depth, format),
+        Command::Bundle {
+            id,
+            depth,
+            format,
+            incoming,
+        } => cmd_bundle(&cli, id, *depth, format, *incoming),
         Command::Stats {
             filter,
             format,
@@ -6024,8 +6035,8 @@ fn cmd_get(cli: &Cli, id: &str, format: &str) -> Result<bool> {
 }
 
 /// Bundle an artifact + its link-graph closure (issue #206).
-fn cmd_bundle(cli: &Cli, id: &str, depth: usize, format: &str) -> Result<bool> {
-    use rivet_core::bundle::{BundleFormat, bundle, render};
+fn cmd_bundle(cli: &Cli, id: &str, depth: usize, format: &str, incoming: bool) -> Result<bool> {
+    use rivet_core::bundle::{BundleFormat, bundle_with_graph, render};
 
     let Some(fmt) = BundleFormat::parse(format) else {
         eprintln!("error: --as must be one of: yaml, jsonl");
@@ -6033,7 +6044,7 @@ fn cmd_bundle(cli: &Cli, id: &str, depth: usize, format: &str) -> Result<bool> {
     };
 
     let ctx = ProjectContext::load(cli)?;
-    match bundle(&ctx.store, id, depth) {
+    match bundle_with_graph(&ctx.store, &ctx.graph, id, depth, incoming) {
         Ok(entries) => {
             print!("{}", render(&entries, fmt));
             Ok(true)

--- a/rivet-core/src/bundle.rs
+++ b/rivet-core/src/bundle.rs
@@ -6,10 +6,12 @@
 //! natural reasoning workflow is `get root -> get neighbour -> get
 //! neighbour-of-neighbour` which is N round-trips for what should be one.
 //!
-//! Traversal is breadth-first over outgoing links and visit-once, so cycles
-//! are inherently safe. Targets that don't exist in the store are emitted
-//! as references inside the parent's `links:` list but are not expanded
-//! (they have no record of their own).
+//! Traversal is breadth-first and visit-once, so cycles are inherently safe.
+//! [`bundle`] follows outgoing links only; [`bundle_with_graph`] additionally
+//! follows incoming links (backlinks) when asked, so bundling a graph sink
+//! like a requirement still pulls in what realizes it (`--incoming`, #428).
+//! Targets that don't exist in the store are emitted as references inside the
+//! parent's `links:` list but are not expanded (they have no record of their own).
 
 use std::collections::{BTreeSet, VecDeque};
 
@@ -114,6 +116,75 @@ pub fn bundle(store: &Store, root: &str, depth: usize) -> Result<Vec<BundleEntry
         for link in &art.links {
             if visited.insert(link.target.clone()) {
                 queue.push_back((link.target.clone(), d + 1));
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Like [`bundle`], but also follows **incoming** links (backlinks) when
+/// `include_incoming` is set.
+///
+/// REQ-168 / #428: [`bundle`] traverses only outgoing links, so bundling a
+/// graph *sink* — a requirement, which everything links TO (`satisfies` /
+/// `verifies` / `allocated-to`) but which links OUT to nothing — yields just
+/// the bare artifact, dropping exactly the realizing design-decisions /
+/// features / tests you want for context. With `include_incoming`, each node's
+/// backlink sources are enqueued too (depth +1), so `rivet bundle <req>
+/// --incoming` returns the requirement *and what realizes it*.
+///
+/// Backlink sources are visited in sorted (`source`) order so the bundle is
+/// deterministic across runs (the graph's backlink store is HashMap-backed;
+/// cf. #415). Outgoing links keep their authored order; within a node,
+/// outgoing neighbours are enqueued before incoming.
+pub fn bundle_with_graph(
+    store: &Store,
+    graph: &crate::links::LinkGraph,
+    root: &str,
+    depth: usize,
+    include_incoming: bool,
+) -> Result<Vec<BundleEntry>, BundleError> {
+    if !include_incoming {
+        return bundle(store, root, depth);
+    }
+    let root_artifact = store
+        .get(root)
+        .ok_or_else(|| BundleError::NotFound(root.to_string()))?;
+
+    let mut visited: BTreeSet<ArtifactId> = BTreeSet::new();
+    let mut queue: VecDeque<(ArtifactId, usize)> = VecDeque::new();
+    let mut out: Vec<BundleEntry> = Vec::new();
+
+    visited.insert(root_artifact.id.clone());
+    queue.push_back((root_artifact.id.clone(), 0));
+
+    while let Some((id, d)) = queue.pop_front() {
+        let Some(art) = store.get(&id) else {
+            continue;
+        };
+        out.push(BundleEntry::from_artifact(art, d));
+        if d >= depth {
+            continue;
+        }
+        // Outgoing neighbours (authored order, like `bundle`).
+        for link in &art.links {
+            if visited.insert(link.target.clone()) {
+                queue.push_back((link.target.clone(), d + 1));
+            }
+        }
+        // Incoming neighbours (backlink sources), sorted + de-duped for a
+        // reproducible bundle regardless of graph (HashMap) iteration order.
+        let mut sources: Vec<&str> = graph
+            .backlinks_to(&id)
+            .iter()
+            .map(|bl| bl.source.as_str())
+            .collect();
+        sources.sort_unstable();
+        sources.dedup();
+        for src in sources {
+            if visited.insert(src.to_string()) {
+                queue.push_back((src.to_string(), d + 1));
             }
         }
     }
@@ -413,5 +484,37 @@ mod tests {
         assert_eq!(BundleFormat::parse("yaml"), Some(BundleFormat::Yaml));
         assert_eq!(BundleFormat::parse("jsonl"), Some(BundleFormat::Jsonl));
         assert_eq!(BundleFormat::parse("xml"), None);
+    }
+
+    // REQ-168 / #428: bundling a graph sink (a requirement that everything
+    // links TO but which links OUT to nothing) must include its realizers
+    // when --incoming is set, and the order must be deterministic.
+    #[test]
+    fn incoming_includes_backlink_sources_deterministically() {
+        use crate::links::LinkGraph;
+        use crate::schema::Schema;
+
+        let store = store_with(vec![
+            make("REQ-SINK", "requirement", "sink", vec![]),
+            make(
+                "DD-1",
+                "design-decision",
+                "dd",
+                vec![("satisfies", "REQ-SINK")],
+            ),
+            make("FEAT-1", "feature", "feat", vec![("satisfies", "REQ-SINK")]),
+        ]);
+        let schema = Schema::merge(&[]);
+        let graph = LinkGraph::build(&store, &schema);
+
+        // Outgoing-only (default / include_incoming=false): just the sink.
+        let out = bundle_with_graph(&store, &graph, "REQ-SINK", 1, false).unwrap();
+        assert_eq!(out.len(), 1, "outgoing-only sink bundle is just the root");
+        assert_eq!(out[0].id, "REQ-SINK");
+
+        // With incoming: root + both realizers, root first, sources sorted.
+        let inc = bundle_with_graph(&store, &graph, "REQ-SINK", 1, true).unwrap();
+        let ids: Vec<&str> = inc.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, vec!["REQ-SINK", "DD-1", "FEAT-1"], "got {ids:?}");
     }
 }


### PR DESCRIPTION
Closes #428 — found by dogfooding last pass, implemented this pass.

## Problem
`rivet bundle` builds an artifact's link-graph closure for LLM context (#206), but traversed **outgoing links only**. A requirement is a graph **sink** — everything links *to* it (`satisfies`/`verifies`/`allocated-to`), it links *out* to nothing — so:
```
$ rivet bundle REQ-001
# rivet bundle (count=1, depth-max=0)   ← just the bare artifact
```
The realizing DDs/features/tests (the incoming links) — exactly the context you want — were dropped.

## Fix
- New `bundle_with_graph(store, graph, root, depth, include_incoming)` and a **`rivet bundle --incoming`** flag that also enqueues each node's backlink sources (depth +1).
- `bundle()` stays outgoing-only (public-API + MCP `rivet_bundle` stability).
- Backlink sources visited in **sorted** order → reproducible bundle across runs (backlink store is HashMap-backed; cf. #415).

## Verify
- `rivet bundle REQ-001` → unchanged `count=1` (back-compat).
- `rivet bundle REQ-001 --incoming` → `count=34` (the realizers), **byte-identical across runs**.
- New unit test `incoming_includes_backlink_sources_deterministically`; 12 bundle tests pass; clippy `--all-targets` + fmt clean; `rivet validate` PASS, docs PASS.

Implements: REQ-168