### PR TITLE
test(playwright): lift node budget in variant-scoping graph invariant (#436)

### DIFF
--- a/tests/playwright/rendering-invariants.spec.ts
+++ b/tests/playwright/rendering-invariants.spec.ts
@@ -204,8 +204,16 @@ test.describe("Rendering invariants — variant scoping coverage", () => {
     // The fixture variant "minimal-ci" binds exactly REQ-001, so the scoped
     // graph ends up with at most a single node — strictly fewer than the
     // unscoped graph for this project's full requirements/features set.
+    // `limit=2000` lifts the default 200-node render budget: the dogfood
+    // dataset grew past 200 requirement nodes (+ neighbours), so the UNSCOPED
+    // `/graph?types=requirement` now returns the "above node budget"
+    // placeholder (0 rendered nodes) instead of an SVG — which made the
+    // `fullNodes >= scopedNodes` invariant fail (fullNodes=0). Lifting the
+    // budget on both fetches keeps the comparison meaningful as the dataset
+    // grows. Same pattern as graph.spec.ts. (#436 — recurring dataset-growth
+    // fragility in the E2E graph views.)
     const respScoped = await page.goto(
-      "/graph?variant=minimal-ci&types=requirement",
+      "/graph?variant=minimal-ci&types=requirement&limit=2000",
     );
     expect(respScoped?.status()).toBe(200);
     await expect(page.locator("h2")).toContainText("Traceability Graph", {
@@ -216,7 +224,7 @@ test.describe("Rendering invariants — variant scoping coverage", () => {
     await expect(page.locator(".variant-banner")).toContainText("minimal-ci");
     const scopedNodes = await page.locator("svg .node, svg g.node").count();
 
-    const respFull = await page.goto("/graph?types=requirement");
+    const respFull = await page.goto("/graph?types=requirement&limit=2000");
     expect(respFull?.status()).toBe(200);
     await expect(page.locator("h2")).toContainText("Traceability Graph", {
       timeout: 30_000,


### PR DESCRIPTION
Fixes the **one red gate on main** — the Playwright E2E failure that was keeping CI from being conclusively green (now visible, not cancelled, thanks to #481).

## Root cause (verified locally — full suite: 399 passed / 1 failed)

`rendering-invariants.spec.ts:195` "/graph?variant=minimal-ci IS scoped" asserts `fullNodes >= scopedNodes`. The dogfood dataset grew past **200 requirement nodes**, so the *unscoped* `/graph?types=requirement` now exceeds the 200-node render budget and returns the "above node budget" placeholder — **0 rendered nodes**. So `fullNodes(0) >= scopedNodes(1)` failed.

This is the same recurring dataset-growth fragility as #435/#436 (the graph E2E tests render against the live, growing corpus), just in a different test.

## Fix

`&limit=2000` on both fetches (the pattern `graph.spec.ts` already uses) so neither view is budget-clipped; the "scoping reduces node count" invariant stays meaningful as the corpus grows.

## Verification

Local (correct pinned chromium): the exact test passes; the full `rendering-invariants.spec.ts` (13 tests) passes; full suite was 399✓/1✗ and this was the lone failure.

`tests/` only — no product code. Refs REQ-171 (the prior budget-bounding fix for these E2E graph tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)