### PR TITLE
fix(mutate): serialize nested (list/map) field values as structures, not strings (REQ-199)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6080,3 +6080,34 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-031
+
+  - id: REQ-199
+    type: requirement
+    title: "`rivet add`/batch/MCP serialize nested (list/map) field values as structures, not block-scalar strings"
+    status: implemented
+    description: |
+      Follow-on to REQ-198 (found while verifying its comprehensiveness): in
+      `render_artifact_yaml` (rivet-core/src/mutate.rs), a non-scalar field value
+      (a sequence or mapping — reachable via `rivet batch` or the MCP add tool,
+      where field values aren't restricted to CLI `--field key=value` strings)
+      hit the `other =>` arm, which `serde_yaml::to_string`-ed the structure
+      (multi-line) and then — after REQ-198 — wrapped it in
+      `yaml_render_scalar_value`, collapsing the list/map into a block-literal
+      STRING (`owners: |-\n  - alice\n  - bob`). Pre-REQ-198 it was instead
+      INVALID YAML (unindented continuation); neither preserved the structure.
+
+      Fix: emit nested field values as properly-indented YAML under the key
+      (serde produces valid YAML; shift it right by the field-content indent), so
+      a list field round-trips as a list and a map as a map.
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib mutate::tests::render_artifact_yaml_nested_field_value_stays_structured`
+          passes (a sequence field round-trips as a sequence, not a string).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [mutate, add, batch, mcp, yaml, data-integrity, serialization, bugfix]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-198

--- a/rivet-core/src/mutate.rs
+++ b/rivet-core/src/mutate.rs
@@ -527,19 +527,27 @@ fn render_artifact_yaml(artifact: &Artifact) -> String {
     if !artifact.fields.is_empty() {
         lines.push("    fields:".to_string());
         for (key, value) in &artifact.fields {
-            let val_str = match value {
-                serde_yaml::Value::String(s) => s.clone(),
-                serde_yaml::Value::Number(n) => n.to_string(),
-                serde_yaml::Value::Bool(b) => b.to_string(),
-                other => serde_yaml::to_string(other)
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string(),
-            };
-            lines.push(format!(
-                "      {key}: {}",
-                yaml_render_scalar_value(&val_str, 6)
-            ));
+            match value {
+                serde_yaml::Value::String(s) => {
+                    lines.push(format!("      {key}: {}", yaml_render_scalar_value(s, 6)));
+                }
+                serde_yaml::Value::Number(n) => lines.push(format!("      {key}: {n}")),
+                serde_yaml::Value::Bool(b) => lines.push(format!("      {key}: {b}")),
+                // Nested sequence/mapping: emit as properly-indented YAML under
+                // the key (serde produces valid YAML; we just shift it right),
+                // not as a block-scalar string — so a list field stays a list.
+                other => {
+                    lines.push(format!("      {key}:"));
+                    let nested = serde_yaml::to_string(other).unwrap_or_default();
+                    for nl in nested.lines() {
+                        if nl.is_empty() {
+                            lines.push(String::new());
+                        } else {
+                            lines.push(format!("        {nl}"));
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -924,5 +932,33 @@ mod tests {
             Some("Line one.\nLine two with \"quotes\"."),
             "multi-line description must round-trip exactly"
         );
+    }
+
+    #[test]
+    fn render_artifact_yaml_nested_field_value_stays_structured() {
+        // A list/map field value (reachable via batch/MCP) must serialize as an
+        // indented nested structure, not collapse into a block-literal string.
+        // (REQ-199)
+        let mut artifact = artifact_with_links("REQ-099", "requirement", &[]);
+        artifact.title = "T".to_string();
+        artifact.fields.insert(
+            "owners".to_string(),
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("alice".to_string()),
+                serde_yaml::Value::String("bob".to_string()),
+            ]),
+        );
+
+        let body = render_artifact_yaml(&artifact);
+        let doc = format!("schema: dev\nartifacts:\n{body}");
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&doc).expect("rendered artifact YAML must parse");
+        let owners = &parsed["artifacts"][0]["fields"]["owners"];
+        assert!(
+            owners.is_sequence(),
+            "a list field must stay a sequence, got: {owners:?}"
+        );
+        assert_eq!(owners[0].as_str(), Some("alice"));
+        assert_eq!(owners[1].as_str(), Some("bob"));
     }
 }


### PR DESCRIPTION
Follow-on to #471 (REQ-198), found while verifying that fix's comprehensiveness.

## Residual gap

In `render_artifact_yaml` (`rivet-core/src/mutate.rs`), a **non-scalar** field value (a sequence/mapping — reachable via `rivet batch` or the MCP `add` tool, where field values aren't limited to CLI `--field key=value` strings) hit the `other =>` arm, which serde-serialized the structure (multi-line) and then — after REQ-198 — wrapped it in `yaml_render_scalar_value`, **collapsing a list/map into a block-literal string**:

```yaml
      owners: |-
        - alice
        - bob          # owners is now the STRING "- alice\n- bob", not a list
```

(Pre-REQ-198 the same input produced *invalid* YAML; neither preserved the structure.)

## Fix

Emit nested field values as properly-indented YAML under the key (serde produces valid YAML; we shift it right by the field-content indent), so a list field round-trips as a list and a map as a map. Scalar fields keep the REQ-198 safe-quoting path.

```yaml
      owners:
        - alice
        - bob
```

## Test

`render_artifact_yaml_nested_field_value_stays_structured` — asserts a sequence field round-trips as a sequence (`owners.is_sequence()`), not a string.

## Verification

`cargo test -p rivet-core --lib mutate::tests` (18/18, incl. the REQ-198 multi-line test) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS. Implements + Verifies **REQ-199**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)