### PR TITLE
fix(embed): {{query:...}} embed renders rows id-sorted for reproducible docs (REQ-193, #415)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5869,3 +5869,40 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-193
+    type: requirement
+    title: "`{{query:...}}` doc embed renders rows id-sorted so generated docs are reproducible"
+    status: implemented
+    description: |
+      Verified bug (issue #415; sibling of REQ-190): `rivet embed 'query:(= type
+      "requirement")'` rendered a DIFFERENT row order on every run. REQ-190 fixed
+      the shared `execute_sexpr` engine, but the `{{query:...}}` embed has its
+      OWN match loop in `render_query` (rivet-core/src/embed.rs) that iterated
+      the HashMap-ordered `ctx.store.iter()` directly — it never went through
+      `execute_sexpr`. Consequences:
+        - embed table rows render in nondeterministic order, so any document
+          containing a `{{query:...}}` embed (compliance reports, zola sites,
+          `rivet docs`) produces churny, non-reproducible output across builds;
+        - the embed's default row `limit` truncated to an arbitrary HashMap-order
+          subset, so an over-limit embed showed a different (and differently
+          incomplete) set each render.
+      The aggregate embeds (`stats:types`, `stats:status`, etc.) were already
+      deterministic — they accumulate into a `BTreeMap`.
+
+      Fix: iterate `ctx.store.iter_sorted()` in `render_query`, making both row
+      order and limit truncation deterministic (lowest-id N).
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib embed::tests::query_embed_renders_rows_id_sorted_for_deterministic_docs`
+          passes.
+        - `rivet embed 'query:(= type "requirement")'` produces byte-identical
+          output across two consecutive runs.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [embed, docs, query, determinism, reproducibility, bugfix]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-159

--- a/rivet-core/src/embed.rs
+++ b/rivet-core/src/embed.rs
@@ -1070,7 +1070,11 @@ fn render_query(request: &EmbedRequest, ctx: &EmbedContext<'_>) -> Result<String
 
     let mut matches: Vec<&crate::model::Artifact> = Vec::new();
     let mut total = 0usize;
-    for artifact in ctx.store.iter() {
+    // `iter_sorted` (ascending by id) makes both the rendered row order and the
+    // `limit` truncation deterministic, so `{{query:...}}` doc embeds produce
+    // reproducible output across builds (the store is HashMap-ordered; #415 /
+    // REQ-190, which fixed the parallel `execute_sexpr` path).
+    for artifact in ctx.store.iter_sorted() {
         if crate::sexpr_eval::matches_filter_with_store(&expr, artifact, ctx.graph, ctx.store) {
             total += 1;
             if matches.len() < limit {
@@ -1784,6 +1788,35 @@ mod tests {
             .collect();
         direct_ids.sort();
         assert_eq!(direct_ids, vec!["REQ-1".to_string(), "REQ-2".to_string()]);
+    }
+
+    #[test]
+    fn query_embed_renders_rows_id_sorted_for_deterministic_docs() {
+        // #415 / REQ-190: `{{query:...}}` embeds must render rows ascending by
+        // id (not HashMap order) so generated docs are reproducible across
+        // builds. Insert in scrambled id order; the HTML must list them sorted.
+        let store = make_store(vec![
+            plain("REQ-030", "requirement", None, &[]),
+            plain("REQ-002", "requirement", None, &[]),
+            plain("REQ-100", "requirement", None, &[]),
+            plain("REQ-001", "requirement", None, &[]),
+        ]);
+        let schema = Schema::merge(&[]);
+        let graph = LinkGraph::build(&store, &schema);
+        let html = run_embed(r#"query:(= type "requirement")"#, &store, &schema, &graph).unwrap();
+        let positions: Vec<usize> = ["REQ-001", "REQ-002", "REQ-030", "REQ-100"]
+            .iter()
+            .map(|id| {
+                html.find(id)
+                    .unwrap_or_else(|| panic!("id {id} missing in embed HTML:\n{html}"))
+            })
+            .collect();
+        let mut sorted = positions.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            positions, sorted,
+            "embed rows must appear ascending by id; got HTML:\n{html}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Verified bug (third instance of #415)

`rivet embed 'query:(= type "requirement")'` rendered a **different row order on every run** (byte-different md5).

REQ-190 (#461) fixed the shared `execute_sexpr` engine — but the `{{query:...}}` doc embed has its **own** match loop in `render_query` (`rivet-core/src/embed.rs`) that iterated the HashMap-ordered `ctx.store.iter()` directly; it never went through `execute_sexpr`. Consequences:

1. **Embed table rows render in nondeterministic order** → any document containing a `{{query:...}}` embed (compliance reports, zola sites, `rivet docs`) produces churny, non-reproducible output across builds.
2. **The row `limit` truncated to an arbitrary HashMap-order subset** → an over-limit embed showed a different (and differently incomplete) set each render.

The aggregate embeds (`stats:types`, `stats:status`, …) were already deterministic — they accumulate into a `BTreeMap`.

## Fix

Iterate `ctx.store.iter_sorted()` in `render_query`, making both row order and `limit` truncation deterministic (lowest-id N).

## Test

`query_embed_renders_rows_id_sorted_for_deterministic_docs` inserts artifacts in scrambled id order and asserts the rendered HTML lists ids ascending (the prior embed test sorted before comparing, which masked the order).

## Verification

`cargo test -p rivet-core --lib embed::tests` — 81/81 · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS. Manually confirmed `rivet embed 'query:(= type "requirement")'` is now **byte-identical (md5)** across two runs.

Implements + Verifies **REQ-193**. Refs #415 (completes the trio with #461/query and #462/orphans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
