### PR TITLE
fix(lsp): resolve cross-repo external links so VSIX doesn't flag them broken (REQ-185)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5569,3 +5569,40 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-185
+    type: requirement
+    title: "LSP/VSIX resolves cross-repo external links (no false broken-link; hover works)"
+    status: implemented
+    description: |
+      User-reported: in the VS Code extension (via the LSP), a `traces-to`
+      link to `ulinc-zephyr:SWREQ-AP-007` was flagged "does not exist" and
+      hover over the cross-repo reference showed nothing — even though the
+      external is synced and `rivet serve` resolves it. Root cause: `cmd_lsp`
+      loaded only `config.sources` into the salsa store, never
+      `config.externals`. `rivet validate` (ProjectContext::load) and `rivet
+      serve` compose externals into the store (prefixed `prefix:ID`), so they
+      resolve; the LSP didn't — a diagnostic-consistency gap (#89).
+
+      Fix: in `cmd_lsp`, load the declared externals via `load_all_externals`,
+      prefix their ids + same-external link targets (mirroring
+      ProjectContext::load), and feed them as a salsa `ExtraArtifactSet` via
+      `db.load_extras`. Route every store/diagnostics/graph query through the
+      `_with_extras` variants (the designed mechanism, already used for
+      adapter-only AADL artifacts). This makes diagnostics, hover, and
+      go-to-definition all external-aware, consistent with validate/serve.
+
+      Acceptance:
+        - `cargo test -p rivet-cli --test lsp_integration
+          lsp_resolves_cross_repo_external_link` passes: the LSP, on a project
+          with a path external, does NOT publish a broken-link diagnostic for a
+          `prefix:ID` link into that external.
+        - The full lsp_integration suite still passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [lsp, vsix, externals, cross-repo, diagnostics, consistency, bugfix, user-reported]
+    fields:
+      priority: must
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-089

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -15418,8 +15418,54 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
         (source_set, schema_set)
     };
 
+    // Load cross-repo externals as salsa "extras" so a `traces-to prefix:ID`
+    // link resolves in diagnostics, hover, and go-to-definition — exactly as
+    // `rivet validate` and `rivet serve` resolve it (they compose externals
+    // into the store, see ProjectContext::load). Without this the LSP/VSIX
+    // reported a synced external reference as a broken link and hover couldn't
+    // find it. Externals are static for the session, so load once and reuse the
+    // (Copy) handle at every query site.
+    let extra_artifacts: Vec<rivet_core::model::Artifact> = config_opt
+        .as_ref()
+        .and_then(|c| c.externals.as_ref())
+        .map(|externals| {
+            let mut out = Vec::new();
+            match rivet_core::externals::load_all_externals(externals, &project_dir) {
+                Ok(resolved) => {
+                    for ext in resolved {
+                        let ext_ids: std::collections::HashSet<String> =
+                            ext.artifacts.iter().map(|a| a.id.clone()).collect();
+                        for mut artifact in ext.artifacts {
+                            // Prefix the id (and same-external link targets) so
+                            // `prefix:ID` references resolve, matching the CLI.
+                            artifact.id = format!("{}:{}", ext.prefix, artifact.id);
+                            for link in &mut artifact.links {
+                                if ext_ids.contains(&link.target) {
+                                    link.target = format!("{}:{}", ext.prefix, link.target);
+                                }
+                            }
+                            out.push(artifact);
+                        }
+                    }
+                }
+                Err(e) => eprintln!(
+                    "rivet lsp: could not load externals (cross-repo links may show as broken \
+                     — run `rivet sync`): {e}"
+                ),
+            }
+            out
+        })
+        .unwrap_or_default();
+    if !extra_artifacts.is_empty() {
+        eprintln!(
+            "rivet lsp: loaded {} external artifact(s) for cross-repo link resolution",
+            extra_artifacts.len()
+        );
+    }
+    let extra_set = db.load_extras(extra_artifacts);
+
     // Build supplementary state for rendering
-    let store = db.store(source_set, schema_set);
+    let store = db.store_with_extras(source_set, schema_set, extra_set);
     let render_schema = db.schema(schema_set);
     let mut render_graph = rivet_core::links::LinkGraph::build(&store, &render_schema);
 
@@ -15454,7 +15500,7 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
     // validation.  validate_documents() checks that every [[ID]] wiki-link in
     // markdown documents points to an artifact that exists in the store;
     // broken refs are surfaced as LSP warnings in the source .md file.
-    let mut diagnostics = db.diagnostics(source_set, schema_set);
+    let mut diagnostics = db.diagnostics_with_extras(source_set, schema_set, extra_set);
     diagnostics.extend(validate::validate_documents(&doc_store, &store));
     let mut prev_diagnostic_files: std::collections::HashSet<std::path::PathBuf> =
         std::collections::HashSet::new();
@@ -15498,7 +15544,7 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
                 match method {
                     "textDocument/hover" => {
                         let params: HoverParams = serde_json::from_value(req.params.clone())?;
-                        let store = db.store(source_set, schema_set);
+                        let store = db.store_with_extras(source_set, schema_set, extra_set);
                         let result = lsp_hover(&params, &store);
                         connection.sender.send(Message::Response(Response {
                             id: req.id,
@@ -15509,7 +15555,7 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
                     "textDocument/definition" => {
                         let params: GotoDefinitionParams =
                             serde_json::from_value(req.params.clone())?;
-                        let store = db.store(source_set, schema_set);
+                        let store = db.store_with_extras(source_set, schema_set, extra_set);
                         let result = lsp_goto_definition(&params, &store);
                         connection.sender.send(Message::Response(Response {
                             id: req.id,
@@ -15519,7 +15565,7 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
                     }
                     "textDocument/completion" => {
                         let params: CompletionParams = serde_json::from_value(req.params.clone())?;
-                        let store = db.store(source_set, schema_set);
+                        let store = db.store_with_extras(source_set, schema_set, extra_set);
                         let schema = db.schema(schema_set);
                         let result = lsp_completion(&params, &store, &schema);
                         connection.sender.send(Message::Response(Response {
@@ -15829,8 +15875,10 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
                                     }
                                 }
                                 // Publish diagnostics for the opened file
-                                let mut new_diagnostics = db.diagnostics(source_set, schema_set);
-                                let new_store = db.store(source_set, schema_set);
+                                let mut new_diagnostics =
+                                    db.diagnostics_with_extras(source_set, schema_set, extra_set);
+                                let new_store =
+                                    db.store_with_extras(source_set, schema_set, extra_set);
                                 new_diagnostics
                                     .extend(validate::validate_documents(&doc_store, &new_store));
                                 lsp_publish_salsa_diagnostics(
@@ -15868,8 +15916,10 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
                                 // Re-query diagnostics (salsa recomputes only what changed)
                                 // and append document [[ID]] reference validation so
                                 // broken wiki-links in markdown files are reported.
-                                let mut new_diagnostics = db.diagnostics(source_set, schema_set);
-                                let new_store = db.store(source_set, schema_set);
+                                let mut new_diagnostics =
+                                    db.diagnostics_with_extras(source_set, schema_set, extra_set);
+                                let new_store =
+                                    db.store_with_extras(source_set, schema_set, extra_set);
                                 new_diagnostics
                                     .extend(validate::validate_documents(&doc_store, &new_store));
                                 lsp_publish_salsa_diagnostics(
@@ -15885,13 +15935,15 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
                                 );
 
                                 // Rebuild render state
-                                render_store = db.store(source_set, schema_set);
+                                render_store =
+                                    db.store_with_extras(source_set, schema_set, extra_set);
                                 let render_schema = db.schema(schema_set);
                                 render_graph = rivet_core::links::LinkGraph::build(
                                     &render_store,
                                     &render_schema,
                                 );
-                                diagnostics_cache = db.diagnostics(source_set, schema_set);
+                                diagnostics_cache =
+                                    db.diagnostics_with_extras(source_set, schema_set, extra_set);
                                 diagnostics_cache.extend(validate::validate_documents(
                                     &doc_store,
                                     &render_store,
@@ -15929,9 +15981,11 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
                                     );
                                     if updated {
                                         // Re-query diagnostics incrementally
-                                        let mut diagnostics =
-                                            db.diagnostics(source_set, schema_set);
-                                        let fresh_store = db.store(source_set, schema_set);
+                                        let mut diagnostics = db.diagnostics_with_extras(
+                                            source_set, schema_set, extra_set,
+                                        );
+                                        let fresh_store =
+                                            db.store_with_extras(source_set, schema_set, extra_set);
                                         diagnostics.extend(validate::validate_documents(
                                             &doc_store,
                                             &fresh_store,

--- a/rivet-cli/tests/lsp_integration.rs
+++ b/rivet-cli/tests/lsp_integration.rs
@@ -699,3 +699,95 @@ fn lsp_diagnostics_for_invalid_artifacts() {
 
     lsp.shutdown();
 }
+
+/// Regression: a cross-repo `prefix:ID` link to a (path) external must NOT be
+/// reported as a broken link by the LSP. Externals are loaded as salsa extras,
+/// matching `rivet validate` / `rivet serve` (which compose externals into the
+/// store). Previously the LSP loaded only local sources, so a synced external
+/// reference like `ext:EXT-1` showed as "does not exist" in VS Code.
+#[test]
+fn lsp_resolves_cross_repo_external_link() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path();
+
+    // External project, loaded via `path:` (no `rivet sync` needed).
+    let ext = dir.join("ext-src");
+    std::fs::create_dir_all(ext.join("artifacts")).unwrap();
+    std::fs::write(
+        ext.join("rivet.yaml"),
+        "project:\n  name: ext\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        ext.join("artifacts/ext.yaml"),
+        "artifacts:\n  - id: EXT-1\n    type: requirement\n    title: External req\n    status: approved\n",
+    )
+    .unwrap();
+
+    // Main project declaring the external + a cross-repo link to it.
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: main\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n\
+         externals:\n  ext:\n    path: ext-src\n    prefix: ext\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    let artifact_path = dir.join("artifacts/req.yaml");
+    let yaml = "artifacts:\n  - id: REQ-LOCAL\n    type: requirement\n    title: Local\n    \
+                status: draft\n    links:\n      - type: traces-to\n        target: ext:EXT-1\n";
+    std::fs::write(&artifact_path, yaml).unwrap();
+
+    let mut lsp = spawn_lsp(dir);
+    let root_uri = format!("file://{}", dir.display());
+    let artifact_uri = format!("file://{}", artifact_path.display());
+    lsp.initialize(&root_uri);
+    std::thread::sleep(Duration::from_secs(2));
+    lsp.send(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": artifact_uri, "languageId": "yaml", "version": 1, "text": yaml
+        }}
+    }));
+    lsp.send(&serde_json::json!({
+        "jsonrpc": "2.0", "id": 50, "method": "textDocument/documentSymbol",
+        "params": { "textDocument": { "uri": artifact_uri } }
+    }));
+
+    let mut all = Vec::new();
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    while std::time::Instant::now() < deadline {
+        let rem = deadline.saturating_duration_since(std::time::Instant::now());
+        match lsp.recv(rem) {
+            Some(m) => {
+                let done = m.get("id").and_then(|v| v.as_u64()) == Some(50);
+                all.push(m);
+                if done {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+
+    for m in &all {
+        if m.get("method").and_then(|v| v.as_str()) == Some("textDocument/publishDiagnostics") {
+            if let Some(arr) = m
+                .get("params")
+                .and_then(|p| p.get("diagnostics"))
+                .and_then(|d| d.as_array())
+            {
+                for d in arr {
+                    let msg = d.get("message").and_then(|v| v.as_str()).unwrap_or("");
+                    assert!(
+                        !(msg.contains("ext:EXT-1") && msg.contains("does not exist")),
+                        "LSP must not flag the cross-repo external link as broken: {msg}"
+                    );
+                }
+            }
+        }
+    }
+    lsp.shutdown();
+}


### PR DESCRIPTION
## User report

In the VS Code extension (via the LSP), a `traces-to` link to
`ulinc-zephyr:SWREQ-AP-007` was flagged **"does not exist"**, and hovering the
cross-repo reference showed nothing — even though the external is synced and
`rivet serve` resolves it fine.

## Root cause

`cmd_lsp` loaded only `config.sources` into the salsa store, **not**
`config.externals`. `rivet validate` (`ProjectContext::load`) and `rivet serve`
compose externals into the store (prefixed `prefix:ID`), so cross-repo refs
resolve there; the LSP didn't — a concrete instance of the VSIX/serve/validate
diagnostic-consistency gap (#89). With a local-only store, `LinkGraph::build`
marks any `prefix:ID` target broken.

## Fix

Load the declared externals via `load_all_externals`, prefix their ids +
same-external link targets (mirroring `ProjectContext::load`), and feed them as
a salsa `ExtraArtifactSet` (`db.load_extras`). Route every store/diagnostics/
graph query through the `_with_extras` variants — the **designed** mechanism,
already used for adapter-only AADL artifacts (`db.rs` doc comment describes this
exact "target lives only in non-source output → false broken-link" class). This
makes diagnostics, hover, and go-to-definition all external-aware, consistent
with validate/serve. Static for the session → loaded once, reused (the handle
is `Copy`).

## Verification

- New `lsp_resolves_cross_repo_external_link` integration test — spawns the
  **real `rivet lsp`** subprocess on a project with a `path:` external and a
  `prefix:ID` link, asserts **no** broken-link diagnostic for it. (Reproduces
  the report; fails before the fix.)
- Full `lsp_integration` suite 6/6; `fmt --check` + `clippy --all-targets -- -D
  warnings` clean; `rivet validate` PASS.

Implements: REQ-185 · Refs: REQ-089, REQ-085

🤖 Generated with [Claude Code](https://claude.com/claude-code)