### PR TITLE
fix(mutate): rivet add emits valid YAML for multi-line/special-char fields (REQ-198)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6044,3 +6044,39 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-007
+
+  - id: REQ-198
+    type: requirement
+    title: "`rivet add` must emit valid YAML for multi-line/special-char fields (data-integrity bug)"
+    status: implemented
+    description: |
+      Verified data-corruption bug (current main): `rivet add --type requirement
+      --title T --description "Line one.<newline>Line two."` writes INVALID YAML
+      and breaks the whole artifacts file. `render_artifact_yaml`
+      (rivet-core/src/mutate.rs) was a naive serializer:
+        - `description: >` folded scalar with only the FIRST line indented — a
+          newline put line 2 at column 0 → "could not find expected ':'" parse
+          error, so `rivet validate` then FAILs to load the file (2 errors).
+        - `title: {raw}` / tag / field values emitted unquoted — a colon (e.g.
+          "Multi word: with colon") also produced invalid YAML.
+      The `modify`/`set_field` path already serializes safely via
+      `yaml_edit::yaml_render_scalar_value`; only the `add` path diverged.
+
+      Fix: route `add`'s title/status/description/tags/field values through the
+      same `yaml_edit` safe emitters (`yaml_quote_inline_scalar` +
+      `yaml_render_scalar_value`), so newlines become block-literal `|` scalars
+      with correct indentation and special chars are quoted.
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib mutate::tests::render_artifact_yaml_multiline_and_colon_is_valid_parseable_yaml`
+          passes (rendered YAML parses; multi-line description round-trips).
+        - In a temp project, `rivet add --type requirement --title X
+          --description $'a\nb'` then `rivet validate` → PASS (was FAIL).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [mutate, add, yaml, data-integrity, serialization, bugfix, agent-ux]
+    fields:
+      priority: must
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-031

--- a/rivet-core/src/mutate.rs
+++ b/rivet-core/src/mutate.rs
@@ -492,20 +492,35 @@ pub fn append_artifact_to_file(artifact: &Artifact, file_path: &Path) -> Result<
 fn render_artifact_yaml(artifact: &Artifact) -> String {
     let mut lines = Vec::new();
 
+    use crate::yaml_edit::{yaml_quote_inline_scalar, yaml_render_scalar_value};
+
     lines.push(format!("  - id: {}", artifact.id));
     lines.push(format!("    type: {}", artifact.artifact_type));
-    lines.push(format!("    title: {}", artifact.title));
+    // Values are YAML-safe-quoted (colons, leading specials, etc.) and
+    // multi-line values become block-literal scalars — reusing the same emitter
+    // the modify/set path uses, so `add` never writes invalid YAML.
+    lines.push(format!(
+        "    title: {}",
+        yaml_quote_inline_scalar(&artifact.title)
+    ));
 
     if let Some(ref status) = artifact.status {
-        lines.push(format!("    status: {status}"));
+        lines.push(format!("    status: {}", yaml_quote_inline_scalar(status)));
     }
 
     if let Some(ref desc) = artifact.description {
-        lines.push(format!("    description: >\n      {desc}"));
+        lines.push(format!(
+            "    description: {}",
+            yaml_render_scalar_value(desc, 4)
+        ));
     }
 
     if !artifact.tags.is_empty() {
-        let tag_list: Vec<String> = artifact.tags.clone();
+        let tag_list: Vec<String> = artifact
+            .tags
+            .iter()
+            .map(|t| yaml_quote_inline_scalar(t))
+            .collect();
         lines.push(format!("    tags: [{}]", tag_list.join(", ")));
     }
 
@@ -521,7 +536,10 @@ fn render_artifact_yaml(artifact: &Artifact) -> String {
                     .trim()
                     .to_string(),
             };
-            lines.push(format!("      {key}: {val_str}"));
+            lines.push(format!(
+                "      {key}: {}",
+                yaml_render_scalar_value(&val_str, 6)
+            ));
         }
     }
 
@@ -880,5 +898,31 @@ mod tests {
         assert!(yaml.contains("tags: [core, test]"));
         assert!(yaml.contains("- type: satisfies"));
         assert!(yaml.contains("target: REQ-001"));
+    }
+
+    #[test]
+    fn render_artifact_yaml_multiline_and_colon_is_valid_parseable_yaml() {
+        // Regression: a newline in the description emitted a folded `>` scalar
+        // whose continuation lines were unindented (column 0), and a colon in
+        // the title was left unquoted — both produced INVALID YAML that broke
+        // the whole artifacts file on the next load. (REQ-198 / mutate add path)
+        let mut artifact = artifact_with_links("REQ-099", "requirement", &[]);
+        artifact.title = "Multi word: with colon".to_string();
+        artifact.description = Some("Line one.\nLine two with \"quotes\".".to_string());
+        artifact.status = Some("draft".to_string());
+        artifact.tags = vec!["core".to_string()];
+
+        let body = render_artifact_yaml(&artifact);
+        // Must parse as a real artifacts document (the bug failed here).
+        let doc = format!("schema: dev\nartifacts:\n{body}");
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&doc).expect("rendered artifact YAML must parse");
+        let art = &parsed["artifacts"][0];
+        assert_eq!(art["title"].as_str(), Some("Multi word: with colon"));
+        assert_eq!(
+            art["description"].as_str(),
+            Some("Line one.\nLine two with \"quotes\"."),
+            "multi-line description must round-trip exactly"
+        );
     }
 }

--- a/rivet-core/src/yaml_edit.rs
+++ b/rivet-core/src/yaml_edit.rs
@@ -638,7 +638,7 @@ fn yaml_plain_scalar_needs_quoting(s: &str) -> bool {
 /// (e.g. `title: <value>`). Never produces a block scalar; multi-line input
 /// is double-quoted with `\n` escapes. Callers that want block scalars for
 /// multi-line text should use [`yaml_render_scalar_value`] instead.
-fn yaml_quote_inline_scalar(s: &str) -> String {
+pub(crate) fn yaml_quote_inline_scalar(s: &str) -> String {
     if yaml_plain_scalar_needs_quoting(s) || s.contains('\n') {
         yaml_double_quote(s)
     } else {
@@ -677,7 +677,7 @@ fn yaml_double_quote(s: &str) -> String {
 /// The returned string begins with the value — for multi-line it starts with
 /// `|\n<indented content>`; for single-line it is the value or its quoted
 /// form. The caller is expected to concatenate `"{key}: "` + result.
-fn yaml_render_scalar_value(s: &str, field_indent: usize) -> String {
+pub(crate) fn yaml_render_scalar_value(s: &str, field_indent: usize) -> String {
     if !s.contains('\n') {
         return yaml_quote_inline_scalar(s);
     }


### PR DESCRIPTION
## Data-corruption bug (found dogfooding, verified on current main)

`rivet add` with a newline in the description writes **invalid YAML and breaks the whole artifacts file**:

```
$ rivet add --type requirement --title "Plain: with colon" --description $'Line one.\nLine two.'
$ rivet validate
WARN  skipping requirements.yaml: YAML parse error: could not find expected ':' ...
Result: FAIL (2 errors)
```

The file it wrote:

```yaml
    title: Plain: with colon          # unquoted colon → ambiguous
    description: >
      Line one.
Line two.                             # ← column 0, breaks the folded scalar
```

## Root cause

`render_artifact_yaml` (`rivet-core/src/mutate.rs`) — the `add` path — was a naive serializer:
- `description: >` folded scalar indented only the **first** line, so a newline dropped line 2 to column 0;
- `title:` / tag / field values were emitted **unquoted**, so a colon also produced invalid YAML.

The `modify`/`set_field` path already serializes safely via `yaml_edit` (it has `test_set_field_writes_multiline_description_as_block_scalar`) — only the `add` path diverged.

## Fix

Route `add`'s `title` / `status` / `description` / `tags` / field values through the **same** emitters the set path uses (`yaml_quote_inline_scalar` + `yaml_render_scalar_value`, now `pub(crate)`): newlines become block-literal `|` scalars with correct indentation, special chars are quoted.

```yaml
    title: "Plain: with colon"
    description: |-
      Line one.
      Line two.
```
→ `rivet validate` PASS, and the multi-line description round-trips exactly.

## Test

`render_artifact_yaml_multiline_and_colon_is_valid_parseable_yaml` — renders an artifact with a multi-line description + colon title and asserts the YAML **parses** and round-trips.

## Verification

`cargo test -p rivet-core --lib mutate::tests` (17/17, incl. the existing `test_render_artifact_yaml`) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS · manually reproduced the original failure → now PASS. Implements + Verifies **REQ-198**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
