### PR TITLE
fix(reqif): title-less artifacts stay re-importable via id LONG-NAME fallback (REQ-183)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5503,3 +5503,37 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-183
+    type: requirement
+    title: "reqif export of a title-less artifact stays re-importable (id fallback for LONG-NAME)"
+    status: implemented
+    description: |
+      Self-found dogfooding a reqif round-trip: `rivet export --format reqif`
+      then `rivet import-results --format reqif` on the same corpus FAILED —
+      "ReqIF SPEC-OBJECT 'CA-CI-1' has neither a ReqIF.Name nor a @LONG-NAME —
+      cannot derive the required `title`". Root cause: some artifact types
+      legitimately have an empty title (an STPA control-action, identified by
+      id; `rivet validate` PASSES with it). The export wrote
+      `long_name = a.title` verbatim → an empty LONG-NAME, which rivet's own
+      import (REQ-123, deliberately strict on title-less objects) then rejected.
+      So rivet produced reqif it couldn't re-import.
+
+      Fix (build_reqif_with_schema): when `a.title` is empty, fall back to the
+      artifact id for the SPEC-OBJECT LONG-NAME (a meaningful name — control
+      actions ARE identified by id). The import strictness is unchanged.
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib test_empty_title_roundtrips_via_id`
+          passes (title-less artifact exports with id as LONG-NAME and
+          re-imports with title = id).
+        - `rivet export --format reqif` of the corpus then `import-results
+          --format reqif` of that file succeeds (previously errored on CA-CI-1).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [export, import, reqif, roundtrip, interop, bugfix, dogfooding, self-found]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-core/src/reqif.rs
+++ b/rivet-core/src/reqif.rs
@@ -1431,7 +1431,17 @@ pub fn build_reqif_with_schema(artifacts: &[Artifact], schema: Option<&Schema>) 
 
             SpecObject {
                 identifier: a.id.clone(),
-                long_name: Some(a.title.clone()),
+                // ReqIF SPEC-OBJECTs need a non-empty LONG-NAME, and rivet's own
+                // reqif import rejects a title-less object (REQ-123). Some
+                // artifact types legitimately have an empty title (e.g. an STPA
+                // control-action, identified by id), so fall back to the id —
+                // otherwise `export --format reqif` produces a file rivet can't
+                // re-import (round-trip break).
+                long_name: Some(if a.title.trim().is_empty() {
+                    a.id.clone()
+                } else {
+                    a.title.clone()
+                }),
                 desc: a.description.clone(),
                 object_type_ref: Some(SpecObjectTypeRef {
                     spec_object_type_ref: type_ref_id,
@@ -2059,6 +2069,45 @@ mod tests {
         assert_eq!(re.len(), 1);
         // Null is not present after round-trip (attribute omitted).
         assert!(!re[0].fields.contains_key("deprecated"));
+    }
+
+    /// An artifact with an empty title (valid for some types, e.g. an STPA
+    /// control-action) must still round-trip: export falls back to the id for
+    /// the SPEC-OBJECT LONG-NAME, so re-import doesn't hard-fail on the missing
+    /// title (REQ-123 strictness). Regression: `export --format reqif` used to
+    /// emit an empty LONG-NAME that rivet's own import then rejected. REQ-183.
+    // rivet: verifies REQ-183
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_empty_title_roundtrips_via_id() {
+        let art = Artifact {
+            id: "CA-1".into(),
+            artifact_type: "control-action".into(),
+            title: String::new(),
+            description: None,
+            status: None,
+            tags: vec![],
+            links: vec![],
+            fields: BTreeMap::new(),
+            fields_per_variant: Default::default(),
+            provenance: None,
+            source_file: None,
+        };
+        let adapter = ReqIfAdapter::new();
+        let bytes = adapter.export(&[art], &AdapterConfig::default()).unwrap();
+        // The export must NOT emit an empty LONG-NAME.
+        let xml = String::from_utf8_lossy(&bytes);
+        assert!(
+            xml.contains("LONG-NAME=\"CA-1\""),
+            "title-less artifact must export with the id as LONG-NAME:\n{xml}"
+        );
+        // And it must re-import cleanly (previously errored on the empty title).
+        let re = adapter
+            .import(&AdapterSource::Bytes(bytes), &AdapterConfig::default())
+            .expect("title-less reqif must re-import without error");
+        assert_eq!(re.len(), 1);
+        assert_eq!(re[0].id, "CA-1");
+        assert_eq!(re[0].title, "CA-1");
     }
 
     /// Tags containing commas or leading whitespace must round-trip intact.


### PR DESCRIPTION
## Found by dogfooding a reqif round-trip

`rivet export --format reqif` → `rivet import-results --format reqif` on the
**same corpus** failed:

```
error: failed to parse ReqIF: SPEC-OBJECT 'CA-CI-1' has neither a ReqIF.Name
attribute nor a @LONG-NAME — cannot derive the required `title` field
```

Root cause: some artifact types legitimately have an **empty title** (an STPA
`control-action` like `CA-CI-1`, identified by id — `rivet validate` passes with
it). The export wrote `long_name = a.title` verbatim → an empty `LONG-NAME`,
which rivet's own import (REQ-123, deliberately strict on title-less objects)
then rejected. So **rivet produced reqif it couldn't re-import**.

## Fix

In `build_reqif_with_schema`, fall back to the artifact **id** for the
SPEC-OBJECT `LONG-NAME` when the title is empty (a meaningful name — control
actions *are* identified by id). The import's strictness is unchanged (still
catches genuinely-malformed external reqif).

## Verification

- New `test_empty_title_roundtrips_via_id` (title-less artifact exports with the
  id as `LONG-NAME` and re-imports with `title = id`); reqif suite **47/47**.
- A real `export --format reqif` of the corpus then `import-results --format
  reqif` of that file now **succeeds** (890 artifacts) — it errored on CA-CI-1
  before.
- `fmt --check` + `clippy --all-targets -- -D warnings` clean; `rivet validate` PASS.

Implements: REQ-183 · Refs: REQ-007, REQ-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)