### PR TITLE
plan: REQ-186 — CLI minimal-build feature (validate without serve+MCP+LSP)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5606,3 +5606,47 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-089
+
+  - id: REQ-186
+    type: requirement
+    title: "CLI supports a minimal build: validate/list/commit without the serve+MCP+LSP dep tree"
+    status: draft
+    description: |
+      Dogfooding friction: `rivet validate`/`list`/`commit-msg-check` are the
+      hook- and CI-critical hot paths, but `rivet-cli` has no minimal build. Its
+      `[features]` are only `default = []` and `wasm`, while `axum`,
+      `tower-http`, `rmcp` (full streamable-HTTP MCP server), `lsp-server`,
+      `lsp-types`, and `notify` are UNCONDITIONAL dependencies. So ANY build from
+      source — `cargo install rivet`, CI's compile step, or a local `cargo build`
+      to test a validate change — compiles the entire web-server + MCP + LSP tree
+      (hundreds of transitive crates), even though validate/list never use it.
+      (Note: the pre-commit hook itself uses the already-installed `rivet` on
+      PATH via `RIVET_BIN:-rivet`, so the hook does NOT rebuild — the cost is on
+      every from-source build, not the hook.) `rivet-core` already gates its
+      heavy deps (`wasm`/`reqwest`/`spar-*` are `optional`); the CLI does not.
+      See GitHub issue #456 (serve/mcp/lsp feature-gating).
+
+      Fix (additive — published binary unchanged): add `serve`/`mcp`/`lsp` cargo
+      features, keep them in `default`, and `#[cfg(feature = ...)]`-gate the
+      corresponding command handlers + module declarations in `main.rs`. Then
+      `--no-default-features` yields a fast `validate`/`list`/`commit-msg-check`
+      build for hooks, CI's validate gate, and the dogfooding loop. The default
+      feature set (and thus `cargo install rivet`) is a maintainer call — filed
+      draft pending that decision; do not change distribution semantics
+      unilaterally.
+
+      Acceptance:
+        - `cargo build -p rivet-cli --no-default-features` succeeds and the
+          resulting `rivet validate` exits 0 on the rivet repo.
+        - `cargo tree -p rivet-cli --no-default-features -i axum` reports axum is
+          NOT in the dependency graph (and likewise for `rmcp`).
+        - The default build is unchanged: `rivet serve --help` and `rivet mcp
+          --help` still succeed under `cargo build -p rivet-cli`.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, build, features, dogfooding, friction, ci, hooks, dependencies]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-007


### PR DESCRIPTION
Files the dogfooding-loop friction finding from issue #456 as a draft requirement.

**Finding:** `rivet-cli` has no minimal build. `[features]` is only `default = []` + `wasm`, while `axum`, `tower-http`, `rmcp` (streamable-HTTP MCP server), `lsp-server`, `lsp-types`, and `notify` are unconditional dependencies. Every from-source build (`cargo install rivet`, CI compile, local `cargo build` to test a validate change) compiles the whole web+MCP+LSP tree even though `validate`/`list` never use it. `rivet-core` already gates its heavy deps (`wasm`/`reqwest`/`spar-*` are `optional`); the CLI does not.

**Proposed fix (additive, draft):** `serve`/`mcp`/`lsp` cargo features kept in `default` (published binary unchanged), `#[cfg]`-gated command handlers, so `--no-default-features` gives a fast `validate`/`list`/`commit-msg-check` build. The default feature set is a distribution-semantics call, so this is filed `draft` for maintainer decision rather than implemented unilaterally.

**Rigor note:** verified the pre-commit hook uses the installed `rivet` on PATH (`RIVET_BIN:-rivet`) and does NOT rebuild — corrected an overstated "hook triggers rebuild" claim in both the REQ and issue #456.

`rivet validate` → PASS (234 pre-existing coverage warnings).

Refs #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)