### PR TITLE
feat(externals): surface un-synced externals so cycle/backlink checks aren't silently incomplete (REQ-170)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5052,3 +5052,42 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-020
+
+  - id: REQ-170
+    type: requirement
+    title: "validate surfaces un-synced externals so cross-repo cycle/backlink checks aren't silently incomplete"
+    status: implemented
+    description: |
+      Follow-up to the multi-repo co-development design (REQ-169). `rivet
+      validate` runs `detect_circular_deps` to catch A->B->A link cycles across
+      repos, building the graph by reading each external's own `rivet.yaml` from
+      `.rivet/repos/<prefix>`. But that read is `if let Ok(...)`: an external
+      that is not synced (or whose config won't parse) is silently skipped, so a
+      cycle or broken reference routed through it is invisible and validate
+      reports a clean "0 circular deps". The acyclicity guarantee is only as
+      good as graph completeness, and the incompleteness was silent (violates
+      F2: loud-fail over silent-success).
+
+      Add `unresolved_externals(externals, project_dir) -> Vec<String>` (sorted)
+      returning the prefixes whose cached `rivet.yaml` cannot be loaded. `rivet
+      validate` reports them: a WARNING naming the un-synced prefixes and
+      telling the user to run `rivet sync`, plus an `unresolved_externals` array
+      in `--format json`. Externals resolvable via a `path:` (the live tree)
+      are not flagged. Warning only — does not change PASS/FAIL.
+
+      Acceptance:
+        - `rivet validate` on a project with an un-synced `git:` external prints
+          a warning containing "INCOMPLETE" and the prefix; `--format json`
+          includes that prefix in `unresolved_externals` while `circular_deps`
+          is 0.
+        - `cargo test -p rivet-core --lib
+          unresolved_externals_lists_only_unsynced_repos` passes.
+        - `rivet validate` on the rivet repo still PASS (spar resolves via its
+          `path:` fixture, so it is not flagged).
+    tags: [externals, sync, cross-repo, validate, loud-fail, f2, dogfooding, self-found]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-020

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -5117,6 +5117,7 @@ fn cmd_validate(
     let mut backlinks: Vec<rivet_core::externals::CrossRepoBacklink> = Vec::new();
     let mut circular_deps: Vec<rivet_core::externals::CircularDependency> = Vec::new();
     let mut version_conflicts: Vec<rivet_core::externals::VersionConflict> = Vec::new();
+    let mut unresolved_externals: Vec<String> = Vec::new();
     if !skip_external_validation {
         if let Some(ref externals) = config.externals {
             if !externals.is_empty() {
@@ -5170,6 +5171,12 @@ fn cmd_validate(
                     &config.project.name,
                     &cli.project,
                 );
+
+                // Which externals are missing from the cache? Their absence
+                // makes the cycle/backlink graph incomplete, so a clean result
+                // is not trustworthy until they are synced (REQ-170).
+                unresolved_externals =
+                    rivet_core::externals::unresolved_externals(externals, &cli.project);
             }
         }
     }
@@ -5350,6 +5357,7 @@ fn cmd_validate(
             "backlinks": backlinks.len(),
             "circular_deps": circular_deps.len(),
             "version_conflicts": version_conflicts.len(),
+            "unresolved_externals": unresolved_externals,
             "lifecycle_gaps": lifecycle_gaps.len(),
             "diagnostics": diag_json,
             "broken_cross_refs": cross_json,
@@ -5419,6 +5427,20 @@ fn cmd_validate(
             for bl in &backlinks {
                 println!("  {}:{} -> {}", bl.source_prefix, bl.source_id, bl.target);
             }
+        }
+
+        if !unresolved_externals.is_empty() {
+            println!();
+            println!(
+                "warning: cross-repo cycle/backlink checks are INCOMPLETE — {} external(s) \
+                 not synced: {}",
+                unresolved_externals.len(),
+                unresolved_externals.join(", ")
+            );
+            println!(
+                "  run `rivet sync` first; a cycle or broken reference routed through an \
+                 un-synced repo cannot be detected."
+            );
         }
 
         if !circular_deps.is_empty() {

--- a/rivet-core/src/externals.rs
+++ b/rivet-core/src/externals.rs
@@ -920,11 +920,45 @@ pub struct CircularDependency {
     pub chain: Vec<String>,
 }
 
+/// Prefixes of externals whose own `rivet.yaml` could not be loaded from the
+/// cache (`.rivet/repos/<prefix>`) — i.e. not yet synced, or present but
+/// unparseable.
+///
+/// The cross-repo cycle graph ([`detect_circular_deps`]) is built by reading
+/// each external's *declared* externals. Any prefix returned here is a HOLE in
+/// that graph: a cycle or broken reference routed through it is invisible, so a
+/// clean "no cycle detected" result cannot be trusted until `rivet sync` has
+/// populated the cache. Surfacing this list lets callers warn instead of
+/// silently reporting a false negative (F2: loud-fail over silent-success).
+///
+/// Returned prefixes are sorted for deterministic reporting.
+pub fn unresolved_externals(
+    externals: &BTreeMap<String, ExternalProject>,
+    project_dir: &Path,
+) -> Vec<String> {
+    let cache_dir = project_dir.join(".rivet/repos");
+    let mut missing = Vec::new();
+    for ext in externals.values() {
+        let ext_dir = resolve_external_dir(ext, &cache_dir, project_dir);
+        let config_path = ext_dir.join("rivet.yaml");
+        if crate::load_project_config(&config_path).is_err() {
+            missing.push(ext.prefix.clone());
+        }
+    }
+    missing.sort();
+    missing
+}
+
 /// Detect circular dependencies in the externals graph.
 ///
 /// Reads each external's own `rivet.yaml` to discover their declared externals,
 /// then checks for cycles using DFS. Circular deps are warnings (valid in mesh
 /// topology) but should be reported so users are aware.
+///
+/// NOTE: externals absent from the cache are silently skipped while building
+/// the graph, so an empty result only means "no cycle *among synced repos*".
+/// Pair this with [`unresolved_externals`] to tell the user when the graph —
+/// and therefore the acyclicity guarantee — is incomplete.
 pub fn detect_circular_deps(
     externals: &BTreeMap<String, ExternalProject>,
     project_name: &str,
@@ -1563,6 +1597,48 @@ mod tests {
 
         let cycles = detect_circular_deps(&externals, "a", dir.path());
         assert!(cycles.is_empty(), "no cycle expected");
+    }
+
+    // rivet: verifies REQ-170
+    #[test]
+    fn unresolved_externals_lists_only_unsynced_repos() {
+        let dir = tempfile::tempdir().unwrap();
+        // A "synced" path external: target dir exists with a loadable rivet.yaml.
+        let synced = dir.path().join("synced-src");
+        std::fs::create_dir_all(&synced).unwrap();
+        std::fs::write(
+            synced.join("rivet.yaml"),
+            "project:\n  name: synced\n  version: '0.1.0'\n  schemas: [common]\nsources: []\n",
+        )
+        .unwrap();
+
+        let mut externals = BTreeMap::new();
+        externals.insert(
+            "synced".into(),
+            crate::model::ExternalProject {
+                git: None,
+                path: Some(synced.to_str().unwrap().into()),
+                git_ref: None,
+                prefix: "synced".into(),
+            },
+        );
+        // A git external that was never synced => no .rivet/repos/notsynced.
+        externals.insert(
+            "notsynced".into(),
+            crate::model::ExternalProject {
+                git: Some("https://example.invalid/x.git".into()),
+                path: None,
+                git_ref: Some("main".into()),
+                prefix: "notsynced".into(),
+            },
+        );
+
+        let missing = unresolved_externals(&externals, dir.path());
+        assert_eq!(
+            missing,
+            vec!["notsynced".to_string()],
+            "only the un-synced git external is a graph hole; the synced path one is not"
+        );
     }
 
     // rivet: verifies REQ-020


### PR DESCRIPTION
## Problem (follow-up to #432 / REQ-169)

`rivet validate` runs `detect_circular_deps` to catch A→B→A link cycles across
repos. It builds the graph by reading each external's own `rivet.yaml` from
`.rivet/repos/<prefix>` — but with `if let Ok(...)`. An external that isn't
synced (or whose config won't parse) is **silently skipped**, so a cycle or
broken reference routed through it is invisible and validate reports a clean
`0 circular deps`. The acyclicity guarantee is only as good as graph
completeness, and that incompleteness was silent (violates F2: loud-fail over
silent-success).

This is the residual gap from the multi-repo "ensure we can't recursively do
this" thread: the cycle check *exists* but can't be *trusted* without knowing
the graph was complete.

## Fix

- `unresolved_externals(externals, project_dir) -> Vec<String>` (sorted) —
  prefixes whose cached `rivet.yaml` cannot be loaded.
- `rivet validate` reports them: a WARNING naming the un-synced prefixes +
  "run `rivet sync`", and an `unresolved_externals` array in `--format json`.
- Externals resolvable via a `path:` (live tree) are **not** flagged.
- Warning only — PASS/FAIL unchanged.

## Verification

- **Live**: a project with an un-synced `git:` external →
  `warning: cross-repo cycle/backlink checks are INCOMPLETE — 1 external(s) not
  synced: ghost`; `--format json` → `unresolved_externals: ["ghost"]` while
  `circular_deps: 0` (the exact false-negative, now loud).
- New unit test `unresolved_externals_lists_only_unsynced_repos`.
- `clippy --all-targets` clean; `rivet validate` on the rivet repo still PASS
  (spar resolves via its `path:` fixture, so it is correctly not flagged).

Implements: REQ-170 · Refs: REQ-020, REQ-169

🤖 Generated with [Claude Code](https://claude.com/claude-code)