### PR TITLE
feat(schema): add `rivet schema sources` — on-disk vs embedded resolution (REQ-177, #431)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5299,3 +5299,38 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-010
+
+  - id: REQ-177
+    type: requirement
+    title: "rivet schema sources lists each active schema's resolution (on-disk pinned vs embedded binary-versioned)"
+    status: implemented
+    description: |
+      Completes the #431 surfacing started in REQ-176. `schema info` shows one
+      schema's source, but a user wants the whole active set at a glance to
+      answer "am I on builtin (embedded, changes on upgrade) or vendored
+      (pinned) schemas?". Add `rivet schema sources` (text + `--format json`)
+      listing each name in `rivet.yaml`'s `schemas:` with on-disk (path) /
+      embedded / missing.
+
+      Backed by a reusable `embedded::schema_sources(names, schemas_dir) ->
+      [(name, SchemaSource)]` helper (OnDisk(path) | Embedded | Missing),
+      mirroring load_schemas_with_fallback's precedence. The command resolves
+      sources WITHOUT loading the schema graph, so it still works (and reports
+      `missing`) when a schema can't be loaded — diagnosing that is the point.
+
+      Acceptance:
+        - `rivet schema sources` (this repo, schemas vendored) shows every
+          schema as `on-disk`.
+        - For a project whose schemas aren't vendored, `rivet schema sources
+          --format json` succeeds (exit 0) and reports a builtin name as
+          `embedded` and an unknown name as `missing`.
+        - `cargo test -p rivet-core --lib schema_sources` and `cargo test -p
+          rivet-cli --test cli_commands schema_sources_reports_resolution` pass.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [schema, embedded, cli, dx, cross-version, dogfooding, self-found, issue-431]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-010

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1240,6 +1240,13 @@ enum SchemaAction {
         #[arg(short, long, default_value = "text")]
         format: String,
     },
+    /// Show where each active schema resolves from: on-disk (pinned) vs
+    /// embedded (compiled into the rivet binary, changes on upgrade) (#431)
+    Sources {
+        /// Output format: "text" (default) or "json"
+        #[arg(short, long, default_value = "text")]
+        format: String,
+    },
     /// List JSON schemas describing `--format json` CLI outputs
     ///
     /// Rivet ships draft-2020-12 JSON Schemas for every `--format json`
@@ -10391,6 +10398,12 @@ fn cmd_schema(cli: &Cli, action: &SchemaAction) -> Result<bool> {
         SchemaAction::GetJson { name, content } => {
             return cmd_schema_get_json(cli, name, *content);
         }
+        // Resolve sources WITHOUT loading the schema graph — the whole point is
+        // to diagnose resolution (incl. missing/embedded schemas), which must
+        // work even when the full load would fail.
+        SchemaAction::Sources { format } => {
+            return cmd_schema_sources(cli, format);
+        }
         SchemaAction::Migrate {
             target,
             apply,
@@ -10513,9 +10526,69 @@ fn cmd_schema(cli: &Cli, action: &SchemaAction) -> Result<bool> {
         }
         SchemaAction::ListJson { .. }
         | SchemaAction::GetJson { .. }
+        | SchemaAction::Sources { .. }
         | SchemaAction::Migrate { .. } => unreachable!(),
     };
     print!("{output}");
+    Ok(true)
+}
+
+/// `rivet schema sources` — report where each active schema resolves from:
+/// an on-disk file (pinned in the project) vs the embedded copy compiled into
+/// the rivet binary (which changes silently on upgrade). Does NOT load the
+/// schema graph, so it works even when a schema is missing (#431 / REQ-177).
+fn cmd_schema_sources(cli: &Cli, format: &str) -> Result<bool> {
+    validate_format(format, &["text", "json"])?;
+    use rivet_core::embedded::SchemaSource;
+    let schemas_dir = resolve_schemas_dir(cli);
+    // The project's active schema list drives what we report; fall back to
+    // `common` only when there's no rivet.yaml.
+    let config_path = cli.project.join("rivet.yaml");
+    let names: Vec<String> = if config_path.exists() {
+        rivet_core::load_project_config(&config_path)
+            .with_context(|| format!("loading {}", config_path.display()))?
+            .project
+            .schemas
+    } else {
+        vec!["common".to_string()]
+    };
+    let sources = rivet_core::embedded::schema_sources(&names, &schemas_dir);
+
+    if format == "json" {
+        let arr: Vec<serde_json::Value> = sources
+            .iter()
+            .map(|(name, src)| {
+                serde_json::json!({
+                    "name": name,
+                    "source": src.kind(),
+                    "path": match src {
+                        SchemaSource::OnDisk(p) => Some(p.display().to_string()),
+                        _ => None,
+                    },
+                })
+            })
+            .collect();
+        let out = serde_json::to_string_pretty(&serde_json::json!({
+            "command": "schema-sources",
+            "schemas": arr,
+        }))
+        .unwrap_or_default();
+        println!("{out}");
+    } else {
+        println!("Schema sources ({}):", sources.len());
+        for (name, src) in &sources {
+            let detail = match src {
+                SchemaSource::OnDisk(p) => format!("on-disk   {}", p.display()),
+                SchemaSource::Embedded => "embedded  (compiled into rivet — changes on \
+                     upgrade; vendor under schemas/ to pin)"
+                    .to_string(),
+                SchemaSource::Missing => "MISSING   (no on-disk file and not a known \
+                     embedded schema)"
+                    .to_string(),
+            };
+            println!("  {name:<18} {detail}");
+        }
+    }
     Ok(true)
 }
 

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -2353,6 +2353,61 @@ fn schema_info_reports_source() {
     );
 }
 
+/// `rivet schema sources` reports each active schema's resolution (on-disk /
+/// embedded / missing) and — crucially — succeeds even when a schema can't be
+/// loaded, since diagnosing that is the point. #431 / REQ-177.
+// rivet: verifies REQ-177
+#[test]
+fn schema_sources_reports_resolution() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("rivet.yaml"),
+        "project:\n  name: t\n  schemas: [common, made-up]\n",
+    )
+    .unwrap();
+    // An existing-but-empty schemas dir → nothing vendored, so `common` falls
+    // back to embedded and `made-up` is missing.
+    let empty = tempfile::tempdir().unwrap();
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.path().to_str().unwrap(),
+            "--schemas",
+            empty.path().to_str().unwrap(),
+            "schema",
+            "sources",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("run schema sources");
+    assert!(
+        out.status.success(),
+        "schema sources must succeed despite a missing schema. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("valid JSON");
+    assert_eq!(
+        v.get("command").and_then(|c| c.as_str()),
+        Some("schema-sources")
+    );
+    let schemas = v
+        .get("schemas")
+        .and_then(|s| s.as_array())
+        .expect("schemas array");
+    let common = schemas
+        .iter()
+        .find(|s| s["name"] == "common")
+        .expect("common present");
+    assert_eq!(common["source"], "embedded");
+    let made = schemas
+        .iter()
+        .find(|s| s["name"] == "made-up")
+        .expect("made-up present");
+    assert_eq!(made["source"], "missing");
+}
+
 // ── JSON validity sweep ────────────────────────────────────────────────
 
 /// Comprehensive sweep: every command that accepts `--format json` must

--- a/rivet-core/src/embedded.rs
+++ b/rivet-core/src/embedded.rs
@@ -140,6 +140,58 @@ pub const BRIDGE_SCHEMAS: &[BridgeInfo] = &[
     },
 ];
 
+/// Where a schema named in `rivet.yaml` resolves from.
+///
+/// Mirrors the resolution order of [`load_schemas_with_fallback`]: an on-disk
+/// file under `<schemas_dir>/` wins; otherwise the compiled-in embedded copy is
+/// used. Surfacing this lets callers tell a user when a builtin schema is
+/// *embedded* (version-bound to the rivet binary, so it changes silently on
+/// upgrade) vs *on-disk* (pinned in the project, version-controlled). #431.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaSource {
+    /// Resolved from a project file at this path (pinned in git).
+    OnDisk(std::path::PathBuf),
+    /// Resolved from the copy compiled into the rivet binary.
+    Embedded,
+    /// Neither on-disk nor embedded — an unknown schema name.
+    Missing,
+}
+
+impl SchemaSource {
+    /// A short machine token: `on-disk` / `embedded` / `missing`.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            SchemaSource::OnDisk(_) => "on-disk",
+            SchemaSource::Embedded => "embedded",
+            SchemaSource::Missing => "missing",
+        }
+    }
+}
+
+/// For each requested schema name, report where it resolves from, using the
+/// same precedence as [`load_schemas_with_fallback`] (on-disk file else
+/// embedded copy). Pure: only checks path existence and the embedded registry.
+/// Order follows `names`.
+pub fn schema_sources(
+    names: &[String],
+    schemas_dir: &std::path::Path,
+) -> Vec<(String, SchemaSource)> {
+    names
+        .iter()
+        .map(|name| {
+            let path = schemas_dir.join(format!("{name}.yaml"));
+            let source = if path.exists() {
+                SchemaSource::OnDisk(path)
+            } else if embedded_schema(name).is_some() {
+                SchemaSource::Embedded
+            } else {
+                SchemaSource::Missing
+            };
+            (name.clone(), source)
+        })
+        .collect()
+}
+
 /// Look up embedded schema content by name.
 pub fn embedded_schema(name: &str) -> Option<&'static str> {
     match name {
@@ -298,4 +350,34 @@ pub fn load_schemas_with_fallback(
     }
 
     Ok(crate::schema::Schema::merge(&files))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // rivet: verifies REQ-177
+    #[test]
+    fn schema_sources_classifies_on_disk_embedded_and_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        // An on-disk file shadows the embedded copy.
+        std::fs::write(dir.path().join("common.yaml"), "schema:\n  name: common\n").unwrap();
+
+        let names = vec![
+            "common".to_string(),  // on-disk (file present)
+            "stpa".to_string(),    // embedded (no file, but a known embedded name)
+            "made-up".to_string(), // missing (neither)
+        ];
+        let got = schema_sources(&names, dir.path());
+
+        assert_eq!(got[0].1.kind(), "on-disk");
+        assert!(matches!(&got[0].1, SchemaSource::OnDisk(p) if p.ends_with("common.yaml")));
+        assert_eq!(got[1].1, SchemaSource::Embedded);
+        assert_eq!(got[2].1, SchemaSource::Missing);
+        // Order follows the input names.
+        assert_eq!(
+            got.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>(),
+            vec!["common", "stpa", "made-up"]
+        );
+    }
 }


### PR DESCRIPTION
Completes the #431 surfacing started in #442 (REQ-176).

## What

`rivet schema info` shows one schema's source; this adds **`rivet schema
sources`** to list the whole active set at a glance, so a user can immediately
tell whether they're on **vendored** (on-disk, pinned in git) or **builtin**
(embedded, version-bound to the rivet binary → changes silently on upgrade)
schemas — the root cause of #431's "issues appear across versions".

```
$ rivet schema sources
Schema sources (7):
  common             on-disk   ./schemas/common.yaml
  stpa               embedded  (compiled into rivet — changes on upgrade; vendor under schemas/ to pin)
  made-up            MISSING   (no on-disk file and not a known embedded schema)
```

Also `--format json` for CI/agents (`{command, schemas:[{name,source,path}]}`).

## How

- Reusable `embedded::schema_sources(names, schemas_dir) -> [(name,
  SchemaSource)]` helper (`OnDisk(path)` / `Embedded` / `Missing`), mirroring
  `load_schemas_with_fallback` precedence.
- The command resolves sources **without** loading the schema graph, so it
  still works (and reports `missing`) when a schema can't be loaded — diagnosing
  that is the whole point.

## Verification

- `schema_sources` unit test (rivet-core) + `schema_sources_reports_resolution`
  integration test (asserts exit 0 **despite** a missing schema, common→embedded,
  made-up→missing).
- `cargo fmt --check` + `clippy --all-targets -- -D warnings` clean; `rivet docs
  check` PASS; `rivet validate` PASS.

Implements: REQ-177 · Refs: REQ-176, REQ-010

🤖 Generated with [Claude Code](https://claude.com/claude-code)