### PR TITLE
ci(nextest): retry flaky tests so one serve-test race doesn't red main (closes #493)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,6 +4,15 @@
 [profile.ci]
 # Fail-fast disabled so all tests run even if some fail
 fail-fast = false
+# Retry failed tests up to twice before reporting failure. The serve/integration
+# tests bind ports and spin up a server, so under CI parallelism one
+# occasionally fails on a timing/port race (this repo has several historical
+# "fix flaky test" fixes). A test that passes on retry is reported FLAKY
+# (visible in the summary) rather than failing the whole Test gate and
+# reddening main; a genuinely-broken test still fails after all retries.
+# Verified: `cargo test --workspace` + `nextest run --all` pass locally — the
+# gate flakes, the code does not.
+retries = 2
 
 [profile.ci.junit]
 # Output JUnit XML for CI consumption


### PR DESCRIPTION
Closes **#493**. Fixes the recurring flaky-`Test`-gate friction at the systemic level.

## Why

Main's `Test` gate went red on commit `00876df` (REQ-207, additive dashboard HTML), but the code is sound:
- `cargo test --workspace` → all pass, 0 failed
- `cargo nextest run --all --profile ci` (the exact CI command) → **2075 passed / 0 failed**
- `serve_integration` → 43/43

→ a **flake** (a serve/integration test racing on a port/timing under CI parallelism). The ci nextest profile had `fail-fast = false` but **no `retries`**, so a single flaky failure reds the whole gate. The repo has already band-aided this per-test three times (server_pages_push_url, test_reload_yaml_error, #331).

## Fix

`retries = 2` on `[profile.ci]`. A test passing on retry → reported **FLAKY** (visible, in the JUnit too); a genuinely-broken test → still fails after all retries. Absorbs races without hiding regressions. Standard nextest practice.

## Verification

`cargo nextest list --profile ci` (config parses) · `cargo nextest run --all --profile ci` → 2075 passed / 0 failed. CI-only config; no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)