### PR TITLE
docs(agents): document the parallel-PR conflict-avoidance policy (#422)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,32 @@ Exempt artifact types (no trailer required): `chore`, `style`, `ci`, `docs`, `bu
 To skip traceability for a commit, add: `Trace: skip`
 <!-- END rivet-managed -->
 
+## Parallel-PR friction (avoiding merge conflicts)
+
+When several PRs are in flight at once (the dogfooding loop is the heaviest
+generator of this), two files conflict over and over unless you follow these
+rules. The conflict is **always** the same shape — two PRs adding a new entry
+at the same spot — so it is fully avoidable:
+
+- **`artifacts/requirements.yaml` — append new artifacts at EOF; never insert
+  mid-file.** Use `rivet add` (it appends via `mutate::append_artifact_to_file`),
+  or, if hand-editing, add the new block at the very end. Two EOF-appends from
+  different PRs are trivially resolved by keeping both blocks; a hand-authored
+  *mid-file* insert ("after REQ-160") collides far worse. Pick the next free id
+  by scanning **all** of `artifacts/` (ids span many files, and an id may be
+  reserved by an unmerged PR — see #479), not just the last line of this file.
+- **`CHANGELOG.md` — already conflict-free via `merge=union`.** `.gitattributes`
+  sets `CHANGELOG.md merge=union` (REQ-164 / #423), so git keeps *both* sides'
+  added lines automatically — this is why CHANGELOG merge conflicts disappeared.
+  Keep adding entries at the top of `## [Unreleased]`; the union driver handles
+  the overlap. (The same driver is *not* applied to `requirements.yaml` — union
+  would silently duplicate lines if two PRs edited the *same* artifact — so the
+  EOF-append discipline above is what keeps that file clean. Tracking: #422.)
+
+If you still hit a `requirements.yaml` EOF conflict (e.g. another PR merged
+first), the resolution is mechanical: keep **both** new blocks, then
+`rivet validate` to confirm the merged file is well-formed.
+
 ## Commit Traceability
 
 This project enforces commit-to-artifact traceability. Every non-exempt


### PR DESCRIPTION
Implements **item 1** of the #422 triage AC (the maintainer-authored Acceptance Criteria in that thread): a "Parallel-PR friction" section in `AGENTS.md`.

## Why

The dogfooding loop is the heaviest generator of `requirements.yaml` + `CHANGELOG.md` merge conflicts — it bit PR #487 just last hour (a `requirements.yaml` EOF collision after main drifted). The CHANGELOG half is already solved (`merge=union`, REQ-164/#423); the `requirements.yaml` half is a *discipline* (append at EOF), which was undocumented. This documents it where agents look.

## What

`AGENTS.md` gains a section stating:
- **`requirements.yaml`** — append new artifacts at EOF (use `rivet add`, which already EOF-appends via `mutate::append_artifact_to_file`); never insert mid-file; pick the next id by scanning all of `artifacts/` and mind ids reserved by unmerged PRs (#479).
- **`CHANGELOG.md`** — already conflict-free via `merge=union`, and *why* `requirements.yaml` deliberately does **not** use union (it would silently duplicate lines if two PRs edited the same artifact).
- The mechanical resolution when a conflict does happen (keep both blocks → `rivet validate`).

## Note

Deliberately a **docs-only change with no new REQ** — filing a REQ here would append to `requirements.yaml` and contribute to the exact collision being documented. Per the #422 AC, it traces to the existing CHANGELOG REQ (`Refs: REQ-164`).

`rivet validate` PASS · referenced ids exist · no `rivet docs check` violations in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)