### PR TITLE
fix(export): honest AADL fallback in the REAL html export path (REQ-200, #468)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6111,3 +6111,42 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-198
+
+  - id: REQ-200
+    type: requirement
+    title: "`rivet export --format html` shows honest AADL fallback (REQ-196 patched the wrong path — bug still live)"
+    status: implemented
+    description: |
+      Verified by dogfooding the real export (build + `rivet export --format
+      html` + scan): the multi-page HTML export STILL ships the perpetual
+      `<p class="aadl-loading">Loading AADL diagram...</p>` placeholder in 2 of
+      987 pages — `documents/ARCH-001.html` (the exact #468 page) and
+      `artifacts/ARCH-SYS-001.html` (an aadl-component artifact). Neither has the
+      honest fallback.
+
+      Root cause: REQ-196 patched `static_aadl_fallback` inside
+      `rivet_core::export::render_document_body_for_export`, but `rivet export
+      --format html` is implemented by `cmd_export_html` (rivet-cli), which
+      renders pages via the rivet-cli `render/` serve renderers and wraps them in
+      a `wrap_page` layout — it never calls the rivet-core function REQ-196
+      fixed. So REQ-196 was effectively a no-op for the real export (and the
+      published compliance report), even though it was marked implemented (on a
+      unit test of the helper, not an e2e export check).
+
+      Fix: apply the same placeholder→honest-note replacement in `wrap_page`, the
+      universal per-page wrapper in `cmd_export_html`, so every exported page is
+      covered.
+
+      Acceptance:
+        - `rivet export --format html` produces ZERO pages containing
+          `<p class="aadl-loading">Loading AADL diagram...</p>`.
+        - The honest "rivet serve dashboard" note appears on pages that had an
+          AADL diagram.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [export, html, aadl, compliance-report, user-reported, bugfix, regression]
+    fields:
+      priority: must
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-196

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -8995,6 +8995,18 @@ fn cmd_export_html(
         .count();
 
     let wrap_page = |title: &str, content: &str, rel_path: &str| -> String {
+        // A static export has no `rivet serve` JS to fill the `.aadl-diagram`
+        // placeholder, so the perpetual "Loading AADL diagram..." reads as a
+        // hung page in compliance reports (#468). Replace it with an honest
+        // note. (REQ-196 patched rivet-core's render_document_page, which this
+        // multi-page exporter does not use — so it never reached the real
+        // output; REQ-200 fixes it here, the universal per-page wrapper.)
+        let content = content.replace(
+            "<p class=\"aadl-loading\">Loading AADL diagram...</p>",
+            "<p class=\"aadl-loading\">AADL architecture diagram — interactive \
+             rendering is available in the <code>rivet serve</code> dashboard.</p>",
+        );
+        let content = content.as_str();
         // REQ-088: depth-adjusted prefix so per-page asset and nav hrefs
         // work for pages at any nesting (root, depth-1, depth-2, …).
         // `rel_path` is the page's path relative to `out_dir`, e.g.

--- a/rivet-cli/tests/export_html.rs
+++ b/rivet-cli/tests/export_html.rs
@@ -160,3 +160,38 @@ fn export_html_filter_narrows_per_artifact_pages() {
          got {filtered_count} pages"
     );
 }
+
+/// #468 / REQ-200: a static export has no JS to fill the `.aadl-diagram`
+/// placeholder, so it must not ship the perpetual "Loading AADL diagram..."
+/// across ANY page. (REQ-196 patched a rivet-core fn the multi-page exporter
+/// never calls, so the bug stayed live until fixed in `wrap_page`.)
+#[test]
+fn export_html_replaces_perpetual_aadl_loading_placeholder() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("dist");
+    run_export(&out, None);
+    let needle = "<p class=\"aadl-loading\">Loading AADL diagram...</p>";
+    let mut offenders: Vec<std::path::PathBuf> = Vec::new();
+    let mut stack = vec![out.clone()];
+    while let Some(d) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for e in rd.filter_map(Result::ok) {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().and_then(|s| s.to_str()) == Some("html")
+                && std::fs::read_to_string(&p)
+                    .unwrap_or_default()
+                    .contains(needle)
+            {
+                offenders.push(p.strip_prefix(&out).unwrap_or(&p).to_path_buf());
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "static export still ships the perpetual AADL placeholder in: {offenders:?}"
+    );
+}


### PR DESCRIPTION
Refs #468. Fixes a regression that **REQ-196 (#469) silently missed.**

## What I found (dogfooding the real export)

Building the current binary and running the actual `rivet export --format html` (then scanning all 988 pages) showed the perpetual `<p class="aadl-loading">Loading AADL diagram...</p>` placeholder **still shipping** in 2 pages — `documents/ARCH-001.html` (the exact page from #468) and `artifacts/ARCH-SYS-001.html` — with no honest fallback.

## Root cause: REQ-196 patched the wrong function

REQ-196 added `static_aadl_fallback` inside `rivet_core::export::render_document_body_for_export`. But `rivet export --format html` is implemented by **`cmd_export_html` in rivet-cli**, which renders pages via the rivet-cli `render/` serve renderers and wraps them in a `wrap_page` layout — it **never calls** the rivet-core function REQ-196 patched. So REQ-196 was effectively a **no-op for the real export** (and the published compliance report) — yet it was marked implemented on a *unit test of the helper*, not an end-to-end export check. (Lesson logged: verify acceptance against real output, not a helper unit test.)

## Fix

Apply the placeholder → honest-note replacement in `wrap_page`, the **universal per-page wrapper** in `cmd_export_html`, so every exported page is covered regardless of which renderer produced it.

```
before:  raw "Loading AADL diagram..." pages: 2, honest-fallback pages: 0
after:   raw "Loading AADL diagram..." pages: 0, honest-fallback pages: present
```

## Test

`export_html_replaces_perpetual_aadl_loading_placeholder` walks the **full** export output and asserts zero pages contain the raw placeholder — an *end-to-end* assertion (the gap that let REQ-196 slip through).

## Verification

`cargo test -p rivet-cli --test export_html …` (pass) · `fmt --check` clean · `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS. Manually confirmed the real export now has 0 raw placeholders. Implements + Verifies **REQ-200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
