### PR TITLE
feat(cli): commits --format json carries the command envelope field (REQ-192)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5835,3 +5835,37 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-159
+
+  - id: REQ-192
+    type: requirement
+    title: "`rivet commits --format json` carries the `command` envelope field (consistency with all other JSON commands)"
+    status: implemented
+    description: |
+      Dogfooding JSON-consistency audit (follow-on to REQ-189): every
+      machine-readable command output carries a top-level `command` field —
+      validate, get, list, stats, coverage, query (REQ-189), matrix, diff,
+      impact all do. `rivet commits --format json` was the lone remaining
+      exception: its envelope was `{summary, broken_refs, orphans, unimplemented,
+      artifact_coverage}` with NO `command` field, so an agent keying off
+      `command` to dispatch on output type finds commits anomalous.
+
+      Verified the false-alarm siblings too: `get`/`coverage --format json`
+      parse as valid JSON (an earlier "invalid control character" reading was a
+      shell-quoting artifact, not a rivet bug), and `commits` output is
+      deterministic — so the only real gap is the missing `command` field.
+
+      Fix (additive): emit `"command": "commits"` in `cmd_commits_json`.
+
+      Acceptance:
+        - `rivet commits --format json | python3 -c 'import sys,json;
+          assert json.load(sys.stdin)["command"]=="commits"'` exits 0.
+        - `cargo test -p rivet-cli --test cli_commands commits_json_output_has_command_envelope`
+          passes.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, commits, json, consistency, agent-ux, machine-readable]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -11380,6 +11380,7 @@ fn cmd_commits_json(analysis: &rivet_core::commits::CommitAnalysis, strict: bool
         .filter(|br| br.malformed)
         .count();
     let json = serde_json::json!({
+        "command": "commits",
         "summary": {
             "linked": analysis.linked.len(),
             "orphans": analysis.orphans.len(),

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6087,3 +6087,29 @@ fn query_json_output_has_command_envelope() {
         );
     }
 }
+
+/// `rivet commits --format json` must carry the `command` envelope field like
+/// every other machine-readable command (validate/get/list/stats/coverage/
+/// query/matrix/diff/impact). commits was the last one missing it. REQ-192.
+/// (Exit code is not asserted: a repo with broken trailers exits non-zero but
+/// still emits the JSON document.)
+#[test]
+fn commits_json_output_has_command_envelope() {
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "commits",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("commits --format json");
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("commits must emit valid JSON");
+    assert_eq!(
+        v.get("command").and_then(|c| c.as_str()),
+        Some("commits"),
+        "commits JSON must carry command=\"commits\" for envelope consistency"
+    );
+}


### PR DESCRIPTION
## Friction → fix (hourly dogfooding loop, JSON-consistency audit)

Auditing the machine-readable envelope across **every** `--format json` command (follow-on to REQ-189), `rivet commits` was the lone remaining command missing the top-level `command` field:

| command | `command` field |
|---|---|
| validate / get / list / stats / coverage / query / matrix / diff / impact | ✅ |
| **commits** | ❌ → keys were `summary, broken_refs, orphans, unimplemented, artifact_coverage` |

An agent dispatching on `command` to interpret output finds commits anomalous.

## Change (additive)

Emit `"command": "commits"` in `cmd_commits_json`.

```
$ rivet commits --format json | jq '.command'
"commits"
```

## Also verified (no bug)

- `get` / `coverage --format json` are **valid JSON** — an earlier "invalid control character" reading was a shell-quoting artifact in my probe, not a rivet bug (checked with `python3 -m json.tool` + a raw-control-byte scan).
- `commits` / `bundle` output is **deterministic** across runs (git-history order; `unimplemented` already sorted).

## Tests

`commits_json_output_has_command_envelope` asserts `command=="commits"` (exit code not asserted — a repo with broken trailers exits non-zero but still emits the JSON).

## Verification

`cargo test -p rivet-cli --test cli_commands commits_json_output_has_command_envelope` (pass) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 (only the pre-existing MSRV-mismatch config warning) · `rivet validate` PASS. Implements + Verifies **REQ-192**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
