### PR TITLE
feat(cli): rivet query accepts s-expression as a positional shorthand (REQ-187)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5650,3 +5650,39 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-187
+    type: requirement
+    title: "`rivet query` accepts the s-expression as a positional shorthand (not only --sexpr)"
+    status: implemented
+    description: |
+      Dogfooding friction: `rivet query '(= type "requirement")'` — the natural
+      form an agent or human types — errors with "unexpected argument", because
+      `query` only accepts the filter via the required `--sexpr` flag. The sibling
+      command `next-id` already established the positional-shorthand pattern
+      (`rivet next-id requirement` works via an optional positional `target` that
+      defers to the explicit flag), but `query` was never given the same
+      treatment — an avoidable inconsistency on the single most-used agent-facing
+      command.
+
+      Fix: add an optional positional `SEXPR` to the `query` clap struct and make
+      `--sexpr` optional; the explicit flag wins if both are given, and a clear
+      error is raised if neither is supplied. `--sexpr` keeps working unchanged
+      (MCP/docs/scripts depend on it), so the change is purely additive.
+
+      Acceptance:
+        - `rivet query '(= id "REQ-007")' --format ids` (positional, no
+          `--sexpr`) exits 0 and prints `REQ-007`.
+        - The positional form and `--sexpr` form yield identical matches
+          (`cargo test -p rivet-cli --test sexpr_filter_integration
+          query_positional_and_flag_are_equivalent`).
+        - `rivet query` with no filter exits non-zero with an error mentioning
+          "s-expression".
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, query, sexpr, ergonomics, agent-ux, friction, consistency]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1132,9 +1132,16 @@ enum Command {
     /// document embed — all three share `rivet_core::query::execute_sexpr`
     /// so their results agree for the same filter.
     Query {
-        /// The s-expression filter (e.g. '(and (= type "requirement") (has-tag "stpa"))')
-        #[arg(long)]
-        sexpr: String,
+        /// The s-expression filter as a positional shorthand, e.g.
+        /// `rivet query '(= type "requirement")'`. Equivalent to `--sexpr`;
+        /// the explicit `--sexpr` flag wins if both are given.
+        #[arg(value_name = "SEXPR")]
+        sexpr_pos: Option<String>,
+
+        /// The s-expression filter (e.g. '(and (= type "requirement") (has-tag "stpa"))').
+        /// Equivalent to passing it positionally.
+        #[arg(long = "sexpr")]
+        sexpr: Option<String>,
 
         /// Maximum number of results (default: 100)
         #[arg(long, default_value = "100")]
@@ -2465,11 +2472,23 @@ fn run(cli: Cli) -> Result<bool> {
         Command::Batch { file } => cmd_batch(&cli, file),
         Command::Embed { query, format } => cmd_embed(&cli, query, format),
         Command::Query {
+            sexpr_pos,
             sexpr,
             limit,
             format,
             variant,
-        } => cmd_query(&cli, sexpr, *limit, format, variant.as_deref()),
+        } => {
+            // The explicit `--sexpr` flag wins; otherwise use the positional
+            // shorthand (`rivet query '(...)'`). Mirrors `next-id`'s positional.
+            match sexpr.as_deref().or(sexpr_pos.as_deref()) {
+                Some(s) => cmd_query(&cli, s, *limit, format, variant.as_deref()),
+                None => anyhow::bail!(
+                    "specify an s-expression filter, e.g. \
+                     `rivet query '(= type \"requirement\")'` or \
+                     `rivet query --sexpr '(has-tag \"stpa\")'`"
+                ),
+            }
+        }
         Command::Stamp {
             id,
             created_by,

--- a/rivet-cli/tests/sexpr_filter_integration.rs
+++ b/rivet-cli/tests/sexpr_filter_integration.rs
@@ -214,3 +214,81 @@ fn coverage_filter_runs_cleanly() {
     let _: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("coverage JSON must parse");
 }
+
+// ── query: positional s-expression shorthand (REQ-187) ─────────────────
+
+#[test]
+fn query_positional_sexpr_works_without_flag() {
+    // `rivet query '(...)'` must work as a positional, mirroring
+    // `next-id`'s positional shorthand — no `--sexpr` required.
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "query",
+            r#"(= id "REQ-007")"#,
+            "--format",
+            "ids",
+        ])
+        .output()
+        .expect("positional query run");
+    assert!(
+        output.status.success(),
+        "positional `rivet query '(...)'` must succeed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("REQ-007"),
+        "positional query must return the matching id"
+    );
+}
+
+#[test]
+fn query_positional_and_flag_are_equivalent() {
+    // A single-match filter keeps this independent of result ordering (#415)
+    // and the default --limit.
+    let run = |positional: bool| -> Vec<String> {
+        let root = project_root();
+        let root_str = root.to_str().unwrap().to_string();
+        let mut args: Vec<String> = vec!["--project".into(), root_str, "query".into()];
+        if positional {
+            args.push(r#"(= id "REQ-007")"#.into());
+        } else {
+            args.push("--sexpr".into());
+            args.push(r#"(= id "REQ-007")"#.into());
+        }
+        args.extend(["--format".to_string(), "ids".to_string()]);
+        let out = Command::new(rivet_bin())
+            .args(&args)
+            .output()
+            .expect("query run");
+        assert!(out.status.success());
+        let mut ids: Vec<String> = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(str::to_string)
+            .collect();
+        ids.sort();
+        ids
+    };
+    assert_eq!(
+        run(true),
+        run(false),
+        "positional and --sexpr forms must yield identical matches"
+    );
+}
+
+#[test]
+fn query_without_any_sexpr_is_reported() {
+    let output = Command::new(rivet_bin())
+        .args(["--project", project_root().to_str().unwrap(), "query"])
+        .output()
+        .expect("no-arg query run");
+    assert!(
+        !output.status.success(),
+        "`rivet query` with no filter must error, got exit 0"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("s-expression"),
+        "error must guide the user to supply an s-expression"
+    );
+}


### PR DESCRIPTION
## Friction → fix (hourly dogfooding loop)

`rivet query '(= type "requirement")'` — the natural form an agent or human types — **errored** with `unexpected argument`, because `query` only accepted the filter via the required `--sexpr` flag:

```
$ rivet query '(= type "requirement")'
error: unexpected argument '(= type "requirement")' found
Usage: rivet query [OPTIONS] --sexpr <SEXPR>
```

The sibling command **`next-id` already established the positional-shorthand pattern** (`rivet next-id requirement` works via an optional positional that defers to the explicit flag). `query` — the single most-used agent-facing command — lacked it. This is an avoidable inconsistency right where agents hit it most.

## Change (additive, backward-compatible)

- Add an optional positional `SEXPR` to the `query` clap struct; make `--sexpr` optional.
- The explicit `--sexpr` flag wins if both are given; a clear example-bearing error is raised if neither is supplied.
- `--sexpr` keeps working unchanged → MCP tool, `{{query:(...)}}` doc embeds, docs, and scripts are unaffected.

```
$ rivet query '(= type "requirement")' --format ids   # now works
$ rivet query --sexpr '(has-tag "stpa")'              # still works
$ rivet query                                         # clear error w/ examples
```

## Tests (`sexpr_filter_integration`)

- `query_positional_sexpr_works_without_flag` — positional form succeeds, returns the match.
- `query_positional_and_flag_are_equivalent` — positional ≡ `--sexpr` (single-match filter, so independent of the #415 ordering/limit nondeterminism).
- `query_without_any_sexpr_is_reported` — no filter exits non-zero with an "s-expression" hint.

## Verification

`cargo test -p rivet-cli --test sexpr_filter_integration` → 9/9 · `cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` exit 0 (only the pre-existing `clippy.toml`/`Cargo.toml` MSRV-mismatch config warning) · `rivet validate` → PASS. Implements + Verifies **REQ-187** (filed + marked implemented in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)