### PR TITLE
docs(artifacts): realize shipped dogfood REQs with feature artifacts (coverage 27.9%→31.8%)

### DIFF
--- a/artifacts/features.yaml
+++ b/artifacts/features.yaml
@@ -1502,3 +1502,69 @@ artifacts:
     provenance:
       created-by: ai-assisted
       timestamp: 2026-04-07T03:40:26Z
+
+  - id: FEAT-136
+    type: feature
+    title: Externals sync safety
+    status: implemented
+    description: >
+      Cross-repo externals are synced and validated without destroying local
+      work or hiding gaps: `rivet sync` refuses to clobber uncommitted edits in
+      a git external's cache (REQ-169), `rivet validate` surfaces un-synced
+      externals so cycle/backlink checks aren't silently incomplete (REQ-170),
+      and `sync` ignores only the `.rivet/repos/` cache rather than the whole
+      `.rivet/` directory (REQ-173).
+    tags: [externals, sync, cross-repo, safety, dogfooding]
+    links:
+      - type: satisfies
+        target: REQ-169
+      - type: satisfies
+        target: REQ-170
+      - type: satisfies
+        target: REQ-173
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-04T00:42:44Z
+
+  - id: FEAT-137
+    type: feature
+    title: Schema source provenance
+    status: implemented
+    description: >
+      Users can see whether each active schema resolves from a pinned on-disk
+      file or the binary-versioned embedded copy: `rivet schema info` reports the
+      source per schema (REQ-176) and `rivet schema sources` lists the whole
+      active set as on-disk / embedded / missing (REQ-177) — making
+      cross-version schema drift visible instead of surprising.
+    tags: [schema, embedded, provenance, dogfooding]
+    links:
+      - type: satisfies
+        target: REQ-176
+      - type: satisfies
+        target: REQ-177
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-04T00:42:44Z
+
+  - id: FEAT-138
+    type: feature
+    title: Traceability navigation and diagnostic guidance
+    status: implemented
+    description: >
+      Commands that help a user navigate and understand the traceability graph:
+      `rivet bundle --incoming` follows backlinks so bundling a sink requirement
+      includes what realizes it (REQ-168), and `rivet validate --explain` names
+      which required backlink source types can attach directly vs. only via an
+      intermediate design artifact (REQ-178).
+    tags: [traceability, diagnostics, dx, dogfooding]
+    links:
+      - type: satisfies
+        target: REQ-168
+      - type: satisfies
+        target: REQ-178
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-04T00:42:44Z


### PR DESCRIPTION
## Dogfooding finding

While exercising rivet on its own repo, `rivet coverage` showed
`requirement-coverage` at 27.9% — and the loop's own recently-shipped REQs
(168–178) all had **zero** incoming `satisfies` links. The loop had been
filing requirements and marking them `implemented` without creating the
`feature`/`design-decision` artifacts that realize them, silently degrading the
repo's own traceability.

## Fix (honest traceability completion)

Three accurate feature artifacts for the shipped capability clusters, each
`satisfies`-linking the REQs it realizes:

| Feature | Realizes |
|---------|----------|
| FEAT-136 Externals sync safety | REQ-169, REQ-170, REQ-173 |
| FEAT-137 Schema source provenance | REQ-176, REQ-177 |
| FEAT-138 Traceability navigation & diagnostic guidance | REQ-168, REQ-178 |

`requirement-coverage` 50/179 → 57/179 (31.8%); `rivet validate` PASS. These
features describe real, merged capabilities — not metric-gaming.

Refs: REQ-168, REQ-169, REQ-170, REQ-173, REQ-176, REQ-177, REQ-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)