### PR TITLE
feat(cli): variant subcommands accept a bare --variant <name> (REQ-195, #466)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5937,3 +5937,37 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-195
+    type: requirement
+    title: "`variant` subcommands accept a bare `--variant <name>` (resolve from artifacts/variants/), consistent with `query`"
+    status: implemented
+    description: |
+      Dogfooding friction (issue #466, verified): `--variant` accepted a bare
+      NAME in `query` (resolved from `artifacts/variants/<name>.yaml`, issue
+      #287) but required a PATH in the `variant` subcommands — so an agent that
+      learned `query --variant dashboard-only` hit a confusing
+      `reading dashboard-only: No such file` on `variant solve/explain/...`,
+      even though the SAME file (`artifacts/variants/dashboard-only.yaml`) drives
+      both.
+
+      Fix (additive): route the `--variant` arg of `variant
+      check/solve/features/value/attr/explain/manifest` through the existing
+      `resolve_variant_arg(project, arg)` helper at the dispatch layer (it
+      resolves a direct path first, then `artifacts/variants/<name>.yaml`, then
+      errors with the available names). Handlers are unchanged; a direct path
+      keeps working.
+
+      Acceptance:
+        - `cargo test -p rivet-cli --test cli_commands variant_solve_accepts_bare_variant_name`
+          passes (bare name resolves; direct path still works).
+        - `rivet variant solve --model artifacts/feature-model.yaml --variant
+          dashboard-only` exits 0 (no "No such file" error).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, variant, ergonomics, agent-ux, consistency, friction]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -2256,79 +2256,88 @@ fn run(cli: Cli) -> Result<bool> {
             ),
             SnapshotAction::List => cmd_snapshot_list(&cli),
         },
-        Command::Variant { action } => match action {
-            VariantAction::Init { name, dir, force } => cmd_variant_init(name, dir, *force),
-            VariantAction::Check {
-                model,
-                variant,
-                format,
-            } => cmd_variant_check(model, variant, format),
-            VariantAction::CheckAll {
-                model,
-                binding,
-                format,
-            } => cmd_variant_check_all(model, binding, format),
-            VariantAction::List { model, format } => cmd_variant_list(model, format),
-            VariantAction::Solve {
-                model,
-                variant,
-                binding,
-                format,
-            } => cmd_variant_solve(&cli, model, variant, binding.as_deref(), format),
-            VariantAction::Features {
-                model,
-                variant,
-                format,
-            } => cmd_variant_features(model, variant, format),
-            VariantAction::Value {
-                model,
-                variant,
-                feature,
-            } => cmd_variant_value(model, variant, feature),
-            VariantAction::Attr {
-                model,
-                variant,
-                feature,
-                key,
-            } => cmd_variant_attr(model, variant, feature, key),
-            VariantAction::Explain {
-                model,
-                variant,
-                feature,
-                format,
-            } => cmd_variant_explain(model, variant, feature.as_deref(), format),
-            VariantAction::Manifest {
-                model,
-                variant,
-                binding,
-                format,
-            } => cmd_variant_manifest(model, variant, binding, format),
-            VariantAction::Matrix {
-                model,
-                binding,
-                format,
-                variants,
-                attrs,
-                wrap,
-                default_runner,
-                runner_attr,
-                max_jobs,
-                fail_fast,
-                variants_dir,
-            } => cmd_variant_matrix(
-                model,
-                binding,
-                format,
-                variants,
-                attrs,
-                wrap,
-                default_runner,
-                runner_attr,
-                *max_jobs,
-                *fail_fast,
-                variants_dir.as_deref(),
-            ),
-        },
+        Command::Variant { action } => {
+            // Resolve a `--variant <NAME|path>` uniformly across the variant
+            // subcommands: a bare name maps to `artifacts/variants/<name>.yaml`,
+            // mirroring `query --variant` (#466 / #287). A direct path is used
+            // as-is; an unknown name errors with the available names.
+            let rv = |arg: &std::path::Path| -> Result<std::path::PathBuf> {
+                Ok(resolve_variant_arg(&cli.project, &arg.to_string_lossy())?.0)
+            };
+            match action {
+                VariantAction::Init { name, dir, force } => cmd_variant_init(name, dir, *force),
+                VariantAction::Check {
+                    model,
+                    variant,
+                    format,
+                } => cmd_variant_check(model, &rv(variant)?, format),
+                VariantAction::CheckAll {
+                    model,
+                    binding,
+                    format,
+                } => cmd_variant_check_all(model, binding, format),
+                VariantAction::List { model, format } => cmd_variant_list(model, format),
+                VariantAction::Solve {
+                    model,
+                    variant,
+                    binding,
+                    format,
+                } => cmd_variant_solve(&cli, model, &rv(variant)?, binding.as_deref(), format),
+                VariantAction::Features {
+                    model,
+                    variant,
+                    format,
+                } => cmd_variant_features(model, &rv(variant)?, format),
+                VariantAction::Value {
+                    model,
+                    variant,
+                    feature,
+                } => cmd_variant_value(model, &rv(variant)?, feature),
+                VariantAction::Attr {
+                    model,
+                    variant,
+                    feature,
+                    key,
+                } => cmd_variant_attr(model, &rv(variant)?, feature, key),
+                VariantAction::Explain {
+                    model,
+                    variant,
+                    feature,
+                    format,
+                } => cmd_variant_explain(model, &rv(variant)?, feature.as_deref(), format),
+                VariantAction::Manifest {
+                    model,
+                    variant,
+                    binding,
+                    format,
+                } => cmd_variant_manifest(model, &rv(variant)?, binding, format),
+                VariantAction::Matrix {
+                    model,
+                    binding,
+                    format,
+                    variants,
+                    attrs,
+                    wrap,
+                    default_runner,
+                    runner_attr,
+                    max_jobs,
+                    fail_fast,
+                    variants_dir,
+                } => cmd_variant_matrix(
+                    model,
+                    binding,
+                    format,
+                    variants,
+                    attrs,
+                    wrap,
+                    default_runner,
+                    runner_attr,
+                    *max_jobs,
+                    *fail_fast,
+                    variants_dir.as_deref(),
+                ),
+            }
+        }
         Command::Runs { action } => match action {
             RunsAction::List { limit, format } => runs_cmd::cmd_list(&cli.project, *limit, format),
             RunsAction::Show { run_id, format } => runs_cmd::cmd_show(&cli.project, run_id, format),

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6163,3 +6163,56 @@ fn snapshot_diff_accepts_positional_baseline() {
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+/// `rivet variant solve --variant <name>` must resolve a bare name from
+/// artifacts/variants/<name>.yaml, like `query --variant` already does (#466);
+/// a direct path must still work (additive). REQ-195.
+#[test]
+fn variant_solve_accepts_bare_variant_name() {
+    let root = project_root();
+    let model = root.join("artifacts/feature-model.yaml");
+    let path = root.join("artifacts/variants/dashboard-only.yaml");
+    if !model.is_file() || !path.is_file() {
+        return; // fixtures moved; nothing to assert
+    }
+
+    // Bare name (the regression — previously errored "No such file").
+    let by_name = Command::new(rivet_bin())
+        .args([
+            "--project",
+            root.to_str().unwrap(),
+            "variant",
+            "solve",
+            "--model",
+            model.to_str().unwrap(),
+            "--variant",
+            "dashboard-only",
+        ])
+        .output()
+        .expect("variant solve by name");
+    assert!(
+        by_name.status.success(),
+        "variant solve --variant <name> must resolve the name. stderr: {}",
+        String::from_utf8_lossy(&by_name.stderr)
+    );
+
+    // Direct path still works (additive guarantee).
+    let by_path = Command::new(rivet_bin())
+        .args([
+            "--project",
+            root.to_str().unwrap(),
+            "variant",
+            "solve",
+            "--model",
+            model.to_str().unwrap(),
+            "--variant",
+            path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("variant solve by path");
+    assert!(
+        by_path.status.success(),
+        "variant solve --variant <path> must still work. stderr: {}",
+        String::from_utf8_lossy(&by_path.stderr)
+    );
+}


### PR DESCRIPTION
Closes #466.

## Friction → fix (hourly dogfooding loop)

`--variant` accepted a bare **name** in `query` (resolving `artifacts/variants/<name>.yaml`, #287) but required a **path** in the `variant` subcommands:

```
$ rivet query --sexpr '...' --variant dashboard-only            # ✅ name resolves
$ rivet variant explain --model fm.yaml --variant dashboard-only
error: reading dashboard-only: No such file or directory        # ❌ required a path
```

The **same file** drives both, so this was a confusing inconsistency for the command an agent reaches for after `query`.

## Change (additive)

Resolve `--variant` once per dispatch arm via the **existing** `resolve_variant_arg(project, arg)` helper (added for #287): direct path → use as-is; bare name → `artifacts/variants/<name>.yaml`; unknown → error listing what was tried. Applies to `variant check/solve/features/value/attr/explain/manifest`. Handlers are unchanged; passing a path still works.

```
$ rivet variant solve   --model fm.yaml --variant dashboard-only   # Variant 'dashboard-only': PASS
$ rivet variant explain --model fm.yaml --variant dashboard-only   # Variant audit: dashboard-only
$ rivet variant solve   --model fm.yaml --variant nope-xyz
error: variant 'nope-xyz' not found.
  Tried: nope-xyz (not a file) and ./artifacts/variants/nope-xyz.yaml (does not exist).
```

## Test

`variant_solve_accepts_bare_variant_name` — asserts the bare name resolves **and** a direct path still works.

## Verification

`cargo test -p rivet-cli --test cli_commands variant_solve_accepts_bare_variant_name` (pass) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 (only the pre-existing MSRV-mismatch config warning) · `rivet validate` PASS. Manually verified `solve`/`explain --variant <name>` now succeed and bogus names give a helpful error. Implements + Verifies **REQ-195**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
