### PR TITLE
fix(query): execute_sexpr returns deterministic (id-sorted) matches (REQ-190, #415)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5768,3 +5768,39 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-190
+    type: requirement
+    title: "`execute_sexpr` returns deterministic (id-sorted) matches so query output + --limit truncation are reproducible"
+    status: implemented
+    description: |
+      Verified bug (issue #415): `rivet query --format json` for the same filter
+      returns results in a DIFFERENT order on every run (run1: REQ-125,166,147...
+      run2: REQ-174,011,117...), because the shared `execute_sexpr` engine
+      iterated the HashMap-ordered `store.iter()`. Two consequences:
+        - match order is nondeterministic across CLI / MCP `rivet_query` / the
+          `{{query:...}}` embed (all three share `execute_sexpr`);
+        - with `--limit`, the kept subset is an arbitrary HashMap-order slice, so
+          an agent paging or sampling gets a different subset each run — a
+          correctness bug, not just cosmetics.
+      `execute` (the non-sexpr path) already sorted by id; `execute_sexpr` was
+      missed. `Store::iter_sorted()` (REQ-159) already exists for exactly this.
+
+      Fix: iterate `store.iter_sorted()` in `execute_sexpr`, making both the
+      match order and the `--limit` truncation deterministic (lowest-id N).
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib query::tests::execute_sexpr_returns_matches_sorted_by_id`
+          passes.
+        - `cargo test -p rivet-core --lib query::tests::execute_sexpr_limit_truncates_to_lowest_ids_deterministically`
+          passes (limit keeps the lowest-id subset).
+        - `rivet query --sexpr '(= type "requirement")' --format ids` produces
+          byte-identical output across two consecutive runs.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [query, determinism, reproducibility, mcp, embed, bugfix, agent-ux]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-159

--- a/rivet-core/src/query.rs
+++ b/rivet-core/src/query.rs
@@ -133,6 +133,11 @@ impl std::error::Error for SexprQueryError {}
 /// embed all converge on a single code path.  `limit` caps the returned
 /// `matches` slice; `total` reports the untruncated count so callers can
 /// show "Showing N of M" style footers without re-running the filter.
+///
+/// Matches are returned in a deterministic order — ascending by `id` — so all
+/// three surfaces produce stable output AND `limit` truncates to the same
+/// lowest-`id` subset across runs (the store is HashMap-ordered; REQ-159 /
+/// #415 — `execute` already sorted, `execute_sexpr` was missed).
 pub fn execute_sexpr<'a>(
     store: &'a Store,
     graph: &LinkGraph,
@@ -151,7 +156,9 @@ pub fn execute_sexpr<'a>(
     let cap = limit.unwrap_or(usize::MAX);
     let mut matches: Vec<&Artifact> = Vec::new();
     let mut total = 0usize;
-    for a in store.iter() {
+    // `iter_sorted` (ascending by id) makes both the match order and the
+    // `limit` truncation deterministic across runs (#415).
+    for a in store.iter_sorted() {
         if !sexpr_eval::matches_filter_with_store(&expr, a, graph, store) {
             continue;
         }
@@ -243,6 +250,36 @@ mod tests {
 
         let r = execute_sexpr(&store, &graph, r#"(= type "requirement")"#, Some(3)).unwrap();
         assert_eq!(r.matches.len(), 3);
+        assert_eq!(r.total, 10);
+        assert!(r.truncated);
+    }
+
+    #[test]
+    fn execute_sexpr_returns_matches_sorted_by_id() {
+        // #415: matches must be ascending by id regardless of insertion order
+        // (the store is HashMap-ordered), so CLI/MCP/embed output is stable.
+        let (store, _schema, graph) = build(vec![
+            plain("REQ-030", "requirement", None, &[]),
+            plain("REQ-002", "requirement", None, &[]),
+            plain("REQ-100", "requirement", None, &[]),
+            plain("REQ-001", "requirement", None, &[]),
+        ]);
+        let r = execute_sexpr(&store, &graph, r#"(= type "requirement")"#, None).unwrap();
+        let ids: Vec<&str> = r.matches.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec!["REQ-001", "REQ-002", "REQ-030", "REQ-100"]);
+    }
+
+    #[test]
+    fn execute_sexpr_limit_truncates_to_lowest_ids_deterministically() {
+        // #415: with a limit, the kept subset must be the lowest-id `cap`
+        // matches, stable across runs — not a HashMap-order arbitrary subset.
+        let artifacts: Vec<Artifact> = (0..10)
+            .map(|i| plain(&format!("REQ-{i:02}"), "requirement", None, &[]))
+            .collect();
+        let (store, _schema, graph) = build(artifacts);
+        let r = execute_sexpr(&store, &graph, r#"(= type "requirement")"#, Some(3)).unwrap();
+        let ids: Vec<&str> = r.matches.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec!["REQ-00", "REQ-01", "REQ-02"]);
         assert_eq!(r.total, 10);
         assert!(r.truncated);
     }


### PR DESCRIPTION
## Verified bug (closes the query part of #415)

`rivet query --format json` for the **same** filter returned a **different order on every run**:

```
run1: REQ-125,REQ-166,REQ-147,REQ-092,...
run2: REQ-174,REQ-011,REQ-117,REQ-094,...   # completely different
```

Root cause: the shared `execute_sexpr` engine iterated the HashMap-ordered `store.iter()`. `list` (via `execute`) already sorted by id — but `execute_sexpr` (used by `rivet query`, the MCP `rivet_query` tool, **and** `{{query:...}}` doc embeds) was missed. Two consequences:

1. **Match order is nondeterministic** across all three surfaces → unstable diffs / non-reproducible output.
2. **With `--limit`, a different *subset* is returned each run** (the truncation kept an arbitrary HashMap-order slice) — a correctness bug for any agent paging or sampling results.

## Fix

Iterate `store.iter_sorted()` (the deterministic accessor added for #415 / REQ-159) in `execute_sexpr`, so both the match order and the `--limit` truncation are deterministic (lowest-id N).

## Verification

- `cargo test -p rivet-core --lib query::tests` — 8/8, incl. two new:
  - `execute_sexpr_returns_matches_sorted_by_id`
  - `execute_sexpr_limit_truncates_to_lowest_ids_deterministically` (asserts the kept subset is the lowest-id N, not merely the count — the previous limit test only checked count and missed this).
- `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS.
- Manually confirmed `rivet query --sexpr '(= type "requirement")' --format ids` is now **byte-identical (md5)** across two consecutive runs and id-sorted.

Implements + Verifies **REQ-190**. Refs #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
