### PR TITLE
fix(export): node-budget the single-page graph render so it can't hang (REQ-201)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6150,3 +6150,36 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-196
+
+  - id: REQ-201
+    type: requirement
+    title: "`rivet export --format html --single-page` must not hang on real-sized projects (node-budget the graph render)"
+    status: implemented
+    description: |
+      Verified hang: on the rivet repo (~900 artifacts), `rivet export --format
+      html --single-page` runs for minutes producing nothing (multi-page export
+      finishes in ~6s). Root cause: `render_section_graph`
+      (rivet-core/src/export.rs) lays out the ENTIRE link graph eagerly via
+      `etch::layout::layout(pg, ...)` with NO node budget; etch's layout is
+      super-linear, so ~900 nodes makes the single-page export hang. The serve
+      path already guards this (`rivet-cli/src/render/graph.rs`
+      `DEFAULT_NODE_BUDGET = 200`, with a "Graph above node budget" page) — the
+      static export did not.
+
+      Fix: in `render_section_graph`, if `node_count > 200`, skip the layout and
+      emit a short note ("Graph has N nodes, exceeding the static-render budget —
+      view it interactively in `rivet serve`"), mirroring the serve guard.
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib export::tests::render_section_graph_over_budget_skips_layout`
+          passes (a graph with >200 nodes returns the budget note, not a layout).
+        - `rivet export --format html --single-page` on the rivet repo completes
+          in seconds (was: minutes / hang).
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [export, html, single-page, graph, performance, hang, bugfix]
+    fields:
+      priority: must
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-007

--- a/rivet-core/src/export.rs
+++ b/rivet-core/src/export.rs
@@ -1842,6 +1842,24 @@ fn render_section_graph(store: &Store, link_graph: &LinkGraph) -> String {
     )
     .unwrap();
 
+    // A static export lays the whole graph out eagerly, but etch's layout is
+    // super-linear — a real project (~900 nodes) makes `rivet export --format
+    // html --single-page` HANG. Mirror the serve path's node budget
+    // (render/graph.rs `DEFAULT_NODE_BUDGET`): above it, skip the layout and
+    // show a note instead of hanging. (REQ-201)
+    const GRAPH_RENDER_BUDGET: usize = 200;
+    if pg.node_count() > GRAPH_RENDER_BUDGET {
+        writeln!(
+            out,
+            "<p class=\"graph-too-large\">Graph has {} nodes, exceeding the \
+             {GRAPH_RENDER_BUDGET}-node static-render budget — view it \
+             interactively in the <code>rivet serve</code> dashboard.</p>",
+            pg.node_count(),
+        )
+        .unwrap();
+        return out;
+    }
+
     let colors = export_type_color_map();
     let svg_opts = SvgOptions {
         type_colors: colors.clone(),
@@ -3083,6 +3101,31 @@ mod tests {
         let graph = LinkGraph::build(&store, &schema);
         let diagnostics = crate::validate::validate(&store, &schema, &graph);
         (store, schema, graph, diagnostics)
+    }
+
+    #[test]
+    fn render_section_graph_over_budget_skips_layout() {
+        // REQ-201: a graph above the node budget must NOT be laid out (etch's
+        // layout is super-linear and hangs the single-page export on real
+        // projects); render a budget note instead.
+        let schema = test_schema();
+        let mut store = Store::new();
+        for i in 0..250 {
+            store
+                .insert(make_artifact(&format!("REQ-{i:03}"), "requirement", &[]))
+                .unwrap();
+        }
+        let graph = LinkGraph::build(&store, &schema);
+        let html = render_section_graph(&store, &graph);
+        assert!(
+            html.contains("exceeding the 200-node"),
+            "must show the budget note for a >200-node graph; got: {}",
+            &html[..html.len().min(400)]
+        );
+        assert!(
+            !html.contains("<svg"),
+            "must NOT emit a laid-out SVG above the budget (that's the hang)"
+        );
     }
 
     fn default_config() -> ExportConfig {


### PR DESCRIPTION
Refs #468-adjacent (same dogfooding sweep). Companion to **REQ-200 (#473)**.

## What I found (dogfooding the real export)

On the rivet repo itself (~900 artifacts), `rivet export --format html --single-page` runs for **minutes producing nothing** (effectively a hang), while the multi-page export of the same project finishes in ~6s.

## Root cause

`render_section_graph` (`rivet-core/src/export.rs`) lays out the **entire** link graph eagerly via `etch::layout::layout(pg, …)` with **no node budget**. etch's layout is super-linear, so ~900 nodes effectively hangs the single-page path.

The **serve** path already guards exactly this: `rivet-cli/src/render/graph.rs` caps at `DEFAULT_NODE_BUDGET = 200` and renders a "Graph above node budget" page instead of laying out an oversized graph. The static export simply never got the same guard.

## Fix

In `render_section_graph`, if `node_count > 200`, skip the layout and emit a short note —

> Graph has N nodes, exceeding the 200-node static-render budget — view it interactively in the `rivet serve` dashboard.

— mirroring the serve guard. Small graphs render an SVG exactly as before.

```
before:  single-page export on rivet repo → minutes / no output
after:   single-page export on rivet repo → ~3s, budget note present
```

## Test

`export::tests::render_section_graph_over_budget_skips_layout` builds a 250-node graph and asserts the output contains the budget note and **no** `<svg>` (the layout that hangs).

## Verification

`cargo test -p rivet-core --lib export::tests::render_section_graph_over_budget_skips_layout` (pass) · `cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS. Manually confirmed `rivet export --format html --single-page` on the rivet repo now completes in ~3s (was minutes/hang). Implements + Verifies **REQ-201**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)