### PR TITLE
feat(serve): presentation/clean mode for recordings (REQ-207, closes #482)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6417,3 +6417,41 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-05T15:26:15Z
+  - id: REQ-207
+    type: requirement
+    title: "`rivet serve` must offer a presentation/clean mode that hides working-state chrome for recordings/screenshots"
+    status: implemented
+    description: |
+      Finding (issue #482). The `rivet serve` dashboard header (context bar)
+      always shows the working-state chrome — branch@sha, an `N uncommitted`
+      badge, the absolute project path, and Reload/Print buttons. That chrome
+      leaks into any recorded video or screenshot (it was visible in every
+      frame of the intro-video capture), looking unprofessional and exposing
+      in-progress branch names / machine-specific paths in published media.
+
+      Fix: a `?presentation=1` (alias `?clean=1`) query param adds a
+      `presentation` class on the document root, and CSS hides `.context-bar`
+      while it is set. Client-side and set once on load, so it survives HTMX
+      navigations (which only swap `#content`); the capture spec / a user just
+      appends the param to the URL. No server plumbing; default (no param) is
+      unchanged.
+
+      Acceptance:
+        - `cargo build -p rivet-cli` succeeds; `rivet serve` page source for
+          `/artifacts?presentation=1` contains the `presentation` toggle script
+          and the `.presentation .context-bar{display:none}` rule.
+        - Playwright `presentation-mode.spec.ts` passes: `.context-bar` is
+          visible without the param and hidden with `?presentation=1` (and
+          `?clean=1`), and the class survives an HTMX nav.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [serve, dashboard, presentation, screenshots, video, ux, dogfooding]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: FEAT-001
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-05T21:19:32Z

--- a/rivet-cli/src/serve/layout.rs
+++ b/rivet-cli/src/serve/layout.rs
@@ -297,7 +297,15 @@ pub(crate) fn page_layout_with_variant(
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Rivet Dashboard</title>
-<style>{fonts_css}{css}</style>
+<style>{fonts_css}{css}.presentation .context-bar{{display:none!important}}</style>
+<script>
+// Presentation/clean mode (#482): `?presentation=1` (or `?clean=1`) hides the
+// working-state chrome (branch, SHA, "N uncommitted", path, Reload/Print) so
+// recorded video / screenshots show a clean dashboard. Set once on load on the
+// root element so it survives HTMX swaps (which only replace #content). Inline
+// in <head> to avoid a flash of the context bar before CSS applies.
+try{{var sp=new URLSearchParams(location.search);if(sp.has('presentation')||sp.has('clean'))document.documentElement.classList.add('presentation')}}catch(e){{}}
+</script>
 <script src="/assets/htmx.js"></script>
 <script src="/assets/mermaid.js"></script>
 <script>

--- a/tests/playwright/presentation-mode.spec.ts
+++ b/tests/playwright/presentation-mode.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+// Presentation/clean mode (#482): `?presentation=1` (or `?clean=1`) hides the
+// working-state chrome (branch, SHA, "N uncommitted", path, Reload/Print) so
+// recorded video / screenshots show a clean dashboard. Dataset-independent —
+// the context bar renders on every page regardless of corpus size.
+test.describe("Presentation mode", () => {
+  test("context bar is visible in normal mode", async ({ page }) => {
+    await page.goto("/artifacts");
+    await expect(page.locator(".context-bar")).toBeVisible();
+  });
+
+  test("?presentation=1 hides the context bar (branch/uncommitted chrome)", async ({
+    page,
+  }) => {
+    await page.goto("/artifacts?presentation=1");
+    // Element still in the DOM but hidden via the `.presentation` class.
+    await expect(page.locator(".context-bar")).toBeHidden();
+    // Content itself is unaffected.
+    await expect(page.locator("main")).toBeVisible();
+  });
+
+  test("?clean=1 is an accepted alias", async ({ page }) => {
+    await page.goto("/coverage?clean=1");
+    await expect(page.locator(".context-bar")).toBeHidden();
+  });
+
+  test("presentation class survives an HTMX navigation", async ({ page }) => {
+    await page.goto("/artifacts?presentation=1");
+    await expect(page.locator(".context-bar")).toBeHidden();
+    // Navigate within the SPA (HTMX swaps #content, not <html>).
+    await page.locator("nav a", { hasText: "Coverage" }).first().click();
+    await expect(page.locator("html")).toHaveClass(/presentation/);
+    await expect(page.locator(".context-bar")).toBeHidden();
+  });
+});


### PR DESCRIPTION
Closes **#482**. The `rivet serve` dashboard's context bar always shows branch@sha, an "N uncommitted" badge, the absolute project path, and Reload/Print buttons — which leaked into every frame of the intro-video capture (and would into any screenshot), looking unprofessional and exposing in-progress branch names / machine paths.

## Fix

`?presentation=1` (alias `?clean=1`) adds a `presentation` class on the document root; CSS hides `.context-bar` while set. **Client-side, set once on load**, so it survives HTMX navigations (which only swap `#content`) — the capture spec or a user just appends the param. Default (no param) unchanged; no server plumbing.

## Verification

- `curl /artifacts?presentation=1` → HTML carries the toggle script + `.presentation .context-bar{display:none}` rule.
- `presentation-mode.spec.ts` (4 tests, dataset-independent): bar visible normally; hidden with `?presentation=1` and `?clean=1`; class survives an HTMX nav. **All pass locally.**
- `cargo fmt --check` + `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS.

Implements + Verifies **REQ-207**. Useful immediately for re-recording the intro video without the branch/dirty chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)