### PR TITLE
fix(links): orphans() returns id-sorted output for deterministic stats/validate (REQ-191, #415)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5804,3 +5804,34 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-159
+
+  - id: REQ-191
+    type: requirement
+    title: "`LinkGraph::orphans` returns id-sorted output so stats/validate/list orphan lists are reproducible"
+    status: implemented
+    description: |
+      Verified bug (issue #415, sibling of REQ-190): `rivet stats --format json`
+      produced a DIFFERENT `orphans` array order on every run (run1:
+      [spar:SPAR-REQ-001, spar:SPAR-SYS-001, SL-TQ-004, ...]; run2: [SL-AI-003,
+      SL-TQ-004, ..., spar:SPAR-REQ-001] — same set, different order). Root
+      cause: `LinkGraph::orphans` iterated the HashMap-ordered `store.iter()`
+      and collected without sorting. The orphan list feeds `rivet stats`,
+      `rivet validate`, and `rivet list` orphan reporting, so all three were
+      nondeterministic. (matrix/export/coverage/list-body were already stable.)
+
+      Fix: iterate `store.iter_sorted()` in `LinkGraph::orphans` so the orphan
+      list is ascending by id and reproducible across runs.
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib links::tests::orphans_are_id_sorted_for_deterministic_output`
+          passes.
+        - `rivet stats --format json` produces byte-identical output across two
+          consecutive runs.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [stats, validate, orphans, determinism, reproducibility, bugfix]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-159

--- a/rivet-core/src/links.rs
+++ b/rivet-core/src/links.rs
@@ -214,9 +214,13 @@ impl LinkGraph {
     }
 
     /// Detect orphan artifacts (no incoming or outgoing links).
+    ///
+    /// Returned in deterministic order — ascending by `id` via `iter_sorted` —
+    /// so `rivet stats`/`validate`/`list` orphan output is reproducible across
+    /// runs (the store is HashMap-ordered; #415).
     pub fn orphans<'a>(&self, store: &'a Store) -> Vec<&'a ArtifactId> {
         store
-            .iter()
+            .iter_sorted()
             .filter(|a| !self.forward.contains_key(&a.id) && !self.backward.contains_key(&a.id))
             .map(|a| &a.id)
             .collect()
@@ -453,6 +457,23 @@ mod tests {
             orphans.len(),
         );
         assert_eq!(orphans[0], "LONE");
+    }
+
+    #[test]
+    fn orphans_are_id_sorted_for_deterministic_output() {
+        // #415: orphan output (stats/validate/list) must be reproducible. Insert
+        // isolated artifacts in scrambled id order; orphans() must yield ascending
+        // by id regardless of the HashMap-ordered store.
+        let (_chained, schema) = chain();
+        let store = store_from(vec![
+            minimal_artifact("REQ-030", "node"),
+            minimal_artifact("REQ-002", "node"),
+            minimal_artifact("REQ-100", "node"),
+            minimal_artifact("REQ-001", "node"),
+        ]);
+        let g = LinkGraph::build(&store, &schema);
+        let ids: Vec<&str> = g.orphans(&store).iter().map(|id| id.as_str()).collect();
+        assert_eq!(ids, vec!["REQ-001", "REQ-002", "REQ-030", "REQ-100"]);
     }
 
     // Verifies: REQ-002


### PR DESCRIPTION
## Verified bug (sibling of #415 / REQ-190)

Extending the determinism audit to other output commands, `rivet stats --format json` was nondeterministic:

```
run1 orphans: [spar:SPAR-REQ-001, spar:SPAR-SYS-001, SL-TQ-004, ...]
run2 orphans: [SL-AI-003, SL-TQ-004, ..., spar:SPAR-REQ-001]   # same set, shuffled
```

Root cause: `LinkGraph::orphans` iterated the HashMap-ordered `store.iter()` and collected without sorting. The orphan list feeds `rivet stats`, `rivet validate`, and `rivet list` orphan reporting — so all three were nondeterministic. (`matrix`/`export`/`coverage`/list-body were already stable — I tested each.)

## Fix

Iterate `store.iter_sorted()` in `LinkGraph::orphans` so the list is ascending by id and reproducible.

## Verification

- `cargo test -p rivet-core --lib links::tests` — 8/8, incl. new `orphans_are_id_sorted_for_deterministic_output` (inserts isolated artifacts in scrambled id order, asserts ascending output).
- `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS.
- Manually confirmed `rivet stats --format json` is now **byte-identical (md5)** across two runs, `orphans` sorted ascending.

Implements + Verifies **REQ-191**. Refs #415 (same class as #461/REQ-190 which fixed the `query` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
