### PR TITLE
fix(serve): preserve active variant scope when filtering/searching (REQ-172, #430)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5131,3 +5131,39 @@ artifacts:
     links:
       - type: traces-to
         target: FEAT-001
+
+  - id: REQ-172
+    type: requirement
+    title: "serve: filtering/search preserves the active variant scope (don't drop ?variant= on hx-push-url)"
+    status: implemented
+    description: |
+      Maintainer-reported (#430). In the serve dashboard the variant
+      `<select id="variant-selector" name="variant">` lives in the context bar,
+      OUTSIDE the filter form. The filter controls (search box, type filter,
+      per-page, status) issue `hx-get` requests with `hx-include` listing only
+      their own form fields and use `hx-push-url`. So filtering/searching a
+      variant-scoped view sent NO `variant=` and the pushed URL lost `?variant=`
+      — silently resetting the scope, and losing it again on reload.
+
+      Fix: add `#variant-selector` to every filter control's `hx-include`
+      (search_input, type_filter, per_page_select, filter_bar form + its inner
+      search, and the validate status select), via a shared
+      `hx_include_with_variant()` helper. The server already treats an empty
+      `variant=` as unscoped, so this is safe when no variant is active, and the
+      selector is only in the DOM when a variant model exists. The reverse flow
+      (select variant after filtering) was already correct: the change handler
+      rewrites only `variant` on the current URL, preserving other params.
+
+      Acceptance:
+        - `cd tests/playwright && npx playwright test serve-variant.spec.ts
+          --project=chromium` passes, including "filtering a variant-scoped list
+          keeps the variant in the URL (#430)".
+        - `cargo test -p rivet-cli --bins components` passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [serve, dashboard, variant, htmx, ux, bugfix, maintainer-reported, issue-430]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-109

--- a/rivet-cli/src/serve/components.rs
+++ b/rivet-cli/src/serve/components.rs
@@ -194,17 +194,32 @@ impl ViewParams {
 /// * `current_query` — current search value.
 /// * `target_url` — hx-get target (e.g. "/artifacts").
 /// * `include_names` — comma-separated list of input names to include via hx-include.
+/// Build an `hx-include` selector list for a filter control, always appending
+/// the variant selector (`#variant-selector`).
+///
+/// The variant `<select>` lives in the context bar, OUTSIDE the filter form,
+/// so a filter/search/sort request that only includes the form's own fields
+/// drops `variant=` — and because these controls use `hx-push-url`, the pushed
+/// URL loses `?variant=` too, so filtering or reloading silently resets the
+/// variant scope (#430). Including the selector explicitly keeps the active
+/// variant on every request. The server treats an empty `variant=` as unscoped
+/// (`api.rs`), so this is safe when no variant is active, and the selector is
+/// only present in the DOM when a variant model exists (otherwise the extra
+/// CSS selector simply matches nothing).
+fn hx_include_with_variant(include_names: &[&str]) -> String {
+    let mut selectors: Vec<String> =
+        include_names.iter().map(|n| format!("[name='{n}']")).collect();
+    selectors.push("#variant-selector".to_string());
+    selectors.join(",")
+}
+
 pub fn search_input(
     placeholder: &str,
     current_query: &str,
     target_url: &str,
     include_names: &[&str],
 ) -> String {
-    let hx_include: String = include_names
-        .iter()
-        .map(|n| format!("[name='{n}']"))
-        .collect::<Vec<_>>()
-        .join(",");
+    let hx_include = hx_include_with_variant(include_names);
     format!(
         "<div style=\"position:relative;flex:1;min-width:200px\">\
          <svg width=\"15\" height=\"15\" viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" \
@@ -238,11 +253,7 @@ pub fn type_select(
     target_url: &str,
     include_names: &[&str],
 ) -> String {
-    let hx_include: String = include_names
-        .iter()
-        .map(|n| format!("[name='{n}']"))
-        .collect::<Vec<_>>()
-        .join(",");
+    let hx_include = hx_include_with_variant(include_names);
     let mut html = format!(
         "<select name=\"types\" hx-get=\"{url}\" hx-target=\"#content\" hx-push-url=\"true\" \
          hx-include=\"{hx_include}\" \
@@ -279,11 +290,7 @@ pub fn type_select(
 /// * `target_url` — hx-get target.
 /// * `include_names` — other input names to include.
 pub fn per_page_select(current: usize, target_url: &str, include_names: &[&str]) -> String {
-    let hx_include: String = include_names
-        .iter()
-        .map(|n| format!("[name='{n}']"))
-        .collect::<Vec<_>>()
-        .join(",");
+    let hx_include = hx_include_with_variant(include_names);
     format!(
         "<select name=\"per_page\" hx-get=\"{url}\" hx-target=\"#content\" hx-push-url=\"true\" \
          hx-include=\"{hx_include}\" \
@@ -375,7 +382,8 @@ pub fn filter_bar(
 ) -> String {
     let mut html = String::with_capacity(2048);
     html.push_str(&format!(
-        "<div class=\"card\"><form class=\"form-row\" hx-get=\"{url}\" hx-target=\"#content\" hx-push-url=\"true\">",
+        "<div class=\"card\"><form class=\"form-row\" hx-get=\"{url}\" hx-target=\"#content\" \
+         hx-push-url=\"true\" hx-include=\"#variant-selector\">",
         url = html_escape(target_url),
     ));
 
@@ -416,7 +424,7 @@ pub fn filter_bar(
         "<div><label>Search</label><br>\
          <input type=\"text\" name=\"q\" placeholder=\"ID or title...\" value=\"{}\" \
          hx-get=\"{url}\" hx-target=\"#content\" hx-push-url=\"true\" \
-         hx-trigger=\"input changed delay:300ms\" hx-include=\"closest form\">\
+         hx-trigger=\"input changed delay:300ms\" hx-include=\"closest form,#variant-selector\">\
          </div>",
         html_escape(q_val),
         url = html_escape(target_url),
@@ -628,7 +636,7 @@ pub fn validation_filter_bar(
     // Severity filter
     html.push_str(
         "<select name=\"status\" hx-get=\"/validate\" hx-target=\"#content\" hx-push-url=\"true\" \
-         hx-include=\"[name='q']\" \
+         hx-include=\"[name='q'],#variant-selector\" \
          style=\"padding:.4rem .6rem;font-size:.82rem;min-width:140px\">",
     );
     for (val, label, count) in &[

--- a/rivet-cli/src/serve/components.rs
+++ b/rivet-cli/src/serve/components.rs
@@ -188,12 +188,6 @@ impl ViewParams {
 
 // ── Search input ──────────────────────────────────────────────────────────
 
-/// Render a search input with magnifying-glass icon.
-///
-/// * `placeholder` — placeholder text (e.g. "Search artifacts...").
-/// * `current_query` — current search value.
-/// * `target_url` — hx-get target (e.g. "/artifacts").
-/// * `include_names` — comma-separated list of input names to include via hx-include.
 /// Build an `hx-include` selector list for a filter control, always appending
 /// the variant selector (`#variant-selector`).
 ///
@@ -207,12 +201,20 @@ impl ViewParams {
 /// only present in the DOM when a variant model exists (otherwise the extra
 /// CSS selector simply matches nothing).
 fn hx_include_with_variant(include_names: &[&str]) -> String {
-    let mut selectors: Vec<String> =
-        include_names.iter().map(|n| format!("[name='{n}']")).collect();
+    let mut selectors: Vec<String> = include_names
+        .iter()
+        .map(|n| format!("[name='{n}']"))
+        .collect();
     selectors.push("#variant-selector".to_string());
     selectors.join(",")
 }
 
+/// Render a search input with magnifying-glass icon.
+///
+/// * `placeholder` — placeholder text (e.g. "Search artifacts...").
+/// * `current_query` — current search value.
+/// * `target_url` — hx-get target (e.g. "/artifacts").
+/// * `include_names` — comma-separated list of input names to include via hx-include.
 pub fn search_input(
     placeholder: &str,
     current_query: &str,

--- a/tests/playwright/serve-variant.spec.ts
+++ b/tests/playwright/serve-variant.spec.ts
@@ -95,4 +95,26 @@ test.describe("Variant selection in rivet serve", () => {
       () => !new URL(window.location.href).searchParams.has("variant"),
     );
   });
+
+  // Regression test for #430: filtering a variant-scoped list must keep the
+  // variant in the pushed URL. The variant <select> lives outside the filter
+  // form, so before the fix the filter request omitted `variant=` and
+  // `hx-push-url` rewrote the URL without it — silently resetting the scope
+  // (and losing it on reload). The fix adds `#variant-selector` to each filter
+  // control's hx-include.
+  test("filtering a variant-scoped list keeps the variant in the URL (#430)", async ({
+    page,
+  }) => {
+    await page.goto("/artifacts?variant=dashboard-only");
+    await expect(page.locator(".variant-banner")).toBeVisible();
+    // Type into the search box (htmx keyup-triggered, pushes a new URL).
+    const search = page.locator("input[name='q']").first();
+    await search.pressSequentially("REQ", { delay: 50 });
+    await page.waitForURL(/q=REQ/);
+    await waitForHtmx(page);
+    // The variant scope must survive the filter — both in the URL and the
+    // server-rendered banner (recomputed from `?variant=`).
+    await expect(page).toHaveURL(/variant=dashboard-only/);
+    await expect(page.locator(".variant-banner")).toBeVisible();
+  });
 });


### PR DESCRIPTION
Fixes #430.

## Problem (maintainer-reported)

In the serve dashboard, filtering or searching a **variant-scoped** view
silently reset the variant scope, and a reload lost it too.

Root cause: the variant `<select id="variant-selector" name="variant">` lives
in the context bar, **outside** the filter form. The filter controls
(`search_input`, `type_filter`, `per_page_select`, `filter_bar`, validate
status select) issue `hx-get` requests whose `hx-include` lists only their own
form fields, and they use `hx-push-url`. So a filter request sent **no**
`variant=`, and `hx-push-url` rewrote the URL **without** `?variant=` →
scope dropped (and lost on reload).

## Fix

Add `#variant-selector` to every filter control's `hx-include`, via a shared
`hx_include_with_variant()` helper. The server already treats an empty
`variant=` as unscoped (`api.rs`), so this is safe when no variant is active,
and the selector only exists in the DOM when a variant model is loaded.

The reverse flow (selecting a variant *after* filtering) was already correct —
the change handler rewrites only `variant` on the current URL, preserving the
other params.

## Verification (real browser)

- New Playwright regression test **"filtering a variant-scoped list keeps the
  variant in the URL (#430)"** — navigates to `/artifacts?variant=dashboard-only`,
  types in the search box, asserts the pushed URL still carries
  `variant=dashboard-only` and the scope banner remains.
- Full `serve-variant.spec.ts` passes **9/9**; `cargo test -p rivet-cli --bins
  components` **51/51**; `clippy --all-targets` clean; `rivet validate` PASS.

Implements: REQ-172 · Refs: REQ-109

🤖 Generated with [Claude Code](https://claude.com/claude-code)