### PR TITLE
fix(cli): revert --project/--schemas global (broke main; clap + positional subcommands)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6497,35 +6497,3 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-06T01:49:27Z
-  - id: REQ-209
-    type: requirement
-    title: "Top-level path args (`--project`/`--schemas`) must be position-independent (clap `global`)"
-    status: implemented
-    description: |
-      Finding (issue #500, hit while implementing #488). `--project`/`-p` and
-      `--schemas` were declared on the top-level Cli without `global = true`, so
-      they only parsed BEFORE the subcommand: `rivet -p X validate` worked but
-      `rivet validate -p X` errored — and with `--format json` produced empty
-      stdout (error on stderr), a confusing failure for anything shelling out to
-      rivet (it cost a debug cycle in the #488 `--new-since` subprocess).
-
-      Fix: mark both args `global = true` so they work in any position. Additive
-      and low-risk — the pre-subcommand form still parses.
-
-      Acceptance:
-        - `cargo test -p rivet-cli --bin rivet cli_global_args_tests` passes
-          (`--project`/`--schemas` parse after the subcommand; `-p` before still parses).
-        - `rivet validate --project .` and `rivet validate -p . --format json`
-          both succeed (previously errored).
-        - `rivet validate` on the rivet repo still PASS.
-    tags: [cli, ergonomics, clap, args, dogfooding]
-    fields:
-      priority: should
-      category: functional
-    links:
-      - type: traces-to
-        target: REQ-007
-    provenance:
-      created-by: ai-assisted
-      model: claude-opus-4-8
-      timestamp: 2026-06-06T02:18:14Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -194,15 +194,15 @@ fn check_for_updates() {
 #[command(name = "rivet", about = "SDLC artifact traceability and validation", version = build_version())]
 struct Cli {
     /// Path to the project directory (containing rivet.yaml).
-    /// `global` so it works in any position (`rivet validate -p X` as well as
-    /// `rivet -p X validate`) — a non-global path arg silently errors when
-    /// placed after the subcommand, which is surprising for tools (#500).
-    #[arg(short, long, default_value = ".", global = true)]
+    /// NOTE: not `global` — clap debug-asserts when a global arg coexists with
+    /// subcommands that take positionals (next-id/link/snapshot diff/…), so
+    /// `--project` must precede the subcommand: `rivet -p X validate`, not
+    /// `rivet validate -p X`. See #500 (reverted REQ-209).
+    #[arg(short, long, default_value = ".")]
     project: PathBuf,
 
-    /// Path to schemas directory. `global` for the same position-independence
-    /// as `--project` (#500).
-    #[arg(long, global = true)]
+    /// Path to schemas directory (precedes the subcommand, like `--project`).
+    #[arg(long)]
     schemas: Option<PathBuf>,
 
     /// Increase verbosity
@@ -16993,32 +16993,6 @@ fn print_diagnostics_with_remediation(
 }
 
 // ── LSP unit tests ─────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod cli_global_args_tests {
-    use super::Cli;
-    use clap::Parser;
-
-    // rivet: verifies REQ-209
-    #[test]
-    fn project_and_schemas_parse_after_the_subcommand() {
-        // The #500 regression: a non-global `--project` errored when placed
-        // after the subcommand. With `global = true` both positions parse.
-        let after =
-            Cli::try_parse_from(["rivet", "validate", "--project", "/x", "--schemas", "/s"])
-                .expect("`--project`/`--schemas` must parse AFTER the subcommand");
-        assert_eq!(after.project.to_str(), Some("/x"));
-        assert_eq!(
-            after.schemas.as_deref().and_then(|p| p.to_str()),
-            Some("/s")
-        );
-
-        // The pre-subcommand form still works (no regression).
-        let before = Cli::try_parse_from(["rivet", "-p", "/y", "validate"])
-            .expect("`-p` before the subcommand must still parse");
-        assert_eq!(before.project.to_str(), Some("/y"));
-    }
-}
 
 #[cfg(test)]
 mod new_since_diff_tests {


### PR DESCRIPTION
**Reverts REQ-209/#501**, which broke `main`.

#501 made `--project`/`--schemas` `global = true` (to fix #500), but clap **does not allow a global arg to coexist with subcommands that take positionals** (`next-id <type>`, `link <src> <tgt>`, `snapshot diff <baseline>`, …). The result: 3 `cli_commands` integration tests panic in clap's `debug_asserts` → the `Test` gate went red on main.

My fault: pre-merge I only exercised `validate` (no positional), which parsed fine; the full integration suite (which I didn't run) would have caught it. Lesson logged.

## This PR

- Removes `global = true` from both args (restores the working pre-subcommand behavior).
- Removes the now-invalid `cli_global_args_tests` and the **REQ-209** artifact.
- Documents on the arg why it can't be global, and that `--project` must precede the subcommand.

So #500 is a **clap limitation, not fixable via `global`** — reopening it with this finding; the standard workaround (`rivet -p X validate`) stands.

## Verification

`cargo test -p rivet-cli --test cli_commands` → **127 passed, 0 failed** (the 3 regressions fixed) · `cargo fmt --check` + `clippy --all-targets -- -D warnings` exit 0 · `rivet validate` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)