### PR TITLE
chore: ignore recorded/generated video repo-wide (mp4/webm/mov/mkv/m4v)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,14 @@ mutants.out*/
 # committed. (Tracked .rivet/ files like agent-context.md stay tracked.)
 .rivet/repos/
 .claude/scheduled_tasks.lock
+
+# Recorded / generated video — never commit. The intro/release video pipeline
+# (tools/intro-video/) already ignores its own out/ dir; this is a repo-wide
+# safety net so a stray capture can't be committed from anywhere (e.g. a
+# future release-demo recording). Video only — committed docs images
+# (png/jpg/gif/svg) are intentionally NOT ignored.
+*.mp4
+*.webm
+*.mov
+*.mkv
+*.m4v


### PR DESCRIPTION
Ensures recorded/generated video can never be committed.

`tools/intro-video/.gitignore` already ignores its `out/` dir (where the intro video, screen capture, and Playwright `.webm` land). This adds a **repo-wide** safety net — as video generation moves toward the release cycle, captures may land outside that one tool, and a multi-MB mp4 slipping into git history would be painful to remove.

- Ignores video extensions only: `*.mp4`, `*.webm`, `*.mov`, `*.mkv`, `*.m4v`.
- **Does not** touch committed docs images (`png`/`jpg`/`gif`/`svg` stay tracked).
- No currently-tracked file is affected (`git ls-files` shows no video committed).

Verified: the existing `out/rivet-intro.mp4` stays ignored, and a hypothetical `docs/some-demo.mp4` / `release/capture.webm` is now caught by the root rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)