### PR TITLE
feat(tools/intro-video): record dashboard in presentation mode (clean frames)

### DIFF
--- a/tools/intro-video/capture.spec.ts
+++ b/tools/intro-video/capture.spec.ts
@@ -100,6 +100,10 @@ async function cliPanel(page: import("@playwright/test").Page) {
 test("rivet intro video capture", async ({ page }) => {
   test.setTimeout(120_000);
   const { base_url } = storyboard.meta;
+  // Record the dashboard in presentation mode (REQ-207 / #482): hides the
+  // branch / "N uncommitted" / path / Reload+Print chrome so the published
+  // video has clean frames regardless of the recording machine's git state.
+  const CLEAN = "?presentation=1";
 
   for (const scene of storyboard.scenes) {
     switch (scene.action) {
@@ -110,21 +114,21 @@ test("rivet intro video capture", async ({ page }) => {
         await cliPanel(page);
         break;
       case "open_dashboard":
-        await page.goto(`${base_url}/`);
+        await page.goto(`${base_url}/${CLEAN}`);
         await page.waitForLoadState("networkidle").catch(() => {});
         break;
       case "browse_artifacts":
-        await page.goto(`${base_url}/artifacts`);
+        await page.goto(`${base_url}/artifacts${CLEAN}`);
         await page.locator("table").first().waitFor().catch(() => {});
         // Gentle scroll to show the list is long / real.
         await page.mouse.wheel(0, 400);
         break;
       case "open_artifact":
-        await page.goto(`${base_url}/artifacts/REQ-001`);
+        await page.goto(`${base_url}/artifacts/REQ-001${CLEAN}`);
         await page.waitForLoadState("networkidle").catch(() => {});
         break;
       case "show_coverage":
-        await page.goto(`${base_url}/coverage`);
+        await page.goto(`${base_url}/coverage${CLEAN}`);
         await page.waitForLoadState("networkidle").catch(() => {});
         break;
       case "outro_card":


### PR DESCRIPTION
Follow-up to **REQ-207 / #482** (serve presentation mode). The intro-video capture now appends `?presentation=1` to the four dashboard scene URLs, so the recorded video hides the branch / "N uncommitted" / path / Reload+Print chrome — the exact thing that was visible in every frame of the first `rivet-intro.mp4`.

- Affects only the dashboard `goto` scenes (open_dashboard, browse_artifacts, open_artifact, show_coverage); title/CLI-help/outro use `setContent` and are unchanged.
- `tools/` only (not in CI; the capture produces an artifact, not assertions).
- Verified by composition — presentation mode itself is proven (`presentation-mode.spec.ts`, 4 passing); confirming the live capture produces clean frames as part of landing.

Next: a full re-record (`generate.sh`) produces a clean narrated `rivet-intro.mp4` ready for YouTube.

🤖 Generated with [Claude Code](https://claude.com/claude-code)