### PR TITLE
fix(externals): ignore only .rivet/repos/ cache, not the whole .rivet/ dir (REQ-173, #433)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5167,3 +5167,36 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-109
+
+  - id: REQ-173
+    type: requirement
+    title: "rivet sync ignores only the external cache (.rivet/repos/), never the whole .rivet/ dir"
+    status: implemented
+    description: |
+      Self-found while dogfooding (#433). `ensure_gitignore` (called by `rivet
+      sync`) appended a blanket `.rivet/` to `.gitignore`, and its
+      already-present check only matched an exact `.rivet/`/`.rivet` line. But
+      rivet itself tracks files under `.rivet/` (e.g. `.rivet/agent-context.md`),
+      and the cache it actually writes is the narrower `.rivet/repos/`. So a
+      blanket `.rivet/` would silently un-track those committed files on a fresh
+      checkout, and it was added even when `.rivet/repos/` was already ignored.
+
+      Fix: append `.rivet/repos/` (the cache `sync` writes), and treat the entry
+      as already-present if any of `.rivet/repos/`, `.rivet/repos`, `.rivet/`, or
+      `.rivet` is present (so re-running is a no-op and a pre-existing broad
+      ignore is respected).
+
+      Acceptance:
+        - After `ensure_gitignore` on a fresh dir, `.gitignore` contains
+          `.rivet/repos/` and NO bare `.rivet/` line.
+        - A `.gitignore` already containing `.rivet/repos/` is left unchanged
+          (returns false).
+        - `cargo test -p rivet-core --lib ensure_gitignore` passes; `rivet
+          validate` on the rivet repo still PASS.
+    tags: [externals, sync, gitignore, bugfix, dogfooding, self-found, issue-433]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-020

--- a/rivet-core/src/externals.rs
+++ b/rivet-core/src/externals.rs
@@ -362,27 +362,33 @@ pub fn sync_all(
     Ok(results)
 }
 
-/// Ensure `.rivet/` is in `.gitignore`. Returns true if added, false if already present.
+/// Ensure the external cache (`.rivet/repos/`) is in `.gitignore`. Returns true
+/// if added, false if already present.
 pub fn ensure_gitignore(project_dir: &Path) -> Result<bool, crate::error::Error> {
     let gitignore = project_dir.join(".gitignore");
     if gitignore.exists() {
         let content = std::fs::read_to_string(&gitignore)
             .map_err(|e| crate::error::Error::Io(format!("read .gitignore: {e}")))?;
-        if content
-            .lines()
-            .any(|l| l.trim() == ".rivet/" || l.trim() == ".rivet")
-        {
+        // Already covered if any line ignores the cache — either the narrow
+        // `.rivet/repos/` we write, or a broad `.rivet/` a user added.
+        if content.lines().any(|l| {
+            let t = l.trim();
+            t == ".rivet/repos/" || t == ".rivet/repos" || t == ".rivet/" || t == ".rivet"
+        }) {
             return Ok(false); // already present
         }
     }
-    // Append
+    // Append. Ignore ONLY the external cache (`.rivet/repos/`), never the whole
+    // `.rivet/` directory — rivet itself tracks files under it (e.g.
+    // `.rivet/agent-context.md`), and a blanket `.rivet/` would silently
+    // un-track them on a fresh checkout (#433).
     use std::io::Write;
     let mut f = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&gitignore)
         .map_err(|e| crate::error::Error::Io(format!("open .gitignore: {e}")))?;
-    writeln!(f, "\n# Rivet external project cache\n.rivet/")
+    writeln!(f, "\n# Rivet external project cache\n.rivet/repos/")
         .map_err(|e| crate::error::Error::Io(format!("write .gitignore: {e}")))?;
     Ok(true) // added
 }
@@ -1221,9 +1227,29 @@ mod tests {
         let added_again = ensure_gitignore(dir.path()).unwrap();
         assert!(!added_again);
 
-        // Verify contents
+        // Verify contents: ignore the narrow cache, NOT the whole .rivet/ dir
+        // (rivet tracks files like .rivet/agent-context.md). #433.
         let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
-        assert!(content.contains(".rivet/"));
+        assert!(content.contains(".rivet/repos/"));
+        assert!(
+            !content
+                .lines()
+                .any(|l| l.trim() == ".rivet/" || l.trim() == ".rivet"),
+            "must not blanket-ignore the whole .rivet/ directory"
+        );
+    }
+
+    // rivet: verifies REQ-173
+    #[test]
+    fn ensure_gitignore_respects_existing_cache_ignore() {
+        // A pre-existing narrow `.rivet/repos/` entry is treated as present —
+        // no duplicate, and no broad `.rivet/` is appended on top.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".gitignore"), "target/\n.rivet/repos/\n").unwrap();
+        let added = ensure_gitignore(dir.path()).unwrap();
+        assert!(!added, "existing .rivet/repos/ should count as present");
+        let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert_eq!(content, "target/\n.rivet/repos/\n", "unchanged");
     }
 
     // rivet: verifies REQ-020


### PR DESCRIPTION
Fixes #433.

## Problem (self-found while dogfooding)

`ensure_gitignore` (run by `rivet sync`) appended a blanket `.rivet/` to
`.gitignore`, and its already-present check only matched an exact `.rivet/` /
`.rivet` line. Two problems:

- rivet itself **tracks** files under `.rivet/` (e.g. `.rivet/agent-context.md`),
  so a blanket `.rivet/` would silently un-track them on a fresh checkout.
- The cache `sync` actually writes is the narrower `.rivet/repos/`, so the broad
  entry was both wrong and added even when `.rivet/repos/` was already ignored.

## Fix

- Append **`.rivet/repos/`** (the cache `sync` writes), never the whole `.rivet/`.
- Treat the entry as already-present if any of `.rivet/repos/`, `.rivet/repos`,
  `.rivet/`, or `.rivet` is present — so re-running is a no-op and a
  pre-existing broad ignore is respected.

## Verification

- `cargo test -p rivet-core --lib ensure_gitignore` — 2/2, including the new
  `ensure_gitignore_respects_existing_cache_ignore` (existing `.rivet/repos/`
  left unchanged) and an assertion that no bare `.rivet/` line is written.
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean;
  `rivet validate` PASS.

Implements: REQ-173 · Refs: REQ-020

🤖 Generated with [Claude Code](https://claude.com/claude-code)