### PR TITLE
ci: key main concurrency group per-sha so main runs stay conclusive (#436)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,8 +1,10 @@
 name: Benchmarks
 
-# Cancel superseded PR runs; protect main + scheduled runs.
+# Cancel superseded PR runs; keep every main commit's run conclusive.
+# On push the group falls back to `github.sha` (not `github.ref`) so a later
+# main push never supersedes an earlier main run (incl. queued ones) — #436.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
 name: CI
 
-# Cancel superseded PR runs; protect main + scheduled runs.
-# `head_ref || ref` keys per-PR-source-branch on PRs, falls back to ref on push.
+# Cancel superseded PR runs; keep every main commit's run conclusive.
+# On PRs, `head_ref` groups per source branch so cancel-in-progress supersedes
+# stale runs. On push, the fallback is `github.sha` (NOT `github.ref`): keying
+# every main commit to its own group means a later push never supersedes an
+# earlier main run — even queued ones (#436). With a shared `refs/heads/main`
+# group, rapid merges left main's runs `cancelled` and Playwright never reached
+# a conclusive result, hiding real regressions.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:


### PR DESCRIPTION
Closes the pure-hygiene half of #436.

## Root cause (verified)

#436 reported Playwright E2E red/cancelled across consecutive main merges with nobody noticing. The concurrency block *looked* correct (`cancel-in-progress` is false on push), yet `gh run list --branch=main` showed the last several main runs `cancelled`. Why?

```yaml
group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
```

On push, `head_ref` is empty, so every main commit shares **one** group: `<workflow>-refs/heads/main`. With `cancel-in-progress: false` the *running* job finishes, but GitHub still supersedes **queued** runs in the group. In a PR-merge train, each new main push cancels the previous *queued* main run — so main rarely reaches a conclusive Playwright/benchmark result. A genuine regression would look identical to the benign dataset-growth failures (#435).

## Fix

Fall back to `github.sha` (not `github.ref`) on push:

```yaml
group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
```

Every main commit now gets its own group and is never superseded. **PRs are unchanged** — `head_ref` still groups per source branch, so `cancel-in-progress` keeps superseding stale PR runs (the desired behavior). Applied to both workflows that shared the pattern: `ci.yml` and `benchmarks.yml`.

No `run:`-context change, so no injection surface — `head_ref`/`sha` are only used in the concurrency-group key.

## Out of scope (your call)

Whether to promote Playwright E2E to a **required** status check (part 2 of #436) is a separate policy decision left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)