### PR TITLE
feat(cli): query --format json carries command envelope + ships query-output schema (REQ-189)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5730,3 +5730,41 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-189
+    type: requirement
+    title: "`rivet query --format json` carries the `command` envelope field + ships a query-output JSON schema"
+    status: implemented
+    description: |
+      Dogfooding pass on JSON-output consistency: every machine-readable command
+      output carries a top-level `command` field (validate, get, list, stats,
+      coverage, supplier all emit it; list/stats/coverage/validate even ship a
+      `schemas/json/*-output.schema.json` registered in JSON_SCHEMA_REGISTRY and
+      surfaced via `rivet schema list-json`/`get-json`). `rivet query --format
+      json` — a primary agent-facing command with the same artifact-collection
+      shape as `list` — was the lone exception: its envelope was
+      `{filter, count, total, truncated, artifacts}` with NO `command` field and
+      NO published output schema. An agent (or a JSON-schema consumer) keying off
+      `command` finds query anomalous.
+
+      Fix (additive): emit `"command": "query"` in the query JSON envelope; add
+      `schemas/json/query-output.schema.json` (mirroring list-output, with
+      query's `filter/total/truncated` and array-valued `links`); register it in
+      JSON_SCHEMA_REGISTRY so `schema list-json`/`get-json query` work.
+
+      Acceptance:
+        - `rivet query --sexpr '(= type "requirement")' --format json | python3 -c
+          'import sys,json;assert json.load(sys.stdin)["command"]=="query"'`
+          exits 0.
+        - `rivet schema get-json query` prints a path to an existing schema file.
+        - `rivet schema list-json --format json` includes a "query" entry.
+        - `cargo test -p rivet-cli --test cli_commands query_json_output_has_command_envelope`
+          passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, query, json, schema, consistency, agent-ux, machine-readable]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -10731,7 +10731,7 @@ fn infer_source_preset(schemas: &[String]) -> String {
         .unwrap_or_else(|| "dev".to_string())
 }
 
-/// The four CLI subcommands that emit machine-readable JSON along with the
+/// The CLI subcommands that emit machine-readable JSON along with the
 /// JSON schema file that describes their output.
 const JSON_SCHEMA_REGISTRY: &[(&str, &str, &str)] = &[
     (
@@ -10753,6 +10753,11 @@ const JSON_SCHEMA_REGISTRY: &[(&str, &str, &str)] = &[
         "list",
         "schemas/json/list-output.schema.json",
         "rivet list --format json",
+    ),
+    (
+        "query",
+        "schemas/json/query-output.schema.json",
+        "rivet query --format json",
     ),
 ];
 
@@ -15303,6 +15308,7 @@ fn cmd_query(
                 })
                 .collect();
             let mut out = serde_json::json!({
+                "command": "query",
                 "filter": sexpr,
                 "count": artifacts.len(),
                 "total": result.total,

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -3479,7 +3479,7 @@ fn schema_list_json_produces_valid_output() {
         .iter()
         .filter_map(|e| e.get("name").and_then(|v| v.as_str()))
         .collect();
-    for expected in ["validate", "stats", "coverage", "list"] {
+    for expected in ["validate", "stats", "coverage", "list", "query"] {
         assert!(
             names.contains(&expected),
             "expected '{expected}' in list, got {names:?}"
@@ -3502,7 +3502,7 @@ fn schema_get_json_returns_path_and_content() {
     let root_str = project_root();
     let root_str = root_str.to_str().unwrap();
 
-    for name in ["validate", "stats", "coverage", "list"] {
+    for name in ["validate", "stats", "coverage", "list", "query"] {
         // Path mode
         let out = Command::new(rivet_bin())
             .args(["--project", root_str, "schema", "get-json", name])
@@ -6050,4 +6050,40 @@ fn modify_help_has_no_duplicated_summary() {
         !help.contains("Modify an existing artifact Modify an existing artifact"),
         "modify --help must not stutter its summary; got:\n{help}"
     );
+}
+
+/// `rivet query --format json` must carry the same `command` envelope field as
+/// list/stats/coverage/validate, and expose the keys query-output.schema.json
+/// documents. REQ-189 (envelope consistency).
+#[test]
+fn query_json_output_has_command_envelope() {
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "query",
+            "--sexpr",
+            r#"(= type "requirement")"#,
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("query --format json");
+    assert!(
+        out.status.success(),
+        "query --format json must succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("valid JSON");
+    assert_eq!(
+        v.get("command").and_then(|c| c.as_str()),
+        Some("query"),
+        "query JSON must carry command=\"query\" for envelope consistency with list/stats/coverage"
+    );
+    for key in ["filter", "count", "total", "truncated", "artifacts"] {
+        assert!(
+            v.get(key).is_some(),
+            "query JSON must expose '{key}' (per query-output.schema.json)"
+        );
+    }
 }

--- a/schemas/json/query-output.schema.json
+++ b/schemas/json/query-output.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseengine.github.io/rivet/schemas/json/query-output.schema.json",
+  "title": "rivet query --format json",
+  "description": "Machine-readable output produced by `rivet query --format json`.",
+  "type": "object",
+  "required": ["command", "filter", "count", "total", "truncated", "artifacts"],
+  "additionalProperties": true,
+  "properties": {
+    "command": {
+      "type": "string",
+      "const": "query"
+    },
+    "filter": {
+      "type": "string",
+      "description": "The s-expression filter that produced these matches."
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of artifacts returned (after any --limit truncation)."
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total number of matches before --limit truncation."
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "True if the result set was truncated by --limit."
+    },
+    "variant": {
+      "type": "string",
+      "description": "Active variant name, present only when --variant was passed."
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "title"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "type": { "type": "string" },
+          "title": { "type": "string" },
+          "status": {
+            "type": "string",
+            "description": "Status string, or '-' if unset."
+          },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "description": { "type": "string" },
+          "links": {
+            "type": "array",
+            "description": "Outgoing links from this artifact.",
+            "items": {
+              "type": "object",
+              "required": ["type", "target"],
+              "additionalProperties": true,
+              "properties": {
+                "type": { "type": "string" },
+                "target": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Friction → fix (hourly dogfooding loop)

A JSON-output consistency pass found that **`rivet query --format json` was the only command missing the `command` envelope field**:

| command | `command` field | output schema |
|---|---|---|
| validate / get / list / stats / coverage | ✅ | ✅ (list/stats/coverage/validate) |
| **query** | ❌ | ❌ |

```
$ rivet query --sexpr '(= type "requirement")' --format json | jq 'keys'
["artifacts","count","filter","total","truncated"]   # no "command"
```

`query` has the same artifact-collection shape as `list` (which ships `list-output.schema.json` and emits `command`), so an agent or JSON-schema consumer keying off `command` finds query anomalous.

## Change (additive)
- Emit `"command": "query"` in the query JSON envelope.
- Add `schemas/json/query-output.schema.json` (mirrors `list-output`, plus query's `filter`/`total`/`truncated` and array-valued `links`).
- Register it in `JSON_SCHEMA_REGISTRY` → `rivet schema list-json` / `schema get-json query` now work.

```
$ rivet query --sexpr '(= type "requirement")' --format json | jq '.command'
"query"
$ rivet schema get-json query
./schemas/json/query-output.schema.json
```

## Tests (`cli_commands`)
- `query_json_output_has_command_envelope` — asserts `command="query"` + required keys.
- Extended `schema_get_json_returns_path_and_content` and `schema_list_json_produces_valid_output` to include `query`.

## Verification
`cargo test -p rivet-cli --test cli_commands` (3 incl. new, pass) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 (only pre-existing MSRV-mismatch warning) · `rivet validate` PASS. Implements + Verifies **REQ-189**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)