### PR TITLE
ci: warn when a schema changes without a version bump (REQ-206, closes #485)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,23 @@ jobs:
       - run: pip install yamllint
       - run: yamllint -c .yamllint.yaml schemas/ artifacts/ rivet.yaml .github/
 
+  # ── Schema version-bump advisory (#485) ───────────────────────────────
+  # Warn (don't fail) when a PR changes a schema's rules but leaves its
+  # `version:` untouched — embedded schemas validate silently differently on
+  # upgrade unless the version tracks content (#431). Warn-only matches the
+  # docs-check coverage gate; flip to STRICT=1 once schema versions are
+  # disciplined. PRs only (needs a base to diff against).
+  schema-version-bump:
+    name: Schema version bump
+    runs-on: [self-hosted, linux, x64, light]
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # full history so we can diff against the PR base
+      - name: Check schema version bumps (warn-only)
+        run: scripts/check-schema-version-bump.sh "origin/${{ github.base_ref }}" HEAD
+
   # ── Docs-vs-reality gate (REQ-054) ────────────────────────────────────
   # A real gate — no continue-on-error.  Budget <1 minute on cached runs.
   docs-check:

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6150,3 +6150,43 @@ artifacts:
     links:
       - type: traces-to
         target: REQ-196
+  - id: REQ-206
+    type: requirement
+    title: "CI must warn when a schema's rules change without a `version:` bump (schema-version drift discipline)"
+    status: implemented
+    description: |
+      Finding (issue #485, verified). Built-in schemas embed into the rivet
+      binary, so a rules change with the `version:` field left unchanged
+      silently alters validation for every embedded-schema consumer (#431) — and
+      the version surfaced by `rivet validate` / `rivet schema sources` (#483)
+      stays uninformative. Evidence: every shipped schema is `0.1.0` except
+      `aspice` (`0.2.0`); `schemas/common.yaml` was changed by 8 commits
+      (several rule-affecting) with zero version bumps.
+
+      Fix: a `scripts/check-schema-version-bump.sh` that diffs `schemas/*.yaml`
+      (excluding `migrations/`) against a base ref and reports any schema whose
+      content changed but whose `version:` line did not. Warn-only by default
+      (a comment/whitespace edit legitimately needs no bump), `STRICT=1` to
+      enforce — mirroring the docs-check coverage gate. Wired into ci.yml as a
+      `schema-version-bump` job on pull_request (fetch-depth 0 to diff the base),
+      emitting GitHub `::warning::` annotations inline.
+
+      Acceptance:
+        - `scripts/check-schema-version-bump.sh f2ecf31^ f2ecf31` warns about
+          `schemas/common.yaml` (changed without a version bump) and exits 0.
+        - `STRICT=1 scripts/check-schema-version-bump.sh f2ecf31^ f2ecf31` exits 1.
+        - A diff range that changes no schema prints `OK` and exits 0.
+        - `.github/workflows/ci.yml` has a `schema-version-bump` job invoking the
+          script on `pull_request`.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [ci, schema, versioning, drift, advisory-gate, dogfooding]
+    fields:
+      priority: should
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-054
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-05T15:26:15Z

--- a/scripts/check-schema-version-bump.sh
+++ b/scripts/check-schema-version-bump.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Flag schema files that changed without a `version:` bump (#485).
+#
+# Built-in schemas embed into the rivet binary, so a rules change with the
+# `version:` left unchanged silently alters validation for every embedded-schema
+# consumer (issue #431) — and the version surfaced by `rivet validate` /
+# `rivet schema sources` (#483) stays uninformative. This guards the discipline:
+# touch a schema's rules, bump its version.
+#
+# Usage:
+#   scripts/check-schema-version-bump.sh [BASE_REF] [HEAD_REF]
+#     BASE_REF  base to diff against (default: origin/main)
+#     HEAD_REF  head to diff        (default: HEAD)
+#
+# Env:
+#   STRICT=1   exit non-zero when a bump is missing (default: warn-only, exit 0)
+#
+# Warn-only by default (matches the project's docs-check --warn-only gate):
+# a comment/whitespace-only schema edit legitimately needs no bump, so this
+# advises rather than blocks. Set STRICT=1 to enforce.
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+HEAD="${2:-HEAD}"
+STRICT="${STRICT:-0}"
+
+# Schema files whose version must track rule changes. Excludes migration
+# recipes (schemas/migrations/) which carry no `version:` metadata.
+# Portable collection (no `mapfile` — macOS ships bash 3.2).
+changed="$(
+  git diff --name-only --diff-filter=d "$BASE...$HEAD" -- 'schemas/*.yaml' \
+    | grep -v '^schemas/migrations/' || true
+)"
+
+missing=()
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  # Did this file's diff touch a `version:` line? (the schema: metadata version)
+  if git diff "$BASE...$HEAD" -- "$f" | grep -qE '^[+-][[:space:]]*version:'; then
+    continue   # version changed — good
+  fi
+  missing+=("$f")
+done <<< "$changed"
+
+if [ "${#missing[@]}" -eq 0 ]; then
+  echo "schema-version-bump: OK (no schema changed without a version bump)"
+  exit 0
+fi
+
+for f in "${missing[@]}"; do
+  ver="$(grep -m1 -E '^[[:space:]]*version:' "$f" 2>/dev/null | tr -d ' ' || echo 'version:?')"
+  msg="$f changed but its $ver was not bumped — bump it if rules changed (semver: minor=new/tightened rule, patch=fix). See #485."
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::warning file=$f::$msg"
+  else
+    echo "WARNING: $msg"
+  fi
+done
+
+if [ "$STRICT" = "1" ]; then
+  echo "schema-version-bump: ${#missing[@]} schema(s) changed without a version bump (STRICT)."
+  exit 1
+fi
+echo "schema-version-bump: ${#missing[@]} schema(s) changed without a version bump (warn-only)."
+exit 0


### PR DESCRIPTION
Closes **#485** (which I filed last loop while shipping the #431/#483 schema-version surfacing).

## Why

Built-in schemas embed into the rivet binary, so a rules change with `version:` left unchanged silently alters validation for every embedded-schema consumer (#431) — and the version surfaced by `rivet validate` / `rivet schema sources` (#483) is uninformative unless it tracks content. **Verified:** every shipped schema is `0.1.0` except `aspice` (`0.2.0`); `schemas/common.yaml` was changed by **8** commits (several rule-affecting) with **zero** version bumps.

## What

`scripts/check-schema-version-bump.sh` diffs `schemas/*.yaml` (excluding `migrations/`) against a base ref and reports any schema whose content changed but whose `version:` line did not.

- **Warn-only by default** (a comment/whitespace edit legitimately needs no bump); `STRICT=1` to enforce — mirroring the existing docs-check coverage gate.
- Wired into `ci.yml` as a `schema-version-bump` job on `pull_request` (`fetch-depth: 0` to diff the base), emitting `::warning::` annotations inline on the PR.

## Verification (all run locally)

| Case | Result |
|------|--------|
| `…sh f2ecf31^ f2ecf31` (common.yaml changed, no bump) | WARNs, exit 0 ✓ |
| `STRICT=1 …sh f2ecf31^ f2ecf31` | exit 1 ✓ |
| range with no schema change | `OK`, exit 0 ✓ |
| predicate vs a changed (quoted) `version:` line | detected → not flagged ✓ |
| predicate vs a rule-only hunk | not matched → flagged ✓ |

`rivet validate` PASS (257). Portable (no `mapfile`; runs on macOS bash 3.2 and CI). Implements + Verifies **REQ-206** (traces REQ-054).

> Follow-up (separate, your call): the data fix — actually bumping the schemas that have drifted — and flipping to `STRICT=1` once versions are disciplined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)