### PR TITLE
fix(export): honest AADL fallback in static HTML, no perpetual Loading (REQ-196, #468)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -5971,3 +5971,41 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-196
+    type: requirement
+    title: "Static HTML export shows an honest AADL-diagram fallback (no perpetual 'Loading…')"
+    status: implemented
+    description: |
+      User-reported: AADL architecture diagrams in the published compliance
+      report (e.g. .../0.15.0/compliance/documents/ARCH-001.html) are stuck on
+      "Loading AADL diagram..." forever. Root cause: `document::render_to_html`
+      emits a `<div class="aadl-diagram"><p class="aadl-loading">Loading AADL
+      diagram...</p></div>` placeholder that is filled at runtime ONLY by
+      `rivet serve`'s `initAadlDiagrams` JS (rivet-cli/src/serve/js.rs), which
+      fetches server-only routes (`/source-raw/arch`, `/wasm/spar_wasm.js`) and a
+      spar WASM renderer. A static export bundles neither that JS nor those
+      routes, so the placeholder never updates — and even the JS's paths are
+      absolute-from-domain-root, wrong for a report served at a subpath.
+
+      This REQ covers the immediate, honest fix: in the export path
+      (`render_document_body_for_export`), rewrite the perpetual "Loading AADL
+      diagram..." into a static note pointing to the interactive `rivet serve`
+      view, so the report no longer looks hung. Actually inlining the rendered
+      SVG at export time (server-side via the spar wasm_runtime) is the larger
+      follow-up tracked in a separate issue.
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib export::tests::static_export_replaces_perpetual_aadl_loading_with_honest_note`
+          passes.
+        - A document with an ```aadl block, exported via `rivet export --format
+          html`, contains no "Loading AADL diagram..." text and instead points
+          to `rivet serve`.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [export, html, aadl, compliance-report, docs, ux, user-reported, bugfix]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-105

--- a/rivet-core/src/export.rs
+++ b/rivet-core/src/export.rs
@@ -2410,7 +2410,22 @@ fn render_document_body_for_export(
     //   <a class="artifact-ref" hx-get="/artifacts/ID" hx-target="#content" href="#">ID</a>
     // We rewrite these to:
     //   <a class="artifact-ref" href="./requirements.html#art-ID">ID</a>
-    rewrite_artifact_links(&raw_html, req_href)
+    static_aadl_fallback(&rewrite_artifact_links(&raw_html, req_href))
+}
+
+/// In a static HTML export there is no `rivet serve` JS/server to fill the
+/// `.aadl-diagram` placeholder (it is rendered at runtime only by the dashboard,
+/// which fetches `/source-raw/...` + the spar WASM module). So the perpetual
+/// "Loading AADL diagram..." text reads as a broken/hung page in compliance
+/// reports. Replace it with an honest static note that points to the
+/// interactive view. (Full server-side SVG inlining at export time is tracked
+/// separately.)
+fn static_aadl_fallback(html: &str) -> String {
+    html.replace(
+        "<p class=\"aadl-loading\">Loading AADL diagram...</p>",
+        "<p class=\"aadl-loading\">AADL architecture diagram — interactive \
+         rendering is available in the <code>rivet serve</code> dashboard.</p>",
+    )
 }
 
 /// Rewrite HTMX artifact links to static relative links for export.
@@ -3826,5 +3841,27 @@ mod tests {
         assert!(nav.contains("results.html"), "nav missing results link");
         assert!(nav.contains(">Source<"), "nav missing Source label");
         assert!(nav.contains(">Results<"), "nav missing Results label");
+    }
+
+    #[test]
+    fn static_export_replaces_perpetual_aadl_loading_with_honest_note() {
+        // A static HTML export has no `rivet serve` JS to fill the
+        // `.aadl-diagram` placeholder, so "Loading AADL diagram..." would hang
+        // forever in a compliance report. The export must rewrite it.
+        let placeholder = "<div class=\"aadl-diagram\" data-root=\"Sys::Arch\">\
+             <p class=\"aadl-loading\">Loading AADL diagram...</p></div>";
+        let out = static_aadl_fallback(placeholder);
+        assert!(
+            !out.contains("Loading AADL diagram..."),
+            "static export must not show a perpetual Loading state; got: {out}"
+        );
+        assert!(
+            out.contains("rivet serve"),
+            "fallback must point to the interactive view; got: {out}"
+        );
+        assert!(
+            out.contains("data-root=\"Sys::Arch\""),
+            "diagram container/context must be preserved; got: {out}"
+        );
     }
 }


### PR DESCRIPTION
Refs #468.

## User-reported bug

AADL architecture diagrams in the published static compliance report (`.../0.15.0/compliance/documents/ARCH-001.html`) are stuck on **"Loading AADL diagram…"** forever.

## Root cause

The `<div class="aadl-diagram"><p class="aadl-loading">Loading AADL diagram...</p></div>` placeholder (from `document::render_to_html`) is filled at runtime **only** by `rivet serve`'s `initAadlDiagrams` JS, which fetches server-only routes (`/source-raw/arch`, `/wasm/spar_wasm.js`) and renders via spar WASM. A **static** export bundles neither that JS nor those routes, so the placeholder never updates → perpetual "Loading…" (every error/fallback path in the JS would otherwise change the text, confirming the JS isn't even running in the export). Full diagnosis + the proper inline-SVG fix are in #468.

## This change (immediate, honest fix)

`render_document_body_for_export` now rewrites the perpetual "Loading AADL diagram…" into a static note pointing to the interactive `rivet serve` view, so the compliance report no longer looks hung. The diagram container/`data-root` is preserved.

```diff
- <p class="aadl-loading">Loading AADL diagram...</p>
+ <p class="aadl-loading">AADL architecture diagram — interactive rendering is
+  available in the <code>rivet serve</code> dashboard.</p>
```

The larger follow-up — **inlining the rendered SVG at export time** (server-side via the existing `wasm_runtime` spar renderer) so the diagrams actually appear in static reports — is tracked in **#468**.

## Test

`static_export_replaces_perpetual_aadl_loading_with_honest_note` asserts the export drops "Loading AADL diagram…", points to `rivet serve`, and preserves `data-root`.

## Verification

`cargo test -p rivet-core --lib export::tests::static_export_replaces_perpetual_aadl_loading_with_honest_note` (pass) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS. Implements + Verifies **REQ-196**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
