### PR TITLE
fix(export): escape backslashes in zola TOML front matter + gate it (REQ-181, #392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,37 @@ jobs:
           path: tests/playwright/test-results/
           if-no-files-found: ignore
 
+  # ── Zola export build smoke (#392) ───────────────────────────────────
+  # Exports the corpus to a scaffolded Zola site under a sub-directory
+  # base_url, runs a real `zola build`, and fails on a broken shortcode or a
+  # dangling/absolute internal link (the REQ-115/116/118 regression class —
+  # and front-matter escaping bugs like an unescaped `\` in a description).
+  # ubuntu-latest because it downloads a pinned zola release. Advisory
+  # (continue-on-error) until the install proves stable on the runners.
+  zola-export-smoke:
+    name: Zola export smoke
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release binary
+        run: cargo build --release --bin rivet
+      - name: Install zola
+        env:
+          ZOLA_VERSION: "0.19.2"
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL -o /tmp/zola.tar.gz \
+            "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xzf /tmp/zola.tar.gz -C "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          zola --version
+      - name: Run zola export smoke
+        run: RIVET_BIN="$PWD/target/release/rivet" scripts/zola-export-smoke.sh
+
   # ── VS Code Extension ────────────────────────────────────────────────
   vscode-extension:
     name: VS Code Extension

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5436,3 +5436,37 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-181
+    type: requirement
+    title: "zola export escapes backslashes in TOML front matter; gate it with a zola-build smoke CI job"
+    status: implemented
+    description: |
+      Self-found by running #392's candidate gate (scripts/zola-export-smoke.sh)
+      locally: `zola build` failed on the exported corpus because an artifact
+      description containing a regex (`grep '\.rs$'`, in REQ-174) was emitted
+      into a TOML multi-line basic string ("""...""") without escaping the
+      backslash. TOML multi-line basic strings process escapes, so a bare `\` is
+      an invalid escape and breaks the build — any description with a backslash
+      poisons the whole site.
+
+      Fix (cmd_export_zola): escape `\` -> `\\` in the description before the
+      existing `"""` handling, mirroring what the title already does. Plus add
+      the zola-export-smoke CI job (#392, ubuntu-latest, pinned zola, advisory
+      `continue-on-error` to start) so this regression class is caught
+      automatically.
+
+      Acceptance:
+        - `cargo test -p rivet-cli --test export_zola
+          zola_frontmatter_escapes_backslashes_in_description` passes (a `\.rs$`
+          description is emitted as `\\.rs$`).
+        - `RIVET_BIN=… scripts/zola-export-smoke.sh` exits 0 (real zola build of
+          the corpus succeeds).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [export, zola, toml, bugfix, ci, dogfooding, self-found, issue-392]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-115

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -8201,8 +8201,13 @@ sort_by = \"title\"
             .replace('\\', "\\\\")
             .replace('"', "\\\"")
             .replace('\n', " ");
-        // Triple-quoted TOML strings can't contain """ so escape that edge case.
-        let description_toml = description_raw.replace("\"\"\"", "\\\"\\\"\\\"");
+        // TOML multi-line basic strings (""") process backslash escapes, so a
+        // literal `\` in the description (e.g. a regex like `\.rs$`) is an
+        // invalid escape that breaks `zola build`. Escape backslashes first
+        // (like the title does), then the `"""` edge case.
+        let description_toml = description_raw
+            .replace('\\', "\\\\")
+            .replace("\"\"\"", "\\\"\\\"\\\"");
 
         let links_md: String = artifact
             .links

--- a/rivet-cli/tests/export_zola.rs
+++ b/rivet-cli/tests/export_zola.rs
@@ -156,3 +156,60 @@ fn zola_shortcode_card_uses_get_url() {
         "shortcode must not hardcode an absolute /<prefix>/artifacts/ href:\n{shortcode}"
     );
 }
+
+/// Regression: a literal backslash in an artifact description (e.g. a regex
+/// like `\.rs$`) must be escaped in the emitted TOML front matter. A
+/// multi-line basic string (""") processes escapes, so a bare `\` is an
+/// invalid escape that makes `zola build` fail to parse the page. #392 / REQ-181.
+// rivet: verifies REQ-181
+#[test]
+fn zola_frontmatter_escapes_backslashes_in_description() {
+    let proj = tempfile::tempdir().unwrap();
+    std::fs::write(
+        proj.path().join("rivet.yaml"),
+        "project:\n  name: t\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(proj.path().join("artifacts")).unwrap();
+    // Single-quoted YAML keeps the backslash literal: description = `matches \.rs$ files`.
+    std::fs::write(
+        proj.path().join("artifacts/a.yaml"),
+        "artifacts:\n  - id: REQ-1\n    type: requirement\n    title: Backslash regex test\n    \
+         description: 'matches \\.rs$ files'\n",
+    )
+    .unwrap();
+
+    let site = tempfile::tempdir().unwrap();
+    std::fs::write(
+        site.path().join("config.toml"),
+        "base_url = \"https://example.test/x\"\ntitle = \"t\"\n[[taxonomies]]\nname = \"tags\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(site.path().join("content")).unwrap();
+
+    let status = Command::new(rivet_bin())
+        .args([
+            "--project",
+            proj.path().to_str().unwrap(),
+            "export",
+            "--format",
+            "zola",
+            "--output",
+            site.path().to_str().unwrap(),
+        ])
+        .status()
+        .expect("run rivet export --format zola");
+    assert!(status.success(), "export exited non-zero: {status:?}");
+
+    let mds = content_markdown(site.path());
+    let md = mds
+        .iter()
+        .find(|m| m.contains("Backslash regex test"))
+        .expect("the REQ-1 page must be exported");
+    // The backslash must be doubled (escaped) in the front matter.
+    assert!(
+        md.contains("\\\\.rs$"),
+        "description backslash must be escaped to \\\\ in TOML front matter:\n{md}"
+    );
+}


### PR DESCRIPTION
## Found by dogfooding #392

Running #392's candidate gate (`scripts/zola-export-smoke.sh`) locally caught a
**real export bug**: `zola build` failed on the exported corpus —

```
ERROR Error when parsing front matter of section `.../req-174.md`
ERROR Reason: TOML parse error ... missing escaped value
23 | hook, gated on staged Rust files (`git diff --cached … | grep '\.rs$'`),
```

An artifact description containing a regex (`\.rs$`, in REQ-174's text) is
emitted into a TOML **multi-line basic string** (`"""..."""`), which processes
backslash escapes — so a bare `\` is an invalid escape and breaks the **whole
site build**. The title already escaped backslashes; the description didn't.

## Fix

1. `cmd_export_zola`: escape `\` → `\\` in the description (before the existing
   `"""` handling), matching the title.
2. **Add the `zola-export-smoke` CI job** (#392): ubuntu-latest, pinned zola
   download, runs the script. Advisory (`continue-on-error: true`) to start, as
   the issue requested, until the install proves stable on the runners.

## Verification

- New `zola_frontmatter_escapes_backslashes_in_description` test (a `\.rs$`
  description is emitted as `\\.rs$`); `export_zola` suite 3/3.
- The smoke script now runs a **real `zola build`** of the corpus to completion
  (907 pages, 0 absolute-link leaks) — it was failing before the fix.
- `fmt --check` + `clippy --all-targets -- -D warnings` clean; `rivet validate` PASS.

This closes #392 (the gate) and fixes the front-matter escaping class it
immediately surfaced.

Implements: REQ-181 · Refs: REQ-115, REQ-138 · Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)