### PR TITLE
feat(cli): rivet next-id accepts a positional type/prefix shorthand (REQ-179, #447)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5374,3 +5374,36 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-004
+
+  - id: REQ-179
+    type: requirement
+    title: "rivet next-id accepts a positional type/prefix shorthand (rivet next-id requirement)"
+    status: implemented
+    description: |
+      Self-found (#447): when I needed the next free FEAT id I reached for a
+      manual grep (and collided, since ids span 9+ files) — not realising
+      `rivet next-id` already existed (since #28) and scans the whole store.
+      A discoverability miss, but it surfaced a real papercut: the natural
+      positional form `rivet next-id feature` was rejected with "unexpected
+      argument 'feature'"; you had to know to pass `--type feature`.
+
+      Add an optional positional `TYPE_OR_PREFIX` that is a shorthand for
+      `--type` (routed through `prefix_for_type`, whose uppercase fallback also
+      makes a bare prefix like `FEAT` work). Explicit `--type`/`--prefix` win if
+      given. The no-argument error now lists all three usable forms instead of
+      "either --type or --prefix must be specified".
+
+      Acceptance:
+        - `rivet next-id requirement` equals `rivet next-id --type requirement`;
+          `rivet next-id FEAT` prints a `FEAT-` id; `rivet next-id` with no arg
+          exits non-zero with a message naming the positional + flag forms.
+        - `cargo test -p rivet-cli --test cli_commands next_id_positional_shorthand`
+          passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, dx, mutation, discoverability, dogfooding, self-found, issue-447]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -953,6 +953,11 @@ enum Command {
 
     /// Print the next available ID for a given artifact type or prefix
     NextId {
+        /// Artifact type or ID prefix as a positional shorthand, e.g.
+        /// `rivet next-id requirement` or `rivet next-id FEAT`
+        #[arg(value_name = "TYPE_OR_PREFIX")]
+        target: Option<String>,
+
         /// Artifact type (e.g., requirement, feature, design-decision)
         #[arg(short = 't', long, group = "id_source")]
         r#type: Option<String>,
@@ -2387,10 +2392,17 @@ fn run(cli: Cli) -> Result<bool> {
             output,
         } => cmd_import_results(&cli, format, file, output),
         Command::NextId {
+            target,
             r#type,
             prefix,
             format,
-        } => cmd_next_id(&cli, r#type.as_deref(), prefix.as_deref(), format),
+        } => cmd_next_id(
+            &cli,
+            target.as_deref(),
+            r#type.as_deref(),
+            prefix.as_deref(),
+            format,
+        ),
         Command::Add {
             r#type,
             title,
@@ -14168,6 +14180,7 @@ fn parse_link_spec(s: &str) -> Result<(String, String), String> {
 /// Print the next available ID for a given artifact type or prefix.
 fn cmd_next_id(
     cli: &Cli,
+    target: Option<&str>,
     artifact_type: Option<&str>,
     prefix: Option<&str>,
     format: &str,
@@ -14178,10 +14191,18 @@ fn cmd_next_id(
     let ctx = ProjectContext::load(cli)?;
     let store = ctx.store;
 
-    let resolved_prefix = match (artifact_type, prefix) {
+    // The positional `target` is a shorthand for --type (it routes through
+    // prefix_for_type, which also handles a bare prefix via its uppercase
+    // fallback — so `next-id requirement` and `next-id FEAT` both work). The
+    // explicit flags win if both are given.
+    let effective_type = artifact_type.or(target);
+    let resolved_prefix = match (effective_type, prefix) {
         (Some(t), _) => mutate::prefix_for_type(t, &store),
         (_, Some(p)) => p.to_string(),
-        (None, None) => anyhow::bail!("either --type or --prefix must be specified"),
+        (None, None) => anyhow::bail!(
+            "specify an artifact type or prefix, e.g. `rivet next-id requirement`, \
+             `rivet next-id --type feature`, or `rivet next-id --prefix REQ`"
+        ),
     };
 
     let next = mutate::next_id(&store, &resolved_prefix);

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -2130,6 +2130,41 @@ fn next_id_json() {
     );
 }
 
+/// `rivet next-id <type>` positional shorthand equals `--type <type>`, and a
+/// bare prefix positional works too (#447 / REQ-179).
+#[test]
+fn next_id_positional_shorthand() {
+    let run = |args: &[&str]| -> String {
+        let out = Command::new(rivet_bin())
+            .args(["--project", project_root().to_str().unwrap()])
+            .args(args)
+            .output()
+            .expect("run rivet next-id");
+        assert!(
+            out.status.success(),
+            "rivet {args:?} must exit 0. stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+    // Positional type == --type.
+    assert_eq!(
+        run(&["next-id", "requirement"]),
+        run(&["next-id", "--type", "requirement"])
+    );
+    // A bare prefix positional resolves to that prefix's next id.
+    assert!(run(&["next-id", "FEAT"]).starts_with("FEAT-"));
+    // No argument is a clear error (not a panic / silent success).
+    let out = Command::new(rivet_bin())
+        .args(["--project", project_root().to_str().unwrap(), "next-id"])
+        .output()
+        .expect("run rivet next-id with no arg");
+    assert!(
+        !out.status.success(),
+        "next-id with no type/prefix must fail"
+    );
+}
+
 // ── rivet schema subcommands ───────────────────────────────────────────
 
 /// `rivet schema show requirement --format json` produces valid JSON.


### PR DESCRIPTION
Addresses the residual papercut in #447.

## Context

`rivet next-id` has existed since #28 and correctly scans the **whole** store
(across all artifact files) for the next free id — so #447's core ask ("a way to
get the next id without a manual single-file grep") was already solved; I just
didn't discover it. But the natural form was rejected:

```
$ rivet next-id feature
error: unexpected argument 'feature' found
```
You had to know to pass `--type feature`.

## Fix

Add an optional positional `TYPE_OR_PREFIX` that's a shorthand for `--type`
(routed through `prefix_for_type`, whose uppercase fallback also makes a bare
prefix like `FEAT` work). Explicit `--type`/`--prefix` still win. The no-arg
error now lists all three usable forms.

```
$ rivet next-id requirement   # == --type requirement
REQ-179
$ rivet next-id FEAT          # bare prefix
FEAT-139
```

## Verification

- `next_id_positional_shorthand` test (positional == `--type`; bare prefix
  works; no-arg fails) + the existing `next_id_json`.
- `fmt --check` + `clippy --all-targets -- -D warnings` clean; `rivet validate` PASS.

Implements: REQ-179 · Refs: REQ-007

🤖 Generated with [Claude Code](https://claude.com/claude-code)