### PR TITLE
feat(cli): positional link/unlink target + accurate init/modify help (REQ-188)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5686,3 +5686,47 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-188
+    type: requirement
+    title: "Agent CLI ergonomics: positional link/unlink target + accurate init/modify help"
+    status: implemented
+    description: |
+      Dogfooding pass over agent-facing commands surfaced three friction points,
+      all verified against current main:
+
+      1. `rivet link <source> <target> --type <t>` — the natural form (source and
+         target as an ordered positional pair) — errored "unexpected argument",
+         because `target` was a required `--target` flag. Same friction class as
+         the `query` positional gap (REQ-187) and the `next-id` positional. Same
+         for `unlink`.
+      2. `rivet init --help` showed two duplicated, contradictory `--preset`
+         doc lines (one listing do-178c/en-50128, the other iec-61508/iec-62304)
+         — clap concatenated them into a stuttering string that also OMITTED 5
+         of the 14 presets resolve_preset actually accepts (stpa-ai, eu-ai-act,
+         safety-case, iso-pas-8800, sotif).
+      3. `rivet modify --help` stuttered: "Modify an existing artifact Modify an
+         existing artifact (...)" — a duplicated doc-comment summary line.
+
+      Fix (additive, low-risk): add an optional positional TARGET to link and
+      unlink (the --target flag still works and wins if both given; clear error
+      if neither). Replace the --preset doc-comment with one accurate line
+      listing all 14 presets. Collapse the duplicated modify summary line.
+      Follow-up idea (not done here): make --preset a single source of truth via
+      a clap value-parser to prevent future drift.
+
+      Acceptance:
+        - `cargo test -p rivet-cli --test cli_commands link_positional_target_is_parsed`
+          passes (positional link target no longer a clap parse error).
+        - `cargo test -p rivet-cli --test cli_commands init_preset_help_lists_all_presets`
+          passes (help lists every preset resolve_preset accepts).
+        - `cargo test -p rivet-cli --test cli_commands modify_help_has_no_duplicated_summary`
+          passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, link, unlink, init, modify, help, agent-ux, ergonomics, friction, docs]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -236,8 +236,9 @@ enum Command {
         #[arg(long)]
         name: Option<String>,
 
-        /// Preset: dev (default), aspice, stpa, cybersecurity, aadl, do-178c, en-50128
-        /// Preset: dev (default), aspice, stpa, cybersecurity, aadl, iec-61508, iec-62304
+        /// Preset (default: dev). One of: dev, aspice, stpa, stpa-ai,
+        /// cybersecurity, aadl, eu-ai-act, safety-case, do-178c, en-50128,
+        /// iec-61508, iec-62304, iso-pas-8800, sotif.
         #[arg(long, default_value = "dev")]
         preset: String,
 
@@ -1017,13 +1018,19 @@ enum Command {
         /// Source artifact ID
         source: String,
 
+        /// Target artifact ID. May be given positionally
+        /// (`rivet link <source> <target> --type <type>`) or via `--target`.
+        #[arg(value_name = "TARGET")]
+        target_pos: Option<String>,
+
         /// Link type (e.g., satisfies, implements, derives-from)
         #[arg(short = 't', long = "type")]
         link_type: String,
 
-        /// Target artifact ID
-        #[arg(long)]
-        target: String,
+        /// Target artifact ID (equivalent to the positional form; the flag
+        /// wins if both are given).
+        #[arg(long = "target")]
+        target: Option<String>,
     },
 
     /// Remove a link between two artifacts
@@ -1031,16 +1038,21 @@ enum Command {
         /// Source artifact ID
         source: String,
 
+        /// Target artifact ID. May be given positionally
+        /// (`rivet unlink <source> <target> --type <type>`) or via `--target`.
+        #[arg(value_name = "TARGET")]
+        target_pos: Option<String>,
+
         /// Link type (e.g., satisfies, implements, derives-from)
         #[arg(short = 't', long = "type")]
         link_type: String,
 
-        /// Target artifact ID
-        #[arg(long)]
-        target: String,
+        /// Target artifact ID (equivalent to the positional form; the flag
+        /// wins if both are given).
+        #[arg(long = "target")]
+        target: Option<String>,
     },
 
-    /// Modify an existing artifact
     /// Modify an existing artifact (status, title, description, tags, fields)
     ///
     /// Use the `--set-*` flags, not positionals. Examples:
@@ -2438,14 +2450,30 @@ fn run(cli: Cli) -> Result<bool> {
         ),
         Command::Link {
             source,
+            target_pos,
             link_type,
             target,
-        } => cmd_link(&cli, source, link_type, target),
+        } => match target.as_deref().or(target_pos.as_deref()) {
+            Some(t) => cmd_link(&cli, source, link_type, t),
+            None => anyhow::bail!(
+                "specify a target artifact, e.g. \
+                 `rivet link {source} <target> --type {link_type}` or \
+                 `rivet link {source} --target <target> --type {link_type}`"
+            ),
+        },
         Command::Unlink {
             source,
+            target_pos,
             link_type,
             target,
-        } => cmd_unlink(&cli, source, link_type, target),
+        } => match target.as_deref().or(target_pos.as_deref()) {
+            Some(t) => cmd_unlink(&cli, source, link_type, t),
+            None => anyhow::bail!(
+                "specify a target artifact, e.g. \
+                 `rivet unlink {source} <target> --type {link_type}` or \
+                 `rivet unlink {source} --target <target> --type {link_type}`"
+            ),
+        },
         Command::Modify {
             id,
             where_filter,

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5951,3 +5951,103 @@ fn trace_command_renders_and_is_deterministic() {
         "trace of a missing id should report not-found"
     );
 }
+
+// ── agent CLI ergonomics (REQ-188) ─────────────────────────────────────
+
+#[test]
+fn link_positional_target_is_parsed() {
+    // Regression: `rivet link <source> <target> --type <t>` (target as a second
+    // positional) previously errored "unexpected argument '<target>'". The
+    // positional must now be parsed (the command may still fail for unrelated
+    // reasons, but never with a clap parse error about the second positional).
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let p = tmp.path().to_str().unwrap().to_string();
+    let init = Command::new(rivet_bin())
+        .args(["init", "--dir", &p])
+        .output()
+        .expect("init");
+    assert!(init.status.success(), "init must succeed");
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            &p,
+            "link",
+            "REQ-001",
+            "REQ-002",
+            "--type",
+            "traces-to",
+        ])
+        .output()
+        .expect("link run");
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("unexpected argument"),
+        "positional target must be parsed, not rejected by clap. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn link_no_target_is_reported() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let p = tmp.path().to_str().unwrap().to_string();
+    Command::new(rivet_bin())
+        .args(["init", "--dir", &p])
+        .output()
+        .expect("init");
+    let out = Command::new(rivet_bin())
+        .args(["--project", &p, "link", "REQ-001", "--type", "traces-to"])
+        .output()
+        .expect("link run");
+    assert!(
+        !out.status.success(),
+        "`rivet link` with no target must error, got exit 0"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("target"),
+        "error must mention the missing target"
+    );
+}
+
+#[test]
+fn init_preset_help_lists_all_presets() {
+    // The --preset help must list every preset `resolve_preset` accepts, with
+    // no duplicated/contradictory lines (the doc-comment had two partial,
+    // conflicting lists). REQ-188.
+    let out = Command::new(rivet_bin())
+        .args(["init", "--help"])
+        .output()
+        .expect("init --help");
+    let help = String::from_utf8_lossy(&out.stdout);
+    for preset in [
+        "aspice",
+        "stpa-ai",
+        "cybersecurity",
+        "aadl",
+        "eu-ai-act",
+        "safety-case",
+        "do-178c",
+        "en-50128",
+        "iec-61508",
+        "iec-62304",
+        "iso-pas-8800",
+        "sotif",
+    ] {
+        assert!(
+            help.contains(preset),
+            "init --help must list preset '{preset}'; got:\n{help}"
+        );
+    }
+}
+
+#[test]
+fn modify_help_has_no_duplicated_summary() {
+    let out = Command::new(rivet_bin())
+        .args(["modify", "--help"])
+        .output()
+        .expect("modify --help");
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !help.contains("Modify an existing artifact Modify an existing artifact"),
+        "modify --help must not stutter its summary; got:\n{help}"
+    );
+}


### PR DESCRIPTION
## Friction → fix (hourly dogfooding loop)

A dogfooding pass over agent-facing commands surfaced three friction points, all verified against current `main`:

### 1. `rivet link` / `unlink` — target forced as a flag
```
$ rivet link REQ-001 REQ-002 --type traces-to
error: unexpected argument 'REQ-002' found
Usage: rivet link --type <LINK_TYPE> --target <TARGET> <SOURCE>
```
Source→target is a natural ordered pair, but `target` was a required `--target` flag — the same friction class as the `query` (REQ-187) and `next-id` positional gaps. **Fix:** optional positional `TARGET` on `link` and `unlink`; `--target` still works and wins if both given; clear error if neither.

### 2. `rivet init --help` — wrong, stuttering `--preset` list
The `--preset` doc-comment had **two duplicated, contradictory** lines (one listing `do-178c/en-50128`, the other `iec-61508/iec-62304`); clap concatenated them into a stutter that also **omitted 5 of the 14** presets `resolve_preset` accepts (`stpa-ai`, `eu-ai-act`, `safety-case`, `iso-pas-8800`, `sotif`). **Fix:** one accurate line listing all 14.

### 3. `rivet modify --help` — stuttering summary
`Modify an existing artifact Modify an existing artifact (…)` — a duplicated doc-comment summary line. **Fix:** collapsed to one line.

## Tests (`cli_commands`)
- `link_positional_target_is_parsed` — positional target no longer a clap parse error.
- `link_no_target_is_reported` — no target → non-zero exit mentioning "target".
- `init_preset_help_lists_all_presets` — help lists every preset `resolve_preset` accepts.
- `modify_help_has_no_duplicated_summary`.

## Verification
`cargo test -p rivet-cli --test cli_commands` (4 new, all pass) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 (only the pre-existing `clippy.toml`/`Cargo.toml` MSRV-mismatch warning) · `rivet validate` PASS. Manually confirmed `rivet link REQ-001 REQ-002 --type traces-to` (positional) creates the real link (`get REQ-001` shows `traces-to -> REQ-002`). Implements + Verifies **REQ-188**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)