### PR TITLE
feat(validate+schema): surface schema set name@version + source everywhere (#431, closes #484)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6183,6 +6183,10 @@ artifacts:
           lists each schema as `name@version (embedded|on-disk)`.
         - `rivet validate --format json` output contains a top-level `schemas`
           array of objects with `name`, `version`, `source`.
+        - `rivet schema sources` reports the same effective set (requested
+          schemas + auto-discovered bridges) WITH each schema's version, so the
+          dedicated command is consistent with the validate surfacing (#484);
+          text shows `name version source`, json entries include `version`.
         - `rivet validate` on the rivet repo still PASS.
     tags: [validate, schema, versioning, reproducibility, surfacing, dogfooding]
     fields:

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6150,3 +6150,48 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-196
+  - id: REQ-205
+    type: requirement
+    title: "`rivet validate` must surface the schema set it used (name@version + embedded/on-disk source) so upgrade-induced validation changes are visible"
+    status: implemented
+    description: |
+      Finding (issue #431). A project using a builtin schema (no local
+      `schemas/` dir) validates against whatever schema copy is compiled into
+      the rivet binary: `embedded::load_schema_contents` prefers an on-disk
+      `<schemas_dir>/<name>.yaml`, else falls back to the embedded copy. So every
+      release that tightens or adds rules to a builtin schema silently changes
+      validation semantics for embedded-schema consumers — `rivet validate` that
+      passed before now flags unchanged artifacts, with nothing indicating the
+      schema changed. Schemas carry a cosmetic `version:` field that was never
+      surfaced.
+
+      Fix (surfacing — option 3 of #431): `rivet validate` now reports the schema
+      set it ran against. Added `embedded::resolve_schema_provenance` (builds on
+      the existing `schema_sources` classifier from REQ-177, adding the parsed
+      `version` and auto-discovered bridges); validate prints a
+      `Schemas: <name>@<version> (embedded|on-disk), …` line (text) and a
+      `schemas` array (json). This makes an upgrade-induced change visible at the
+      point it bites, without changing any validation semantics. (Pinning/gating
+      — option 2 — remains a separate maintainer call on syntax.)
+
+      Acceptance:
+        - `cargo test -p rivet-core --lib embedded::tests::resolve_schema_provenance_reports_version_and_source`
+          passes (on-disk reports its version + source "on-disk"; embedded
+          reports a non-empty compiled-in version + source "embedded"; missing
+          omitted).
+        - `rivet validate` text output contains a line starting `Schemas: ` that
+          lists each schema as `name@version (embedded|on-disk)`.
+        - `rivet validate --format json` output contains a top-level `schemas`
+          array of objects with `name`, `version`, `source`.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [validate, schema, versioning, reproducibility, surfacing, dogfooding]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-177
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-05T13:29:57Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -10729,6 +10729,10 @@ fn cmd_schema_sources(cli: &Cli, format: &str) -> Result<bool> {
     } else {
         vec!["common".to_string()]
     };
+    // #484: report the full effective set (requested names + auto-discovered
+    // bridges) and each schema's version — so this dedicated command is at
+    // least as informative as the `Schemas:` line `rivet validate` now prints.
+    let names = rivet_core::embedded::schema_names_with_bridges(&names);
     let sources = rivet_core::embedded::schema_sources(&names, &schemas_dir);
 
     if format == "json" {
@@ -10737,6 +10741,7 @@ fn cmd_schema_sources(cli: &Cli, format: &str) -> Result<bool> {
             .map(|(name, src)| {
                 serde_json::json!({
                     "name": name,
+                    "version": rivet_core::embedded::schema_version_of(name, src),
                     "source": src.kind(),
                     "path": match src {
                         SchemaSource::OnDisk(p) => Some(p.display().to_string()),
@@ -10754,6 +10759,12 @@ fn cmd_schema_sources(cli: &Cli, format: &str) -> Result<bool> {
     } else {
         println!("Schema sources ({}):", sources.len());
         for (name, src) in &sources {
+            let version = rivet_core::embedded::schema_version_of(name, src);
+            let ver = if version.is_empty() {
+                "-".to_string()
+            } else {
+                version
+            };
             let detail = match src {
                 SchemaSource::OnDisk(p) => format!("on-disk   {}", p.display()),
                 SchemaSource::Embedded => "embedded  (compiled into rivet — changes on \
@@ -10763,7 +10774,7 @@ fn cmd_schema_sources(cli: &Cli, format: &str) -> Result<bool> {
                      embedded schema)"
                     .to_string(),
             };
-            println!("  {name:<18} {detail}");
+            println!("  {name:<28} {ver:<8} {detail}");
         }
     }
     Ok(true)

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -4832,6 +4832,14 @@ fn cmd_validate(
         ..
     } = ctx;
 
+    // #431: resolve which schema set (and version, and embedded-vs-vendored
+    // source) this run validates against, so an upgrade-induced change in a
+    // builtin schema is visible rather than silent. Surfaced in both outputs.
+    let schema_provenance = rivet_core::embedded::resolve_schema_provenance(
+        &config.project.schemas,
+        &resolve_schemas_dir(cli),
+    );
+
     // REQ-062 / F2: `load_artifacts` swallows per-file YAML parse failures
     // to a stderr `log::warn!`, so a malformed artifact file produced a
     // green `Result: PASS` over an effectively-empty load. Re-walk every
@@ -5462,6 +5470,7 @@ fn cmd_validate(
             "version_conflict_details": conflicts_json,
             "lifecycle_coverage": lifecycle_json,
             "cross_repo_diagnostics": cross_repo_diagnostics_json,
+            "schemas": serde_json::to_value(&schema_provenance).unwrap_or(serde_json::Value::Null),
         });
         if let Some((ref vname, bound_count)) = variant_scope_name {
             output["variant"] = serde_json::json!({
@@ -5616,6 +5625,18 @@ fn cmd_validate(
             );
         } else {
             println!("Result: PASS ({} warnings)", warnings);
+        }
+
+        // #431: show the schema set this run validated against — name@version
+        // and whether each is vendored (pinned in-project) or embedded (from
+        // this binary, so it can change silently on a rivet upgrade).
+        if !schema_provenance.is_empty() {
+            let list = schema_provenance
+                .iter()
+                .map(|s| format!("{}@{} ({})", s.name, s.version, s.source))
+                .collect::<Vec<_>>()
+                .join(", ");
+            println!("Schemas: {list}");
         }
     }
 

--- a/rivet-core/src/embedded.rs
+++ b/rivet-core/src/embedded.rs
@@ -296,6 +296,75 @@ pub fn load_schema_contents(
     result
 }
 
+/// Provenance of a resolved schema: which version was used and whether it came
+/// from a vendored (on-disk) file or the embedded (compiled-into-the-binary)
+/// copy. Surfaced by `rivet validate` so an upgrade-induced validation change —
+/// a builtin schema that tightened or added rules between rivet releases —
+/// becomes visible instead of silent (issue #431).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct SchemaProvenance {
+    pub name: String,
+    pub version: String,
+    /// `"vendored"` (on-disk, pinned in the project's git) or `"embedded"`
+    /// (compiled into this rivet binary, so it changes when rivet is upgraded).
+    pub source: &'static str,
+    /// Path to the on-disk schema when `source == "vendored"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+/// Resolve the provenance (name, version, source) of every schema `validate`
+/// will use for the given names — including auto-discovered bridges. Builds on
+/// [`schema_sources`] (the single on-disk/embedded classifier, REQ-177) and adds
+/// the schema `version` plus the bridge set, so the CLI can surface exactly
+/// which schema set, and which version of each, a given `rivet validate` ran
+/// against (issue #431). `Missing` schemas are omitted (already warned about by
+/// the loader). The `source` string matches [`SchemaSource::kind`]
+/// (`"on-disk"` / `"embedded"`) for one vocabulary across `validate` and
+/// `rivet schema sources`.
+pub fn resolve_schema_provenance(
+    schema_names: &[String],
+    schemas_dir: &std::path::Path,
+) -> Vec<SchemaProvenance> {
+    // Expand to the same name set the loader uses: requested names + bridges.
+    let mut names: Vec<String> = schema_names.to_vec();
+    for bridge in discover_bridges(schema_names) {
+        if !names.iter().any(|n| n == bridge) {
+            names.push(bridge.to_string());
+        }
+    }
+
+    schema_sources(&names, schemas_dir)
+        .into_iter()
+        .filter_map(|(name, source)| {
+            let (version, path) = match &source {
+                SchemaSource::OnDisk(p) => {
+                    let version = std::fs::read_to_string(p)
+                        .ok()
+                        .and_then(|c| serde_yaml::from_str::<SchemaFile>(&c).ok())
+                        .map(|s| s.schema.version)
+                        .unwrap_or_default();
+                    (version, Some(p.display().to_string()))
+                }
+                SchemaSource::Embedded => {
+                    let version = load_embedded_schema(&name)
+                        .ok()
+                        .map(|s| s.schema.version)
+                        .unwrap_or_default();
+                    (version, None)
+                }
+                SchemaSource::Missing => return None,
+            };
+            Some(SchemaProvenance {
+                name,
+                version,
+                source: source.kind(),
+                path,
+            })
+        })
+        .collect()
+}
+
 /// Load and merge schemas, falling back to embedded when files are not found.
 ///
 /// Automatically discovers and appends applicable bridge schemas.
@@ -379,5 +448,40 @@ mod tests {
             got.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>(),
             vec!["common", "stpa", "made-up"]
         );
+    }
+
+    // rivet: verifies REQ-205
+    #[test]
+    fn resolve_schema_provenance_reports_version_and_source() {
+        let dir = tempfile::tempdir().unwrap();
+        // An on-disk schema with an explicit version shadows any embedded copy.
+        std::fs::write(
+            dir.path().join("common.yaml"),
+            "schema:\n  name: common\n  version: 9.9.9\n",
+        )
+        .unwrap();
+
+        let names = vec![
+            "common".to_string(),  // on-disk (file present, version 9.9.9)
+            "stpa".to_string(),    // embedded (known builtin)
+            "made-up".to_string(), // missing -> omitted
+        ];
+        let prov = resolve_schema_provenance(&names, dir.path());
+
+        let common = prov.iter().find(|p| p.name == "common").unwrap();
+        assert_eq!(common.source, "on-disk");
+        assert_eq!(common.version, "9.9.9");
+        assert!(common.path.as_deref().unwrap().ends_with("common.yaml"));
+
+        let stpa = prov.iter().find(|p| p.name == "stpa").unwrap();
+        assert_eq!(stpa.source, "embedded");
+        assert!(
+            !stpa.version.is_empty(),
+            "embedded schema must report its compiled-in version"
+        );
+        assert!(stpa.path.is_none());
+
+        // Missing schemas are not surfaced (the loader already warns).
+        assert!(prov.iter().all(|p| p.name != "made-up"));
     }
 }

--- a/rivet-core/src/embedded.rs
+++ b/rivet-core/src/embedded.rs
@@ -313,6 +313,39 @@ pub struct SchemaProvenance {
     pub path: Option<String>,
 }
 
+/// Parse the declared `version:` of a resolved schema. Returns an empty string
+/// when the version can't be determined (unparseable on-disk file, or a
+/// `Missing` schema). Shared by [`resolve_schema_provenance`] and the
+/// `rivet schema sources` command so both surfaces report the same version.
+pub fn schema_version_of(name: &str, source: &SchemaSource) -> String {
+    match source {
+        SchemaSource::OnDisk(p) => std::fs::read_to_string(p)
+            .ok()
+            .and_then(|c| serde_yaml::from_str::<SchemaFile>(&c).ok())
+            .map(|s| s.schema.version)
+            .unwrap_or_default(),
+        SchemaSource::Embedded => load_embedded_schema(name)
+            .ok()
+            .map(|s| s.schema.version)
+            .unwrap_or_default(),
+        SchemaSource::Missing => String::new(),
+    }
+}
+
+/// Expand a requested schema-name list to the full effective set the loader
+/// uses: the requested names plus any auto-discovered bridge schemas (dedup'd,
+/// order-preserving). Shared by `validate` and `rivet schema sources` so both
+/// report the same set.
+pub fn schema_names_with_bridges(schema_names: &[String]) -> Vec<String> {
+    let mut names: Vec<String> = schema_names.to_vec();
+    for bridge in discover_bridges(schema_names) {
+        if !names.iter().any(|n| n == bridge) {
+            names.push(bridge.to_string());
+        }
+    }
+    names
+}
+
 /// Resolve the provenance (name, version, source) of every schema `validate`
 /// will use for the given names — including auto-discovered bridges. Builds on
 /// [`schema_sources`] (the single on-disk/embedded classifier, REQ-177) and adds
@@ -326,34 +359,18 @@ pub fn resolve_schema_provenance(
     schema_names: &[String],
     schemas_dir: &std::path::Path,
 ) -> Vec<SchemaProvenance> {
-    // Expand to the same name set the loader uses: requested names + bridges.
-    let mut names: Vec<String> = schema_names.to_vec();
-    for bridge in discover_bridges(schema_names) {
-        if !names.iter().any(|n| n == bridge) {
-            names.push(bridge.to_string());
-        }
-    }
+    let names = schema_names_with_bridges(schema_names);
 
     schema_sources(&names, schemas_dir)
         .into_iter()
         .filter_map(|(name, source)| {
-            let (version, path) = match &source {
-                SchemaSource::OnDisk(p) => {
-                    let version = std::fs::read_to_string(p)
-                        .ok()
-                        .and_then(|c| serde_yaml::from_str::<SchemaFile>(&c).ok())
-                        .map(|s| s.schema.version)
-                        .unwrap_or_default();
-                    (version, Some(p.display().to_string()))
-                }
-                SchemaSource::Embedded => {
-                    let version = load_embedded_schema(&name)
-                        .ok()
-                        .map(|s| s.schema.version)
-                        .unwrap_or_default();
-                    (version, None)
-                }
-                SchemaSource::Missing => return None,
+            if matches!(source, SchemaSource::Missing) {
+                return None;
+            }
+            let version = schema_version_of(&name, &source);
+            let path = match &source {
+                SchemaSource::OnDisk(p) => Some(p.display().to_string()),
+                _ => None,
             };
             Some(SchemaProvenance {
                 name,
@@ -483,5 +500,41 @@ mod tests {
 
         // Missing schemas are not surfaced (the loader already warns).
         assert!(prov.iter().all(|p| p.name != "made-up"));
+    }
+
+    // rivet: verifies REQ-205
+    #[test]
+    fn schema_version_of_reads_on_disk_embedded_and_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("common.yaml"),
+            "schema:\n  name: common\n  version: 9.9.9\n",
+        )
+        .unwrap();
+
+        let on_disk = SchemaSource::OnDisk(dir.path().join("common.yaml"));
+        assert_eq!(schema_version_of("common", &on_disk), "9.9.9");
+
+        // A known embedded schema reports its compiled-in version.
+        assert!(!schema_version_of("stpa", &SchemaSource::Embedded).is_empty());
+
+        // Missing -> empty.
+        assert_eq!(schema_version_of("made-up", &SchemaSource::Missing), "");
+    }
+
+    // rivet: verifies REQ-205
+    #[test]
+    fn schema_names_with_bridges_appends_discovered_bridges() {
+        // stpa + dev should pull in the stpa-dev bridge (auto-discovered).
+        let names = vec!["common".to_string(), "stpa".to_string(), "dev".to_string()];
+        let expanded = schema_names_with_bridges(&names);
+        // Original names are preserved and come first.
+        assert_eq!(&expanded[..3], &names[..]);
+        // At least one bridge was appended beyond the requested names.
+        assert!(
+            expanded.len() > names.len(),
+            "expected bridge schemas to be appended, got {expanded:?}"
+        );
+        assert!(expanded.iter().any(|n| n.contains("bridge")));
     }
 }


### PR DESCRIPTION
Implements the surfacing fix (option 3) from **#431**, from the hourly dogfooding loop.

## The gap

A project on builtin schemas (no local `schemas/` dir) validates against whatever schema copy is **compiled into the rivet binary** — `embedded::load_schema_contents` prefers an on-disk `<schemas_dir>/<name>.yaml`, else falls back to the embedded copy. So every release that tightens or adds a rule to a builtin schema **silently** changes validation for embedded-schema consumers: a `rivet validate` that passed now flags unchanged artifacts, with nothing indicating the schema moved. The `version:` field existed but was never surfaced.

## Fix

`rivet validate` now reports the schema set it ran against:

```
Result: PASS (258 warnings)
Schemas: common@0.1.0 (on-disk), dev@0.1.0 (on-disk), …, stpa-dev.bridge@0.1.0 (on-disk)
```

```json
"schemas": [
  { "name": "common", "version": "0.1.0", "source": "on-disk", "path": "./schemas/common.yaml" },
  …
]
```

- **rivet-core:** `embedded::resolve_schema_provenance` builds on the existing `schema_sources` classifier (REQ-177) — keeping one `on-disk`/`embedded` vocabulary — and adds the parsed `version` plus auto-discovered bridges.
- **rivet-cli:** `validate` surfaces it in both text and JSON. No validation semantics change.

An embedded-schema project shows `(embedded)`, making the upgrade risk visible at the point it bites; a project that vendored its schemas (the #431 option-1 recommended posture) shows `(on-disk)` = pinned. Pinning/gating (option 2, turning the version into a hard gate) remains a separate maintainer call on syntax.

## Verification

`cargo test -p rivet-core --lib embedded::tests::resolve_schema_provenance_reports_version_and_source` (pass) · `rivet validate` prints the `Schemas:` line incl. bridges · `--format json` emits the `schemas` array · `rivet validate` PASS · `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` (exit 0). Implements + Verifies **REQ-205** (traces REQ-177).

🤖 Generated with [Claude Code](https://claude.com/claude-code)