### PR TITLE
feat(externals): rivet sync refuses to clobber uncommitted git-external edits (REQ-169)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5015,3 +5015,40 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-169
+    type: requirement
+    title: "rivet sync refuses to overwrite uncommitted changes in a git external's cached checkout"
+    status: implemented
+    description: |
+      Self-found while triaging a maintainer question about co-developing two
+      synced repos at once. `git:` externals are cloned into
+      `.rivet/repos/<prefix>` and `rivet sync` re-runs `git fetch` + `git
+      checkout <ref>` over that checkout. If you edited files there while
+      working in both repos, the checkout silently moves HEAD out from under
+      your edits (or fails cryptically) — uncommitted work is lost with no
+      warning. `path:` externals are unaffected (they symlink to the live tree;
+      cf. REQ-020), which is the supported way to co-develop both repos.
+
+      Add a guard: before fetch+checkout, `is_working_tree_dirty()` checks `git
+      status --porcelain` for staged/unstaged changes to TRACKED files
+      (untracked `??` entries are preserved by checkout, so they do not block).
+      When dirty and `--force` is not given, `sync` aborts non-zero naming the
+      prefix and path, and points to commit+push / `--force` / `path:`. A new
+      `rivet sync --force` opts out (discard). Loud-fail over silent loss (F2).
+
+      Acceptance:
+        - With a `git:` external whose `.rivet/repos/<prefix>` has an
+          uncommitted tracked edit, `rivet sync` exits non-zero and the message
+          names the prefix and `--force`; `rivet sync --force` proceeds.
+        - `cargo test -p rivet-core --lib
+          is_working_tree_dirty_detects_tracked_edits_not_untracked` passes; the
+          existing externals tests still pass.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [externals, sync, cross-repo, safety, loud-fail, dx, dogfooding, self-found]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-020

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -796,6 +796,10 @@ enum Command {
         /// Use local path for all externals that have one, skipping git fetch/clone
         #[arg(long)]
         local: bool,
+        /// Discard uncommitted changes in a git external's cached checkout
+        /// (`.rivet/repos/<prefix>`) instead of refusing to sync over them
+        #[arg(long)]
+        force: bool,
     },
 
     /// Pin external dependencies to exact commits in rivet.lock
@@ -2177,7 +2181,7 @@ fn run(cli: Cli) -> Result<bool> {
             rt.block_on(serve::run(app_state, bind, watch))?;
             Ok(true)
         }
-        Command::Sync { local } => cmd_sync(&cli, *local),
+        Command::Sync { local, force } => cmd_sync(&cli, *local, *force),
         Command::Lock { update } => cmd_lock(&cli, *update),
         Command::Externals { action } => match action {
             ExternalsAction::Discover { path, format } => cmd_externals_discover(path, format),
@@ -11579,7 +11583,7 @@ fn resolve_schemas_dir(cli: &Cli) -> PathBuf {
     }
 }
 
-fn cmd_sync(cli: &Cli, local_only: bool) -> Result<bool> {
+fn cmd_sync(cli: &Cli, local_only: bool, force: bool) -> Result<bool> {
     let config_path = cli.project.join("rivet.yaml");
     if !config_path.exists() {
         let project_dir =
@@ -11601,6 +11605,9 @@ fn cmd_sync(cli: &Cli, local_only: bool) -> Result<bool> {
     if local_only {
         eprintln!("Using --local: preferring path externals, skipping git fetch/clone");
     }
+    if force {
+        eprintln!("Using --force: will discard uncommitted changes in git external checkouts");
+    }
 
     // Ensure .rivet/ is gitignored
     let added = rivet_core::externals::ensure_gitignore(&cli.project)?;
@@ -11608,7 +11615,7 @@ fn cmd_sync(cli: &Cli, local_only: bool) -> Result<bool> {
         eprintln!("Added .rivet/ to .gitignore");
     }
 
-    let results = rivet_core::externals::sync_all(externals, &cli.project, local_only)?;
+    let results = rivet_core::externals::sync_all(externals, &cli.project, local_only, force)?;
     for (name, path) in &results {
         eprintln!("  Synced {} → {}", name, path.display());
     }

--- a/rivet-core/src/externals.rs
+++ b/rivet-core/src/externals.rs
@@ -104,6 +104,7 @@ pub fn sync_external(
     cache_dir: &Path,
     project_dir: &Path,
     local_only: bool,
+    force: bool,
 ) -> Result<PathBuf, crate::error::Error> {
     let dest = cache_dir.join(&ext.prefix);
     std::fs::create_dir_all(cache_dir)
@@ -188,6 +189,22 @@ pub fn sync_external(
         let no_hooks = ["-c", "core.hooksPath=/dev/null"];
 
         if dest.join(".git").exists() {
+            // Guard: refuse to fetch+checkout over an external whose cached
+            // working tree has uncommitted, tracked changes. Re-syncing would
+            // move HEAD out from under (or fail cryptically on top of) edits a
+            // user made while co-developing both repos in `.rivet/repos/`,
+            // silently losing their work. The supported way to "work in both"
+            // is to commit & push the changes upstream and re-sync, or use a
+            // `path:` external (a symlink to the live tree). `--force` opts out.
+            if !force && is_working_tree_dirty(&dest) {
+                return Err(crate::error::Error::Io(format!(
+                    "external '{}' has uncommitted changes in {} — refusing to sync over them.\n\
+                     Commit & push them upstream then re-sync, or re-run with `--force` to discard.\n\
+                     (To co-develop both repos, declare this external with `path:` instead of `git:`.)",
+                    ext.prefix,
+                    dest.display()
+                )));
+            }
             // Fetch updates — unshallow if this was a shallow clone and we
             // need a specific commit SHA that may not be in the shallow history.
             let mut fetch_args = vec!["fetch", "origin"];
@@ -334,11 +351,12 @@ pub fn sync_all(
     externals: &BTreeMap<String, ExternalProject>,
     project_dir: &Path,
     local_only: bool,
+    force: bool,
 ) -> Result<Vec<(String, PathBuf)>, crate::error::Error> {
     let cache_dir = project_dir.join(".rivet/repos");
     let mut results = Vec::new();
     for (name, ext) in externals {
-        let path = sync_external(ext, &cache_dir, project_dir, local_only)?;
+        let path = sync_external(ext, &cache_dir, project_dir, local_only, force)?;
         results.push((name.clone(), path));
     }
     Ok(results)
@@ -565,6 +583,28 @@ pub struct LockEntry {
     pub git: Option<String>,
     pub commit: String,
     pub prefix: String,
+}
+
+/// Whether a git working tree has uncommitted, *tracked* modifications.
+///
+/// Returns true if `git status --porcelain` reports any staged or unstaged
+/// change to a tracked file. Untracked files (`??`) are ignored: a re-sync's
+/// `git checkout` preserves them, so they are not "work that sync would
+/// destroy". Returns false if the status cannot be determined (e.g. git is
+/// unavailable) — the caller's checkout will then surface any real conflict
+/// rather than this guard blocking on an indeterminate state.
+pub fn is_working_tree_dirty(repo_dir: &Path) -> bool {
+    let output = match Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(repo_dir)
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return false,
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .any(|line| !line.trim_start().is_empty() && !line.starts_with("??"))
 }
 
 /// Read the current commit SHA of a git repository.
@@ -1083,7 +1123,7 @@ mod tests {
         };
 
         let cache_dir = dir.path().join(".rivet/repos");
-        let result = sync_external(&ext, &cache_dir, dir.path(), false);
+        let result = sync_external(&ext, &cache_dir, dir.path(), false, false);
         assert!(result.is_ok());
 
         // For path externals, the cache should contain a symlink or copy
@@ -1102,8 +1142,37 @@ mod tests {
             prefix: "bad".into(),
         };
         let cache_dir = dir.path().join(".rivet/repos");
-        let result = sync_external(&ext, &cache_dir, dir.path(), false);
+        let result = sync_external(&ext, &cache_dir, dir.path(), false, false);
         assert!(result.is_err());
+    }
+
+    // rivet: verifies REQ-169
+    #[test]
+    fn is_working_tree_dirty_detects_tracked_edits_not_untracked() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .unwrap()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "t@t"]);
+        git(&["config", "user.name", "t"]);
+        std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-qm", "init"]);
+
+        // Pristine checkout → clean.
+        assert!(!is_working_tree_dirty(repo));
+        // An untracked-only file is preserved by checkout → still clean.
+        std::fs::write(repo.join("scratch.tmp"), "x").unwrap();
+        assert!(!is_working_tree_dirty(repo));
+        // A modification to a tracked file → dirty (sync must refuse).
+        std::fs::write(repo.join("a.txt"), "two\n").unwrap();
+        assert!(is_working_tree_dirty(repo));
     }
 
     // rivet: verifies REQ-020
@@ -1162,7 +1231,7 @@ mod tests {
             },
         );
 
-        let results = sync_all(&externals, dir.path(), false).unwrap();
+        let results = sync_all(&externals, dir.path(), false, false).unwrap();
         assert_eq!(results.len(), 2);
         assert!(dir.path().join(".rivet/repos/alpha").exists());
         assert!(dir.path().join(".rivet/repos/beta").exists());

--- a/rivet-core/tests/externals_schemas.rs
+++ b/rivet-core/tests/externals_schemas.rs
@@ -146,7 +146,7 @@ fn load_all_externals_populates_schema() {
             prefix: "spar".into(),
         },
     );
-    rivet_core::externals::sync_all(&externals, dir.path(), true).unwrap();
+    rivet_core::externals::sync_all(&externals, dir.path(), true, false).unwrap();
 
     let resolved = load_all_externals(&externals, dir.path()).unwrap();
     assert_eq!(resolved.len(), 1);

--- a/rivet-core/tests/externals_sync.rs
+++ b/rivet-core/tests/externals_sync.rs
@@ -64,7 +64,7 @@ fn sync_spar_external_via_local_path() {
     };
 
     let cache_dir = dir.path().join(".rivet/repos");
-    let result = sync_external(&ext, &cache_dir, dir.path(), true);
+    let result = sync_external(&ext, &cache_dir, dir.path(), true, false);
     assert!(result.is_ok(), "sync_external failed: {:?}", result.err());
 
     // The cache should contain a symlink to the fixture
@@ -164,7 +164,7 @@ fn load_all_externals_with_spar() {
     );
 
     // Sync first so that the cache is populated
-    rivet_core::externals::sync_all(&externals, dir.path(), true).unwrap();
+    rivet_core::externals::sync_all(&externals, dir.path(), true, false).unwrap();
 
     // Then load all externals
     let resolved = load_all_externals(&externals, dir.path()).unwrap();


### PR DESCRIPTION
## Problem (self-found while triaging a co-development question)

`git:` externals are cloned into `.rivet/repos/<prefix>`, and `rivet sync`
re-runs `git fetch` + `git checkout <ref>` over that checkout. If you edited
files there while working in **both** repos at once, the checkout silently
moves `HEAD` out from under your edits (or fails cryptically) — uncommitted
work is lost with no warning. This is the concrete "a sync destroys local
work" hole.

`path:` externals are unaffected: they symlink to the live working tree
(REQ-020), which is the *supported* way to co-develop both repos.

## Fix

- `is_working_tree_dirty()` — checks `git status --porcelain` for staged/
  unstaged changes to **tracked** files. Untracked (`??`) entries are ignored
  because `git checkout` preserves them, so they are not work sync would lose.
- Gate the git fetch/checkout in `sync_external`: when dirty and `--force` is
  not given, abort non-zero, name the prefix + path, and point to commit+push /
  `--force` / declaring the external with `path:` instead. (`path` externals
  skip the guard entirely.)
- New `rivet sync --force` opts out (discard).
- Loud-fail over silent loss (F2 doctrine).

## Verification

- **End-to-end**: a git external with a dirty cached checkout → `rivet sync`
  exits 1 with the guard message; `rivet sync --force` proceeds (exit 0).
- New unit test `is_working_tree_dirty_detects_tracked_edits_not_untracked`
  (clean / untracked-only / tracked-edit); existing externals tests pass.
- `clippy --all-targets` clean; `rivet validate` PASS.

Implements: REQ-169 · Refs: REQ-020

🤖 Generated with [Claude Code](https://claude.com/claude-code)