### PR TITLE
feat(schema): rivet schema info reports on-disk vs embedded source (REQ-176, #431)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5233,3 +5233,37 @@ artifacts:
     links:
       - type: traces-to
         target: FEAT-001
+
+  - id: REQ-176
+    type: requirement
+    title: "rivet schema info reports whether a schema is on-disk (pinned) or embedded (binary-versioned)"
+    status: implemented
+    description: |
+      Self-found triaging #431. `load_schemas_with_fallback` resolves each
+      schema as on-disk (`<schemas_dir>/<name>.yaml`) if present, else the
+      compiled-in embedded copy — but never reports which source it used. So a
+      project relying on builtin schemas gets the embedded copy swapped
+      silently when the rivet binary is upgraded, and cross-version diagnostic
+      drift ("issues appearing") looks like it came from nowhere.
+
+      `rivet schema info <name>` already prints the version; add a `Source:`
+      line to its text output naming on-disk (with path) vs embedded (with a
+      hint to vendor under schemas/ to pin). The on-disk-vs-embedded branch is
+      already computed inline in the Info command, so this is a local change —
+      no loader signature change. JSON output is unchanged (keeps its
+      documented shape).
+
+      Acceptance:
+        - `rivet --schemas <dir-with-common.yaml> schema info common` text
+          output contains `Source: on-disk`; with an empty schemas dir it
+          contains `Source: embedded`.
+        - `cargo test -p rivet-cli --test cli_commands schema_info` passes
+          (incl. the unchanged `schema_info_json`).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [schema, embedded, dx, cross-version, dogfooding, self-found, issue-431]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-010

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -10482,14 +10482,34 @@ fn cmd_schema(cli: &Cli, action: &SchemaAction) -> Result<bool> {
         SchemaAction::Validate => schema_cmd::cmd_validate(&schema),
         SchemaAction::Info { name, format } => {
             let path = schemas_dir.join(format!("{name}.yaml"));
-            let schema_file = if path.exists() {
-                rivet_core::schema::Schema::load_file(&path)
-                    .with_context(|| format!("loading schema {}", path.display()))?
+            // Track WHERE the schema resolved from: an on-disk file (pinned in
+            // the project, version-controlled) vs the compiled-in embedded copy
+            // (which changes silently when the rivet binary is upgraded). #431:
+            // without this, a user can't tell their builtin schema is
+            // binary-versioned, so cross-version diagnostic drift looks like it
+            // appeared from nowhere.
+            let (schema_file, source) = if path.exists() {
+                (
+                    rivet_core::schema::Schema::load_file(&path)
+                        .with_context(|| format!("loading schema {}", path.display()))?,
+                    format!("on-disk ({})", path.display()),
+                )
             } else {
-                rivet_core::embedded::load_embedded_schema(name)
-                    .map_err(|e| anyhow::anyhow!("{e}"))?
+                (
+                    rivet_core::embedded::load_embedded_schema(name)
+                        .map_err(|e| anyhow::anyhow!("{e}"))?,
+                    "embedded (compiled into the rivet binary — changes when rivet is upgraded; \
+                     vendor it under schemas/ to pin)"
+                        .to_string(),
+                )
             };
-            schema_cmd::cmd_info(&schema_file, format)
+            let mut info = schema_cmd::cmd_info(&schema_file, format);
+            // Append the source on text output only; JSON output keeps its
+            // documented shape (schema-info.schema.json).
+            if format == "text" {
+                info.push_str(&format!("\nSource: {source}\n"));
+            }
+            info
         }
         SchemaAction::ListJson { .. }
         | SchemaAction::GetJson { .. }

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -2294,6 +2294,65 @@ fn schema_info_json() {
     );
 }
 
+/// `rivet schema info <name>` (text) reports whether the schema resolved from
+/// an on-disk file (pinned in the project) or the embedded copy (compiled into
+/// the binary, changes on upgrade). #431 / REQ-176.
+// rivet: verifies REQ-176
+#[test]
+fn schema_info_reports_source() {
+    // Embedded: an empty schemas dir → `common` falls back to the compiled-in
+    // copy, and the source line must say so.
+    let empty = tempfile::tempdir().unwrap();
+    let out = Command::new(rivet_bin())
+        .args([
+            "--schemas",
+            empty.path().to_str().unwrap(),
+            "schema",
+            "info",
+            "common",
+        ])
+        .output()
+        .expect("run schema info (embedded)");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains("Source: embedded"),
+        "expected embedded source, got:\n{text}"
+    );
+
+    // On-disk: a schemas dir holding common.yaml → reported as on-disk (pinned).
+    let ondisk = tempfile::tempdir().unwrap();
+    std::fs::copy(
+        project_root().join("schemas").join("common.yaml"),
+        ondisk.path().join("common.yaml"),
+    )
+    .expect("copy common.yaml");
+    let out2 = Command::new(rivet_bin())
+        .args([
+            "--schemas",
+            ondisk.path().to_str().unwrap(),
+            "schema",
+            "info",
+            "common",
+        ])
+        .output()
+        .expect("run schema info (on-disk)");
+    assert!(
+        out2.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    let text2 = String::from_utf8_lossy(&out2.stdout);
+    assert!(
+        text2.contains("Source: on-disk"),
+        "expected on-disk source, got:\n{text2}"
+    );
+}
+
 // ── JSON validity sweep ────────────────────────────────────────────────
 
 /// Comprehensive sweep: every command that accepts `--format json` must


### PR DESCRIPTION
Addresses #431.

## Problem

`load_schemas_with_fallback` resolves each schema as on-disk
(`<schemas_dir>/<name>.yaml`) if present, else the compiled-in **embedded**
copy — but never reports which source it used. So a project relying on builtin
schemas gets the embedded copy swapped silently when the rivet binary is
upgraded, and cross-version diagnostic drift ("issues appearing") looks like it
came from nowhere. `rivet schema info` already shows the version but not the
source.

## Fix

Add a `Source:` line to `rivet schema info <name>` **text** output:
- `Source: on-disk (./schemas/common.yaml)` — pinned, version-controlled.
- `Source: embedded (compiled into the rivet binary — changes when rivet is
  upgraded; vendor it under schemas/ to pin)`.

The on-disk-vs-embedded branch is already computed inline in the `Info`
command, so this is a local change — no loader signature change. JSON output is
unchanged (keeps its `schema-info.schema.json` shape).

## Verification

- New `schema_info_reports_source` test drives both branches deterministically
  via `--schemas` (empty dir → embedded; dir with `common.yaml` → on-disk).
- The existing `schema_info_json` still passes (JSON unaffected).
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean;
  `rivet validate` PASS.

Implements: REQ-176 · Refs: REQ-010

🤖 Generated with [Claude Code](https://claude.com/claude-code)