### PR TITLE
ci(hooks): pre-commit also runs cargo fmt --check on staged Rust (REQ-174, #438)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5201,6 +5201,38 @@ artifacts:
       - type: traces-to
         target: REQ-020
 
+  - id: REQ-174
+    type: requirement
+    title: "install-hooks.sh pre-commit also runs cargo fmt --check on staged Rust (catch the most common CI Format failure locally)"
+    status: implemented
+    description: |
+      Self-found while dogfooding (#438). The generated pre-commit hook in
+      `scripts/install-hooks.sh` ran only `rivet validate` — not `cargo fmt
+      --check` — so AI-agent/contributor commits passed local hooks but failed
+      the CI Format job (the single most common first-push failure; cf. #437).
+      A separate `scripts/pre-commit` file DID run fmt+clippy but was orphaned
+      (the installer never wired it).
+
+      Add a fast `cargo fmt --all -- --check` step to the installed pre-commit
+      hook, gated on staged Rust files (`git diff --cached … | grep '\.rs$'`),
+      blocking with a clear "run cargo fmt --all" message. Clippy/test stay out
+      of the per-commit hook (too slow) — they remain CI's job. Convenience
+      only; CI is still the real gate (REQ-051).
+
+      Acceptance:
+        - After `scripts/install-hooks.sh`, committing a staged Rust file with a
+          formatting violation is blocked by the pre-commit hook (exit 1); a
+          clean tree (or a commit with no staged `.rs`) is not blocked.
+        - `bash -n scripts/install-hooks.sh` passes; `rivet validate` on the
+          rivet repo still PASS.
+    tags: [ci, hooks, dx, fmt, dogfooding, self-found, issue-438]
+    fields:
+      priority: should
+      category: process
+    links:
+      - type: traces-to
+        target: REQ-051
+
   - id: REQ-175
     type: requirement
     title: "serve /graph integration tests retry on status==0 so they don't flap red on unrelated PRs"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -31,8 +31,21 @@ echo "  commit-msg hook installed"
 # ── pre-commit hook ──────────────────────────────────────────────────
 cat > "$HOOKS_DIR/pre-commit" << 'HOOK'
 #!/usr/bin/env bash
-# Run rivet validate before commit. Blocks on errors.
+# Pre-commit: cargo fmt check (staged Rust) + rivet validate. Blocks on errors.
 # Installed by scripts/install-hooks.sh
+
+# Formatting is the single most common first-push CI failure and is cheap
+# (~1s), so guard it here when the commit touches Rust. Clippy/test are too
+# slow for every commit — they stay in CI (and an optional pre-push hook).
+# This hook is convenience only; CI is the real gate (see REQ-051).
+if command -v cargo &>/dev/null \
+    && git diff --cached --name-only --diff-filter=ACM | grep -q '\.rs$'; then
+    if ! cargo fmt --all -- --check; then
+        echo "cargo fmt: formatting issues. Run 'cargo fmt --all', then re-stage."
+        exit 1
+    fi
+fi
+
 RIVET_BIN="${RIVET_BIN:-rivet}"
 if command -v "$RIVET_BIN" &>/dev/null; then
     output=$("$RIVET_BIN" validate --format json 2>/dev/null)
@@ -45,6 +58,6 @@ if command -v "$RIVET_BIN" &>/dev/null; then
 fi
 HOOK
 chmod +x "$HOOKS_DIR/pre-commit"
-echo "  pre-commit hook installed"
+echo "  pre-commit hook installed (cargo fmt check + rivet validate)"
 
 echo "Done. Hooks will use '$RIVET_BIN' binary."


### PR DESCRIPTION
Addresses #438.

## Problem (self-found while dogfooding)

`scripts/install-hooks.sh` generates a pre-commit hook that runs **only**
`rivet validate` — not `cargo fmt --check`. So agent/contributor commits pass
local hooks but fail the CI **Format** job (the single most common first-push
failure; this loop hit it on #437). A separate `scripts/pre-commit` file *did*
run fmt+clippy, but it was orphaned — the installer never wired it.

## Fix

Add a fast `cargo fmt --all -- --check` step to the installed pre-commit hook,
**gated on staged Rust files** (`git diff --cached … | grep '\.rs$'`), blocking
with a clear "run `cargo fmt --all`" message. Clippy/test stay out of the
per-commit hook (too slow) — they remain CI's responsibility. Convenience only;
CI is still the real gate (REQ-051).

## Verification

- Installed the hooks and tested: a staged Rust file with a formatting
  violation **blocks** the hook (exit 1, prints the fmt diff); a clean tree and
  a commit with **no** staged `.rs` are **not** blocked (this very PR's commit
  exercised that path — non-Rust commit, fmt skipped, validate ran).
- `bash -n scripts/install-hooks.sh` clean; `rivet validate` PASS.

Implements: REQ-174 · Refs: REQ-051

🤖 Generated with [Claude Code](https://claude.com/claude-code)