### PR TITLE
feat(add): rivet add stamps AI provenance at creation (REQ-203, closes #476)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6150,3 +6150,53 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-196
+  - id: REQ-203
+    type: requirement
+    title: "`rivet add` must stamp AI provenance at creation (--created-by/--model + RIVET_PROVENANCE_CREATED_BY), and the add-path serializer must emit the provenance block"
+    status: implemented
+    description: |
+      Finding (issue #476, AI-agent dogfooding). The AI-provenance system was
+      wired to the editor, not to rivet's mutation commands, so the SANCTIONED
+      creation path produced UNSTAMPED artifacts: `cmd_add`
+      (rivet-cli/src/main.rs) built the `Artifact` with `provenance: None`, and
+      the `.claude/settings.json` stamp hook only matches Edit/Write — a heredoc
+      append or `rivet add` (both Bash calls) never fired it. For a tool whose
+      pitch is AI-artifact auditability, AI-created artifacts silently missing
+      provenance is a correctness gap.
+
+      Compounding (caught during implementation): `mutate::render_artifact_yaml`
+      — the single serializer for the add path — did NOT emit the `provenance`
+      block at all, so merely setting `artifact.provenance` would have been a
+      silent no-op (the REQ-196/200 class of bug). Both halves are required.
+
+      Fix:
+        - Add `--created-by <human|ai|ai-assisted>` and `--model <M>` to
+          `rivet add`; `--created-by` falls back to the
+          `RIVET_PROVENANCE_CREATED_BY` env var so CI/agent environments can set
+          it once. Value validated up front (before project load). When absent,
+          no provenance block is written (prior behavior preserved).
+        - Extract `current_utc_timestamp()` (shared by cmd_stamp and cmd_add) so
+          both surfaces emit identical ISO-8601 timestamps with no chrono dep.
+        - Teach `render_artifact_yaml` to emit the `provenance:` block (field
+          order matches yaml_edit::set_provenance: created-by, model, session-id,
+          timestamp, reviewed-by).
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib render_artifact_yaml_` passes
+          (emits-when-present + omits-when-absent).
+        - `rivet add -t requirement --title T --created-by ai-assisted --model M`
+          writes a `provenance:` block with created-by/model/timestamp; a plain
+          `rivet add` writes none; `RIVET_PROVENANCE_CREATED_BY=ai rivet add`
+          stamps from the env; `--created-by robot` errors.
+        - `rivet validate` PASS on the resulting project.
+    tags: [cli, provenance, ai-provenance, rivet-add, friction, dogfooding, bugfix]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-007
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-05T09:38:15Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1011,6 +1011,20 @@ enum Command {
         /// Target YAML file to append the artifact to
         #[arg(long)]
         file: Option<PathBuf>,
+
+        /// Stamp AI provenance at creation: origin of the artifact
+        /// ("human", "ai", or "ai-assisted"). When omitted, no provenance
+        /// block is written (matching prior behavior). Defaults its value
+        /// from the RIVET_PROVENANCE_CREATED_BY env var when the flag is
+        /// absent, so CI / agent environments can set it once.
+        #[arg(long)]
+        created_by: Option<String>,
+
+        /// AI model identifier to record in provenance (e.g.
+        /// "claude-opus-4-8"). Only used when --created-by is set (or
+        /// defaulted from the environment).
+        #[arg(long)]
+        model: Option<String>,
     },
 
     /// Add a link between two artifacts
@@ -2457,6 +2471,8 @@ fn run(cli: Cli) -> Result<bool> {
             fields,
             links,
             file,
+            created_by,
+            model,
         } => cmd_add(
             &cli,
             r#type,
@@ -2467,6 +2483,8 @@ fn run(cli: Cli) -> Result<bool> {
             fields,
             links,
             file.as_deref(),
+            created_by.as_deref(),
+            model.as_deref(),
         ),
         Command::Link {
             source,
@@ -14344,10 +14362,37 @@ fn cmd_add(
     fields: &[(String, String)],
     links: &[(String, String)],
     file: Option<&std::path::Path>,
+    created_by: Option<&str>,
+    model: Option<&str>,
 ) -> Result<bool> {
-    use rivet_core::model::{Artifact, Link};
+    use rivet_core::model::{Artifact, Link, Provenance};
     use rivet_core::mutate;
     use std::collections::BTreeMap;
+
+    // Provenance stamping at creation (issue #476). `--created-by` falls back
+    // to the RIVET_PROVENANCE_CREATED_BY env var so CI / agent environments can
+    // set it once. When neither is present, no provenance block is written
+    // (prior behavior preserved). Validate the value up front, before any work.
+    let created_by_owned = created_by
+        .map(str::to_string)
+        .or_else(|| std::env::var("RIVET_PROVENANCE_CREATED_BY").ok())
+        .filter(|s| !s.is_empty());
+    if let Some(cb) = created_by_owned.as_deref() {
+        match cb {
+            "human" | "ai" | "ai-assisted" => {}
+            other => anyhow::bail!(
+                "invalid --created-by value '{other}'. Must be one of: human, ai, ai-assisted"
+            ),
+        }
+    }
+    let provenance = created_by_owned.map(|cb| Provenance {
+        created_by: cb,
+        model: model.map(str::to_string),
+        session_id: None,
+        timestamp: Some(current_utc_timestamp()),
+        reviewed_by: None,
+        federation: None,
+    });
 
     let ctx = ProjectContext::load(cli)?;
     let (store, schema) = (ctx.store, ctx.schema);
@@ -14384,7 +14429,7 @@ fn cmd_add(
         links: link_vec,
         fields: fields_map,
         fields_per_variant: Default::default(),
-        provenance: None,
+        provenance,
         source_file: None,
     };
 
@@ -14693,6 +14738,35 @@ fn files_changed_since(project: &std::path::Path, git_ref: &str) -> Result<Vec<S
     Ok(paths)
 }
 
+/// Current UTC time as an ISO 8601 `YYYY-MM-DDTHH:MM:SSZ` string, computed
+/// with std only (no chrono dependency). Shared by `cmd_stamp` and
+/// `cmd_add`'s provenance stamping so the two surfaces emit identical
+/// timestamps.
+fn current_utc_timestamp() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    let secs = now.as_secs();
+    // Convert to UTC date-time components
+    let days = secs / 86400;
+    let day_secs = secs % 86400;
+    let hours = day_secs / 3600;
+    let minutes = (day_secs % 3600) / 60;
+    let seconds = day_secs % 60;
+    // Civil date from days since epoch (algorithm from Howard Hinnant)
+    let z = days as i64 + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
 #[allow(clippy::too_many_arguments)]
 fn cmd_stamp(
     cli: &Cli,
@@ -14718,29 +14792,7 @@ fn cmd_stamp(
     let ctx = ProjectContext::load(cli)?;
     let store = ctx.store;
 
-    // Generate ISO 8601 timestamp using std (no chrono dependency)
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap();
-    let secs = now.as_secs();
-    // Convert to UTC date-time components
-    let days = secs / 86400;
-    let day_secs = secs % 86400;
-    let hours = day_secs / 3600;
-    let minutes = (day_secs % 3600) / 60;
-    let seconds = day_secs % 60;
-    // Civil date from days since epoch (algorithm from Howard Hinnant)
-    let z = days as i64 + 719468;
-    let era = if z >= 0 { z } else { z - 146096 } / 146097;
-    let doe = (z - era * 146097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    let timestamp = format!("{y:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}Z");
+    let timestamp = current_utc_timestamp();
 
     // Collect artifact IDs to stamp.
     // Filter pipeline (applied in order, each shrinks the candidate set):

--- a/rivet-core/src/mutate.rs
+++ b/rivet-core/src/mutate.rs
@@ -559,6 +559,28 @@ fn render_artifact_yaml(artifact: &Artifact) -> String {
         }
     }
 
+    // Provenance (issue #476): when `rivet add --created-by` stamps an
+    // artifact at creation, emit the block here — otherwise the field would be
+    // silently dropped on write (the serializer is the single source of truth
+    // for `add` output). Field order matches yaml_edit::set_provenance so the
+    // add-path and stamp-path produce identical blocks.
+    if let Some(ref prov) = artifact.provenance {
+        lines.push("    provenance:".to_string());
+        lines.push(format!("      created-by: {}", prov.created_by));
+        if let Some(ref m) = prov.model {
+            lines.push(format!("      model: {m}"));
+        }
+        if let Some(ref sid) = prov.session_id {
+            lines.push(format!("      session-id: {sid}"));
+        }
+        if let Some(ref ts) = prov.timestamp {
+            lines.push(format!("      timestamp: {ts}"));
+        }
+        if let Some(ref rb) = prov.reviewed_by {
+            lines.push(format!("      reviewed-by: {rb}"));
+        }
+    }
+
     lines.join("\n") + "\n"
 }
 
@@ -960,5 +982,49 @@ mod tests {
         );
         assert_eq!(owners[0].as_str(), Some("alice"));
         assert_eq!(owners[1].as_str(), Some("bob"));
+    }
+
+    #[test]
+    fn render_artifact_yaml_emits_provenance_when_present() {
+        // Issue #476: `rivet add --created-by` stamps provenance at creation;
+        // the serializer must emit it (else the field is silently dropped on
+        // write — the REQ-196/200 class of no-op). Verify the block round-trips
+        // with the canonical kebab-case keys.
+        use crate::model::Provenance;
+        let mut artifact = artifact_with_links("REQ-099", "requirement", &[]);
+        artifact.title = "T".to_string();
+        artifact.provenance = Some(Provenance {
+            created_by: "ai-assisted".to_string(),
+            model: Some("claude-opus-4-8".to_string()),
+            session_id: None,
+            timestamp: Some("2026-06-05T00:00:00Z".to_string()),
+            reviewed_by: None,
+            federation: None,
+        });
+
+        let body = render_artifact_yaml(&artifact);
+        let doc = format!("schema: dev\nartifacts:\n{body}");
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&doc).expect("rendered artifact YAML must parse");
+        let prov = &parsed["artifacts"][0]["provenance"];
+        assert_eq!(prov["created-by"].as_str(), Some("ai-assisted"));
+        assert_eq!(prov["model"].as_str(), Some("claude-opus-4-8"));
+        assert_eq!(prov["timestamp"].as_str(), Some("2026-06-05T00:00:00Z"));
+        // Omitted optional fields must not appear at all.
+        assert!(prov.get("session-id").is_none());
+        assert!(prov.get("reviewed-by").is_none());
+    }
+
+    #[test]
+    fn render_artifact_yaml_omits_provenance_when_absent() {
+        // Default behavior preserved: no provenance block when none is set.
+        let mut artifact = artifact_with_links("REQ-099", "requirement", &[]);
+        artifact.title = "T".to_string();
+        artifact.provenance = None;
+        let body = render_artifact_yaml(&artifact);
+        assert!(
+            !body.contains("provenance:"),
+            "unstamped add must not emit a provenance block, got:\n{body}"
+        );
     }
 }


### PR DESCRIPTION
Closes #476. From the hourly dogfooding loop — a friction I hit filing REQ-202, then traced to a correctness gap.

## The gap

The AI-provenance system was wired to the **editor**, not to rivet's own mutation commands, so the **sanctioned** creation path produced **unstamped** artifacts:

| Path | Stamped? |
|------|----------|
| `Edit`/`Write` tool on `artifacts/**` (fires the `.claude/settings.json` hook) | ✅ |
| `cat >>` / heredoc append (a `Bash` call) | ❌ |
| **`rivet add`** (`cmd_add` built the `Artifact` with `provenance: None`) | ❌ |

For a tool whose pitch is AI-artifact auditability, AI-created artifacts silently missing provenance is a correctness gap — and the *recommended* tool was the one that dropped it.

## Compounding bug caught while implementing

`mutate::render_artifact_yaml` — the single serializer for the `add` path — **did not emit the `provenance` block at all**. So just setting `artifact.provenance = Some(..)` would have been a **silent no-op** (the exact REQ-196/REQ-200 class of bug). I verified against the *written file*, not the struct, and fixed both halves.

## Fix

- `rivet add` gains `--created-by <human|ai|ai-assisted>` and `--model <M>`; `--created-by` falls back to the `RIVET_PROVENANCE_CREATED_BY` env var so CI/agent environments set it once. Value validated up front (before project load). Absent ⇒ no block (prior behavior preserved).
- Extract `current_utc_timestamp()`, shared by `cmd_stamp` and `cmd_add`, so both emit identical ISO-8601 timestamps (no chrono dep).
- `render_artifact_yaml` now emits the `provenance:` block (field order matches `yaml_edit::set_provenance`).

## Verification

- Unit (rivet-core): `render_artifact_yaml_emits_provenance_when_present`, `render_artifact_yaml_omits_provenance_when_absent` — both pass.
- **End-to-end** on a fresh `rivet init` project: `rivet add --created-by ai-assisted --model claude-opus-4-8` wrote the block; plain `rivet add` wrote none; `RIVET_PROVENANCE_CREATED_BY=ai rivet add` stamped from env; `--created-by robot` errored; `rivet validate` PASS.
- `cargo fmt --all -- --check` exit 0 · `cargo clippy --all-targets -- -D warnings` exit 0 (only the pre-existing MSRV-config warning).

Implements + Verifies **REQ-203**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)