### PR TITLE
test(serve): /graph tests retry on status==0 to stop flapping on unrelated PRs (REQ-175)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5200,3 +5200,36 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-020
+
+  - id: REQ-175
+    type: requirement
+    title: "serve /graph integration tests retry on status==0 so they don't flap red on unrelated PRs"
+    status: implemented
+    description: |
+      Self-found while triaging a red CI Test job on an artifact/script-only PR
+      (#440). `cargo nextest` exit 100 → the JUnit artifact named
+      `serve_integration::graph_type_filter_renders_when_under_budget`, which
+      asserted `/graph?types=requirement` returns 200 but got status=0 (a
+      transient connection drop after the server's health probe passed — a
+      transport failure, not a content mismatch). It passed locally; my change
+      was shell + YAML only.
+
+      The file already had `fetch_page_with_retry` (15s read timeout + one retry
+      on status==0) created for exactly this flake class, but the two /graph
+      tests (`graph_focused_view_renders_svg`,
+      `graph_type_filter_renders_when_under_budget`) called `fetch_with_timeout`
+      directly, bypassing the retry. Switch both to `fetch_page_with_retry`.
+
+      Acceptance:
+        - `cargo test -p rivet-cli --test serve_integration graph_` passes.
+        - Neither `graph_focused_view_renders_svg` nor
+          `graph_type_filter_renders_when_under_budget` calls
+          `fetch_with_timeout` directly (both use the status==0 retry wrapper).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [serve, test, ci-stability, flake, dogfooding, self-found]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: FEAT-001

--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -999,12 +999,10 @@ fn graph_focused_view_renders_svg() {
     let (mut child, port) = start_server();
 
     let start = std::time::Instant::now();
-    let (status, body, _) = fetch_with_timeout(
-        port,
-        "/graph?focus=REQ-001&depth=2",
-        true,
-        std::time::Duration::from_secs(15),
-    );
+    // Use the retry wrapper (15s + one retry on status==0): besides the
+    // latency edge, a transient connection drop after the health probe
+    // surfaces as status=0 and flapped this test red on unrelated PRs.
+    let (status, body, _) = fetch_page_with_retry(port, "/graph?focus=REQ-001&depth=2");
     let elapsed = start.elapsed();
     eprintln!(
         "graph_focused_view_renders_svg: GET /graph?focus=REQ-001&depth=2 -> {} bytes in {elapsed:?}",
@@ -1114,15 +1112,11 @@ fn graph_type_filter_renders_when_under_budget() {
     // The type-filtered graph still does a BFS + layout over the dogfood
     // corpus, which can brush past the default 5s read timeout on a loaded CI
     // runner — the same chronic flake the focus-graph tests hit, where a
-    // timeout surfaces as status=0 and fails the `== 200` assertion. Give it
-    // the same generous budget the other graph endpoints use; this test
-    // asserts on the response, not on a hard latency bound.
-    let (status, body, _) = fetch_with_timeout(
-        port,
-        "/graph?types=requirement",
-        true,
-        Duration::from_secs(15),
-    );
+    // timeout (or a transient connection drop after the health probe) surfaces
+    // as status=0 and fails the `== 200` assertion. Use the retry wrapper
+    // (15s + one retry on status==0); this test asserts on the response, not
+    // on a hard latency bound. (Observed flapping red on artifact-only PRs.)
+    let (status, body, _) = fetch_page_with_retry(port, "/graph?types=requirement");
     let elapsed = start.elapsed();
     let has_svg = body.contains("<svg");
     let has_budget = body.contains("budget");


### PR DESCRIPTION
## Problem (self-found triaging a red CI Test job)

PR #440 (artifact + shell only) failed the **Test** job. `cargo nextest` exit
100 → the uploaded JUnit named the failure:

```
serve_integration::graph_type_filter_renders_when_under_budget
  assertion `left == right` failed: /graph?types=requirement must return 200
  left: 0   right: 200
```

Status **0** = a transient connection drop after the server's `/api/v1/health`
probe already passed (a transport flake, not a content mismatch). It passed in
the full local suite; #440 touched no Rust.

## Root cause

`serve_integration.rs` already has `fetch_page_with_retry` (15s read timeout +
one retry on `status == 0`) built for exactly this flake class. But the two
`/graph` tests — `graph_focused_view_renders_svg` and
`graph_type_filter_renders_when_under_budget` — called `fetch_with_timeout`
**directly**, bypassing the retry (the author bumped the timeout but didn't add
the retry).

## Fix

Switch both to `fetch_page_with_retry`. No assertion weakened — same 15s budget,
plus the established status-0 retry the rest of the file uses.

## Verification

- `cargo test -p rivet-cli --test serve_integration graph_` → 4/4 pass.
- `cargo fmt --check` clean; `rivet validate` PASS.

Verifies: REQ-175 · Refs: FEAT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)