### PR TITLE
feat(cli): snapshot diff accepts the baseline path positionally (REQ-194)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5906,3 +5906,34 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-159
+
+  - id: REQ-194
+    type: requirement
+    title: "`rivet snapshot diff` accepts the baseline path as a positional shorthand (not only --baseline)"
+    status: implemented
+    description: |
+      Dogfooding friction: `rivet snapshot diff <baseline.json>` — the natural
+      form (mirroring `git diff <ref>`, `diff <file>`) — errored with "unexpected
+      argument", because `snapshot diff` only accepted the baseline via the
+      `--baseline` flag. Same friction class as the `query` (REQ-187), `link`
+      (REQ-188), and `next-id` positional shorthands. An agent capturing then
+      diffing a snapshot naturally writes `snapshot diff <path>`.
+
+      Fix (additive): add an optional positional `BASELINE` to `snapshot diff`;
+      the `--baseline` flag still works and wins if both are given. When neither
+      is supplied, the existing auto-detect (latest snapshot under `snapshots/`)
+      is preserved.
+
+      Acceptance:
+        - `cargo test -p rivet-cli --test cli_commands snapshot_diff_accepts_positional_baseline`
+          passes (capture a snapshot, then `snapshot diff <path>` positionally
+          exits 0 with no clap parse error).
+        - `rivet snapshot diff --baseline <path>` still works unchanged.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, snapshot, diff, ergonomics, agent-ux, friction, consistency]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1390,7 +1390,12 @@ enum SnapshotAction {
     },
     /// Compare current state against a baseline snapshot
     Diff {
-        /// Path to the baseline snapshot JSON file
+        /// Path to the baseline snapshot JSON file. May be given positionally
+        /// (`rivet snapshot diff <baseline>`) or via `--baseline`.
+        #[arg(value_name = "BASELINE")]
+        baseline_pos: Option<PathBuf>,
+        /// Path to the baseline snapshot JSON file (equivalent to the positional
+        /// form; the flag wins if both are given).
         #[arg(long)]
         baseline: Option<PathBuf>,
         /// Output format: "text" (default), "json", or "markdown"
@@ -2240,9 +2245,15 @@ fn run(cli: Cli) -> Result<bool> {
             SnapshotAction::Capture { name, output } => {
                 cmd_snapshot_capture(&cli, name.as_deref(), output.as_deref())
             }
-            SnapshotAction::Diff { baseline, format } => {
-                cmd_snapshot_diff(&cli, baseline.as_deref(), format)
-            }
+            SnapshotAction::Diff {
+                baseline_pos,
+                baseline,
+                format,
+            } => cmd_snapshot_diff(
+                &cli,
+                baseline.as_deref().or(baseline_pos.as_deref()),
+                format,
+            ),
             SnapshotAction::List => cmd_snapshot_list(&cli),
         },
         Command::Variant { action } => match action {

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6113,3 +6113,53 @@ fn commits_json_output_has_command_envelope() {
         "commits JSON must carry command=\"commits\" for envelope consistency"
     );
 }
+
+/// `rivet snapshot diff <baseline>` must accept the baseline path positionally
+/// (previously it errored "unexpected argument" — only --baseline worked).
+/// Mirrors the next-id/query/link positional shorthands. REQ-194.
+#[test]
+fn snapshot_diff_accepts_positional_baseline() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let p = tmp.path().to_str().unwrap().to_string();
+    let snap = tmp.path().join("snap.json");
+    assert!(
+        Command::new(rivet_bin())
+            .args(["init", "--dir", &p])
+            .output()
+            .expect("init")
+            .status
+            .success(),
+        "init must succeed"
+    );
+    let cap = Command::new(rivet_bin())
+        .args([
+            "--project",
+            &p,
+            "snapshot",
+            "capture",
+            "--output",
+            snap.to_str().unwrap(),
+        ])
+        .output()
+        .expect("snapshot capture");
+    assert!(
+        cap.status.success(),
+        "capture must succeed: {}",
+        String::from_utf8_lossy(&cap.stderr)
+    );
+    // Positional baseline (no --baseline flag).
+    let out = Command::new(rivet_bin())
+        .args(["--project", &p, "snapshot", "diff", snap.to_str().unwrap()])
+        .output()
+        .expect("snapshot diff");
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("unexpected argument"),
+        "positional baseline must be parsed, not rejected by clap. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.status.success(),
+        "diff against the just-captured snapshot must succeed. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
## Friction → fix (hourly dogfooding loop)

`rivet snapshot diff <baseline.json>` — the natural form, mirroring `git diff <ref>` / `diff <file>` — errored:

```
$ rivet snapshot diff snapshots/v1.json
error: unexpected argument 'snapshots/v1.json' found
Usage: rivet snapshot diff [OPTIONS]
```

The baseline was only accepted via `--baseline`. Same friction class as the `query` (REQ-187), `link` (REQ-188), and `next-id` positional shorthands — an agent that captures then diffs a snapshot naturally writes `snapshot diff <path>`.

## Change (additive)

Optional positional `BASELINE` on `snapshot diff`; `--baseline` still works and wins if both are given. When neither is supplied, the existing **auto-detect** (latest snapshot under `snapshots/`) is preserved.

```
$ rivet snapshot diff snap.json            # now works (positional)
$ rivet snapshot diff --baseline snap.json # still works
$ rivet snapshot diff                       # still auto-detects latest
```

## Test

`snapshot_diff_accepts_positional_baseline` captures a snapshot in a temp project, then diffs it positionally — asserts no clap parse error and exit 0.

## Verification

`cargo test -p rivet-cli --test cli_commands snapshot_diff_accepts_positional_baseline` (pass) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 (only the pre-existing MSRV-mismatch config warning) · `rivet validate` PASS. Manually confirmed both the positional and `--baseline` forms exit 0 against a freshly captured snapshot. Implements + Verifies **REQ-194**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
