### PR TITLE
fix(serve,lsp): sort the 2 remaining nondeterministic store.iter() output sites (REQ-204, #415)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6150,3 +6150,46 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-196
+  - id: REQ-204
+    type: requirement
+    title: "Remaining nondeterministic store.iter() ordered-output sites must sort by id (serve /api/search, LSP id-completion)"
+    status: implemented
+    description: |
+      Follow-on audit of issue #415 (Store::iter() is HashMap-ordered). REQ-159
+      already added `Store::iter_sorted()` + the doc warning and migrated the
+      clear-cut sites (query.rs::execute, migrate_cmd, render/externals). This
+      audits the remaining `store.iter()` ordered-output candidates the reporter
+      flagged and fixes the two that genuinely regress:
+
+        1. serve `/api/search` (rivet-cli/src/main.rs): pushed artifact + doc
+           matches in HashMap order, then `results.truncate(50)`. So with >50
+           matches, WHICH 50 survive — not just their order — varied per process.
+           Fix: sort `results` by the `id` field before `truncate(50)`.
+        2. LSP id-completion (`lsp_completion`, the `[[`/`target:` branch):
+           pushed CompletionItems in HashMap order while the sibling `type:`
+           branch already sorted. Fix: extract `artifact_id_completions(store)`
+           that builds the list via `iter_sorted()` (ascending id), matching the
+           sibling branch.
+
+      Audited and confirmed already-safe (no change needed): query.rs::execute,
+      migrate_cmd.rs (iter_sorted), render/externals.rs (sorts), export filter
+      (sorts), serve tree/search-expand (BTreeMap / sort), validate & coverage
+      filter-rebuilds (set membership), HashSet id collects, aggregation loops.
+
+      Acceptance:
+        - `cargo test -p rivet-cli --bin rivet lsp_tests::artifact_id_completions_are_sorted_by_id`
+          passes (ids inserted out of order come back ascending).
+        - `rg "results.sort_by" rivet-cli/src/main.rs` shows the search results
+          sorted before `truncate(50)`.
+        - `rivet validate` PASS.
+    tags: [determinism, store, lsp, serve, search, bugfix, footgun, dogfooding]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-159
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-05T10:20:52Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -15919,6 +15919,11 @@ fn cmd_lsp(cli: &Cli) -> Result<bool> {
                                 }
                             }
 
+                            // Deterministic order before truncation: render_store
+                            // / doc_store iterate in HashMap order, so without a
+                            // sort *which* 50 results survive truncate(50) — not
+                            // just their order — would vary per process (#415).
+                            results.sort_by(|a, b| a["id"].as_str().cmp(&b["id"].as_str()));
                             results.truncate(50);
                         }
 
@@ -16369,6 +16374,24 @@ fn lsp_goto_definition(
     })
 }
 
+/// Build artifact-ID completion items in deterministic (ascending-id) order.
+///
+/// `Store::iter()` is HashMap-ordered, so completing over it directly yielded
+/// suggestions in a per-process-random order (the `type:` branch already
+/// sorted; the ID branch did not — #415). Using `iter_sorted()` makes the
+/// completion list stable and matches the sibling branch's behavior.
+fn artifact_id_completions(store: &Store) -> Vec<lsp_types::CompletionItem> {
+    store
+        .iter_sorted()
+        .map(|art| lsp_types::CompletionItem {
+            label: art.id.clone(),
+            kind: Some(lsp_types::CompletionItemKind::REFERENCE),
+            detail: Some(format!("{} ({})", art.title, art.artifact_type)),
+            ..Default::default()
+        })
+        .collect()
+}
+
 fn lsp_completion(
     params: &lsp_types::CompletionParams,
     store: &Store,
@@ -16385,15 +16408,8 @@ fn lsp_completion(
 
     if trimmed.starts_with("target:") || trimmed.starts_with("- target:") || trimmed.contains("[[")
     {
-        // Suggest artifact IDs
-        for art in store.iter() {
-            items.push(lsp_types::CompletionItem {
-                label: art.id.clone(),
-                kind: Some(lsp_types::CompletionItemKind::REFERENCE),
-                detail: Some(format!("{} ({})", art.title, art.artifact_type)),
-                ..Default::default()
-            });
-        }
+        // Suggest artifact IDs (sorted — see artifact_id_completions; #415).
+        items.extend(artifact_id_completions(store));
     } else if trimmed.starts_with("type:") || trimmed.starts_with("- type:") {
         // Suggest artifact types seen in the store
         let mut types: Vec<String> = store.types().map(|t| t.to_string()).collect();
@@ -16762,6 +16778,41 @@ mod stamp_glob_tests {
 #[cfg(test)]
 mod lsp_tests {
     use super::*;
+
+    // ── artifact_id_completions (deterministic ordering, #415) ─────────
+
+    #[test]
+    fn artifact_id_completions_are_sorted_by_id() {
+        // Insert ids out of order; the completion list must come back
+        // ascending regardless of HashMap iteration order (#415 footgun).
+        let mut store = Store::new();
+        for id in ["REQ-003", "REQ-001", "REQ-010", "REQ-002"] {
+            store
+                .insert(rivet_core::model::Artifact {
+                    id: id.into(),
+                    artifact_type: "requirement".into(),
+                    title: format!("title {id}"),
+                    description: None,
+                    status: None,
+                    tags: vec![],
+                    links: vec![],
+                    fields: std::collections::BTreeMap::new(),
+                    fields_per_variant: Default::default(),
+                    provenance: None,
+                    source_file: None,
+                })
+                .unwrap();
+        }
+        let labels: Vec<String> = artifact_id_completions(&store)
+            .into_iter()
+            .map(|c| c.label)
+            .collect();
+        assert_eq!(
+            labels,
+            vec!["REQ-001", "REQ-002", "REQ-003", "REQ-010"],
+            "id completions must be deterministically sorted by id"
+        );
+    }
 
     // ── lsp_word_at_position ───────────────────────────────────────────
 


### PR DESCRIPTION
Follow-on to **#415** from the hourly dogfooding loop. Completes the audit the reporter offered to do.

## State of #415

Fixes **1+2 are already shipped** under REQ-159: `Store::iter_sorted()` exists, `Store::iter()` carries the "order is unspecified" warning, and the clear-cut sites (`query.rs::execute`, `migrate_cmd`, `render::externals`) were migrated. This PR audits the **remaining** `store.iter()` ordered-output candidates the issue flagged and fixes the two that genuinely regress.

## Fixed

1. **serve `/api/search`** — artifact + doc matches were pushed in HashMap order, then `results.truncate(50)`. So with >50 matches, **which 50 survive** (not just their order) varied per process. Now sorts `results` by the `id` field before `truncate(50)`.
2. **LSP id-completion** (`lsp_completion`, the `[[` / `target:` branch) — pushed `CompletionItem`s in HashMap order, while the **sibling `type:` branch already sorted**. Extracted `artifact_id_completions(store)` built via `iter_sorted()` (ascending id), restoring consistency.

## Audited & confirmed already-safe (no change)

`query.rs::execute`, `migrate_cmd` (uses `iter_sorted`), `render/externals` (sorts), export filter (sorts before render), serve tree / search-expand (BTreeMap or explicit sort), validate & coverage filter-rebuilds (set-membership Store rebuilds — order-irrelevant), `HashSet<id>` collects, and aggregation loops.

## Test

`lsp_tests::artifact_id_completions_are_sorted_by_id` — ids inserted out of order come back ascending.

## Verification

`cargo test -p rivet-cli --bin rivet lsp_tests::artifact_id_completions_are_sorted_by_id` (pass) · `cargo fmt --all -- --check` (exit 0) · `cargo clippy --all-targets -- -D warnings` (exit 0) · `rivet validate` PASS. Implements + Verifies **REQ-204** (traces-to REQ-159).

🤖 Generated with [Claude Code](https://claude.com/claude-code)