### PR TITLE
feat(cli): add `import` as a visible alias for import-results (REQ-184, #453)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5537,3 +5537,35 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-184
+    type: requirement
+    title: "rivet import is a visible alias for import-results (the natural inverse of export)"
+    status: implemented
+    description: |
+      Self-found (#453) while dogfooding a reqif round-trip. `rivet export
+      --format reqif` exists, so the natural way to bring a file back is `rivet
+      import` — but in the default build that errored ("unrecognized subcommand
+      'import'"). The capability lives in `import-results` (junit/needs-json/
+      reqif). Note: `import` IS a real command but only under the `wasm` feature
+      (a distinct custom-WASM-adapter importer), so it's absent from the
+      default/common build.
+
+      Add `import` as a visible alias of `import-results`, gated to non-wasm
+      builds (`cfg_attr(not(feature = "wasm"), command(visible_alias =
+      "import"))`) so it never collides with the wasm-adapter `import` command.
+
+      Acceptance:
+        - In the default build, `rivet import --format reqif <file> --output
+          <dir>` succeeds (equivalent to `import-results`); `rivet --help` lists
+          `import-results` with `[aliases: import]`.
+        - `cargo test -p rivet-cli --test export_reqif_roundtrip
+          import_alias_works_for_reqif` passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, import, dx, discoverability, dogfooding, self-found, issue-453]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -938,6 +938,12 @@ enum Command {
     },
 
     /// Import test results or artifacts from external formats
+    //
+    // `import` is the natural name a user reaches for (the inverse of `export`),
+    // so expose it as a visible alias (#453). Only when the `wasm` feature is
+    // OFF — with it on, `import` is the distinct custom-WASM-adapter command
+    // above, and a duplicate alias would conflict.
+    #[cfg_attr(not(feature = "wasm"), command(visible_alias = "import"))]
     ImportResults {
         /// Input format: "junit" (JUnit XML), "needs-json" (sphinx-needs), or "reqif" (OMG ReqIF 1.2)
         #[arg(long)]

--- a/rivet-cli/tests/export_reqif_roundtrip.rs
+++ b/rivet-cli/tests/export_reqif_roundtrip.rs
@@ -175,3 +175,51 @@ fn export_reqif_to_directory_gives_actionable_error() {
         "must not leak the raw OS error. Got:\n{stderr}"
     );
 }
+
+/// `rivet import` is a visible alias for `import-results` (the natural inverse
+/// of `export`) in the default build. #453 / REQ-184.
+#[test]
+fn import_alias_works_for_reqif() {
+    let proj = tempfile::tempdir().unwrap();
+    write_project(proj.path());
+    // Export the project to a reqif file.
+    let reqif = proj.path().join("out.reqif");
+    let st = Command::new(rivet_bin())
+        .args([
+            "--project",
+            proj.path().to_str().unwrap(),
+            "export",
+            "--format",
+            "reqif",
+            "--output",
+            reqif.to_str().unwrap(),
+        ])
+        .status()
+        .expect("run export");
+    assert!(st.success(), "reqif export must succeed");
+
+    // Re-import it via the `import` ALIAS (not `import-results`).
+    let outdir = proj.path().join("imported");
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            proj.path().to_str().unwrap(),
+            "import",
+            "--format",
+            "reqif",
+            reqif.to_str().unwrap(),
+            "--output",
+            outdir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run `rivet import` (alias)");
+    assert!(
+        out.status.success(),
+        "`rivet import` alias must work. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        outdir.join("reqif-import.yaml").exists(),
+        "import alias must produce the imported YAML"
+    );
+}


### PR DESCRIPTION
Closes #453.

## Context

Dogfooding a reqif round-trip, `rivet import` (the natural inverse of `export`)
errored:
```
$ rivet import --format reqif corpus.reqif
error: unrecognized subcommand 'import'
```
The standard-format importer is `import-results` (junit/needs-json/reqif).
`import` *is* a real command — but only under the **`wasm`** feature (a distinct
custom-WASM-adapter importer), so it's absent from the default/common build.

## Fix

Add `import` as a **visible alias** of `import-results`, gated to non-wasm
builds so it never collides with the wasm `import` command:

```rust
#[cfg_attr(not(feature = "wasm"), command(visible_alias = "import"))]
ImportResults { … }
```

Now `rivet import --format reqif <file>` works, and `rivet --help` shows
`import-results … [aliases: import]`.

## Verification

- New `import_alias_works_for_reqif` test (`rivet import --format reqif`
  round-trips an exported project).
- `docs_coverage` 8/8 (the known-subcommands check is unaffected); `fmt --check`
  + `clippy --all-targets -- -D warnings` clean; `rivet validate` PASS.

Implements: REQ-184 · Refs: REQ-007 · Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)