### PR TITLE
fix(playwright): bound graph E2E node count so dataset growth doesn't trip render budget (REQ-171)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5091,3 +5091,43 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-020
+
+  - id: REQ-171
+    type: requirement
+    title: "graph E2E tests must bound node count so dataset growth doesn't trip the render budget"
+    status: implemented
+    description: |
+      Self-found while triaging why Playwright E2E was red. Three graph/diagram
+      tests fail reproducibly (through the CI retry), and have been red across
+      multiple merges — unnoticed because Playwright E2E is a non-required check
+      and main runs are concurrency-cancelled, so it never reports a conclusive
+      green. Root cause is dataset growth, not a serve regression:
+
+      - `graph.spec.ts` "custom polygon shapes" hit `/graph?types=requirement,
+        design-decision&depth=2` with NO `?limit=`. The dogfood dataset grew
+        past the default 200-node render budget for that filter, so the view
+        returns the "above node budget" placeholder (no SVG) and the polygon
+        assertion gets 0. Verified locally: the same URL with `&limit=2000`
+        renders the real graph.
+      - `diagram-viewer.spec.ts` graph page used `/graph?limit=2000` (the FULL
+        ~871-node graph); that page is now heavy enough that `goto`+settle
+        exceeded the timeout, failing the `.svg-viewer` toolbar/fullscreen
+        checks. A bounded focused subgraph renders the same wrapper fast.
+
+      Fix (test-only): add `&limit=2000` to the polygon test, and point the
+      diagram-viewer graph case at a focused subgraph
+      (`/graph?focus=REQ-001&depth=1&limit=2000`). Both verified green in a real
+      browser locally (7/7 in the affected specs).
+
+      Acceptance:
+        - `cd tests/playwright && npx playwright test graph.spec.ts
+          diagram-viewer.spec.ts --project=chromium --grep
+          "polygon|toolbar present|fullscreen toggles"` passes (was 3 failing).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [serve, dashboard, graph, playwright, e2e, dogfooding, self-found, ci-hygiene]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: FEAT-001

--- a/tests/playwright/diagram-viewer.spec.ts
+++ b/tests/playwright/diagram-viewer.spec.ts
@@ -12,11 +12,14 @@ import { waitForHtmx } from "./helpers";
  */
 const VIEWER_PAGES = [
   // Top-level link graph — always has toolbar.
-  // ?limit=2000 bypasses the default 200-node budget (added in 2fafe1a)
-  // so the dogfood dataset (~742 artifacts) renders the actual SVG
-  // instead of the "graph above node budget" placeholder. 2000 is
-  // MAX_NODE_BUDGET in render/graph.rs.
-  { name: "graph", url: "/graph?limit=2000" },
+  // Use a *focused* subgraph (REQ-001 + depth-1 neighbours) rather than the
+  // full graph: this test pins the `.svg-viewer` toolbar invariant, not graph
+  // size. The dogfood dataset outgrew the old `?limit=2000` full render — at
+  // ~871 artifacts that page is heavy enough that `goto` + settle exceeded the
+  // timeout, so the toolbar/fullscreen checks failed. A bounded focused graph
+  // renders the same `.svg-viewer` wrapper quickly and deterministically.
+  // (`limit=2000` kept so the focused subgraph is never budget-clipped.)
+  { name: "graph", url: "/graph?focus=REQ-001&depth=1&limit=2000" },
   // Doc linkage view.
   { name: "doc-linkage", url: "/doc-linkage" },
   // /help renders the schema-linkage mermaid diagram (a Schema Linkage

--- a/tests/playwright/graph.spec.ts
+++ b/tests/playwright/graph.spec.ts
@@ -31,7 +31,13 @@ test.describe("Graph View", () => {
   });
 
   test("graph SVG contains custom polygon shapes", async ({ page }) => {
-    await page.goto("/graph?types=requirement,design-decision&depth=2");
+    // ?limit=2000 lifts the default 200-node render budget: the dogfood
+    // dataset grew past 200 requirement+design-decision nodes at depth 2, so
+    // without it the view returns the "above node budget" placeholder (no SVG,
+    // no polygons) and this test fails. The filtered subset still renders fast.
+    await page.goto(
+      "/graph?types=requirement,design-decision&depth=2&limit=2000",
+    );
     await waitForHtmx(page);
     await expect(page.locator("svg").first()).toBeVisible({ timeout: 15_000 });
     // Custom shapes render as polygon elements (diamonds, hexagons, etc.)


### PR DESCRIPTION
## Finding (self-found triaging red Playwright E2E)

Three graph/diagram E2E tests have been failing **reproducibly** (through the
CI retry) across multiple merges. It went unnoticed because **Playwright E2E
is a non-required check and `main` runs are concurrency-cancelled**, so it
never reports a conclusive green — see companion issue.

Root cause is **dogfood-dataset growth, not a serve regression** (verified in a
real browser locally):

| Test | URL | Why it failed |
|------|-----|---------------|
| `graph.spec.ts` custom polygon shapes | `/graph?types=requirement,design-decision&depth=2` (no `?limit=`) | Dataset grew past the **default 200-node render budget** for that filter → view returns the "above node budget" placeholder (no SVG) → `svg polygon` count = 0 |
| `diagram-viewer.spec.ts` graph: viewer toolbar present | `/graph?limit=2000` (full ~871-node graph) | Page now heavy enough that `goto`+settle exceeds the timeout → `.svg-viewer` checks fail |
| `diagram-viewer.spec.ts` graph: fullscreen toggles class | same | same |

## Fix (test-only)

- Polygon test: add `&limit=2000` (the filtered subset still renders fast).
- diagram-viewer graph case: point at a **focused subgraph**
  `/graph?focus=REQ-001&depth=1&limit=2000` — this test pins the `.svg-viewer`
  toolbar **invariant**, not graph size, so a bounded graph exercises the same
  wrapper deterministically.

## Verification

Ran the affected specs in a real Chromium locally: **7/7 passed** (was 3
failing). `rivet validate` still PASS.

Verifies: REQ-171 · Refs: FEAT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)