### PR TITLE
fix(serve/docs): honest AADL/WASM-unavailable guidance, not broken tooling (REQ-197, #468)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6009,3 +6009,38 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-105
+
+  - id: REQ-197
+    type: requirement
+    title: "Honest AADL/WASM-unavailable guidance — stop pointing users at broken/unpublished tooling"
+    status: implemented
+    description: |
+      Follow-on to the user-reported AADL bug (#468): when the spar WASM isn't
+      bundled, rivet pointed users at tooling that does not work for them. The
+      serve dashboard fallback said "run ./scripts/build-wasm.sh and rebuild"
+      (that script requires a local spar checkout + wasm32-wasip2 + Node/jco),
+      and `rivet-cli/assets/wasm/README.md` advertised `./scripts/fetch-wasm.sh`
+      under "Downloading from GitHub releases" — but spar publishes NO WASM
+      release asset (pulseengine/spar#259), so fetch-wasm.sh always fails. Both
+      sent users (incl. the reporter) down dead ends.
+
+      Fix (docs + messaging, no behaviour change): the serve `AADL_JS` fallback
+      messages now state the WASM is "not bundled in this build" and reference
+      the tracking issue (#468) instead of the broken script; the README
+      honestly describes the current state (stub fallback, fetch-wasm.sh blocked
+      on spar#259, build-from-source requires a local spar checkout + toolchain).
+
+      Acceptance:
+        - `cargo test -p rivet-cli --bin rivet serve::js::tests::aadl_wasm_fallback_messages_are_honest`
+          passes (fallback no longer instructs running build-wasm.sh; states
+          "not bundled in this build"; references the tracking issue).
+        - `grep -q 'spar does .*not.*publish' rivet-cli/assets/wasm/README.md`
+          (README states the current blocked status).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [serve, aadl, wasm, docs, ux, user-reported, dx]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-cli/assets/wasm/README.md
+++ b/rivet-cli/assets/wasm/README.md
@@ -1,37 +1,46 @@
 # WASM Components
 
-This directory holds pre-built WASM components for rivet adapters.
+This directory holds the pre-built `spar-wasm` component used to render AADL
+diagrams in the `rivet serve` dashboard. The component is **not committed** to
+git (`.gitignore` excludes `*.wasm` and `js/`); `rivet-cli/build.rs` falls back
+to writing empty **stub** assets when none are present, so the build always
+succeeds but AADL diagrams render a "not available" fallback.
+
+> **Status (see pulseengine/rivet#468, pulseengine/spar#259):** spar does **not
+> yet publish** a WASM release asset, so there is currently no turnkey way to
+> obtain the real component — the options below require a local spar checkout
+> and toolchain. Once spar publishes a browser bundle, `fetch-wasm.sh` will pull
+> it and no local build will be needed.
 
 ## spar-wasm
 
-The `spar_wasm.wasm` component provides AADL parsing, analysis, and SVG rendering.
+The `spar_wasm.wasm` component provides AADL parsing, analysis, and SVG
+rendering. The browser loads the jco-transpiled bundle (`js/spar_wasm.js` +
+`js/spar_wasm.core*.wasm`), which `serve` embeds via `include_bytes!`.
 
-### Building from source
+### Building from source (requires a local spar checkout + toolchain)
+
+Needs the `spar` repo checked out, the `wasm32-wasip2` Rust target, and Node
+(`npx @bytecodealliance/jco`):
+
+```bash
+rustup target add wasm32-wasip2
+./scripts/build-wasm.sh /path/to/spar     # compiles + jco-transpiles into js/
+```
+
+Or the two steps manually:
 
 ```bash
 cd /path/to/spar
 cargo build --target wasm32-wasip2 -p spar-wasm --release
-cp target/wasm32-wasip2/release/spar_wasm.wasm /path/to/sdlc/rivet-cli/assets/wasm/
-```
-
-### Downloading from GitHub releases
-
-```bash
-./scripts/fetch-wasm.sh
-```
-
-### jco transpilation (for browser use)
-
-The dashboard uses `--instantiation async` mode so the browser JS can provide
-a virtual WASI filesystem with pre-fetched `.aadl` files:
-
-```bash
+cp target/wasm32-wasip2/release/spar_wasm.wasm /path/to/rivet/rivet-cli/assets/wasm/
 npx @bytecodealliance/jco transpile --instantiation async \
   rivet-cli/assets/wasm/spar_wasm.wasm -o rivet-cli/assets/wasm/js/
 ```
 
-Or use the build script which handles both compilation and transpilation:
+### Downloading from GitHub releases
 
-```bash
-./scripts/build-wasm.sh /path/to/spar
-```
+`./scripts/fetch-wasm.sh` is intended to download a prebuilt component from the
+`pulseengine/spar` releases — **but spar does not publish a WASM asset yet**
+(pulseengine/spar#259), so this currently fails. It will work once that asset is
+published; the script will then be updated to fetch the browser bundle.

--- a/rivet-cli/src/serve/js.rs
+++ b/rivet-cli/src/serve/js.rs
@@ -718,7 +718,7 @@ async function checkWasmAvailable(){
 
 async function getSparRenderer(aadlFiles){
   if(!wasmAvailable){
-    throw new Error('AADL WASM renderer not available (run ./scripts/build-wasm.sh and rebuild)');
+    throw new Error('AADL WASM renderer is not bundled in this build (see rivet-cli/assets/wasm/README.md; tracking: pulseengine/rivet#468)');
   }
   if(!wasmModulePromise){
     wasmModulePromise = import('/wasm/spar_wasm.js');
@@ -748,7 +748,7 @@ async function initAadlDiagrams(){
     containers.forEach(function(c){
       c.setAttribute('data-loaded','true');
       var ld = c.querySelector('.aadl-loading');
-      if(ld) ld.textContent = 'AADL diagram requires spar WASM (run ./scripts/build-wasm.sh and rebuild)';
+      if(ld) ld.textContent = 'AADL diagram unavailable — the spar WASM renderer is not bundled in this build (tracking: pulseengine/rivet#468).';
     });
     return;
   }
@@ -1274,3 +1274,28 @@ document.body.addEventListener('htmx:afterSwap', initMatrixDrilldown);
 document.addEventListener('DOMContentLoaded', initMatrixDrilldown);
 </script>
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The AADL WASM-unavailable fallback messages must not point users at the
+    /// broken/unsupported `build-wasm.sh` (it needs a local spar checkout +
+    /// toolchain). They must give an honest "not bundled in this build" status
+    /// with the tracking issue. REQ-197 / #468.
+    #[test]
+    fn aadl_wasm_fallback_messages_are_honest() {
+        assert!(
+            !AADL_JS.contains("build-wasm.sh and rebuild"),
+            "fallback must not instruct users to run the broken build-wasm.sh"
+        );
+        assert!(
+            AADL_JS.contains("not bundled in this build"),
+            "fallback must state the WASM is not bundled in this build"
+        );
+        assert!(
+            AADL_JS.contains("pulseengine/rivet#468"),
+            "fallback should reference the tracking issue"
+        );
+    }
+}


### PR DESCRIPTION
Refs #468.

## Friction (follow-on to the user-reported AADL bug)

When the spar WASM isn't bundled, rivet pointed users at tooling that **doesn't work for them** — the exact dead ends the #468 reporter hit:

- **serve dashboard fallback:** `AADL diagram requires spar WASM (run ./scripts/build-wasm.sh and rebuild)` — but `build-wasm.sh` needs a local `spar` checkout + `wasm32-wasip2` + Node/`jco`.
- **`rivet-cli/assets/wasm/README.md`:** advertised `./scripts/fetch-wasm.sh` under "Downloading from GitHub releases" — but spar publishes **no** WASM release asset (pulseengine/spar#259), so it always fails.

## Change (docs + messaging only, no behaviour change)

- The serve `AADL_JS` fallback messages now state the renderer is **"not bundled in this build"** and reference the tracking issue **#468**, instead of pointing at the broken script.
- The README honestly describes the current state: the stub fallback, `fetch-wasm.sh` being blocked on spar#259, and that building from source requires a local spar checkout + toolchain.

## Test

`serve::js::tests::aadl_wasm_fallback_messages_are_honest` — asserts the fallback no longer instructs running `build-wasm.sh`, states "not bundled in this build", and references the tracking issue.

## Verification

`cargo test -p rivet-cli --bin rivet serve::js::tests::aadl_wasm_fallback_messages_are_honest` (pass) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS. Implements + Verifies **REQ-197**.

This is interim guidance honesty; the real fix (spar publishes the WASM bundle → rivet bundles it) is tracked in #468 / spar#259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
