### PR TITLE
docs(cli): clarify --project/--schemas precede the subcommand (#500)

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -193,15 +193,17 @@ fn check_for_updates() {
 #[derive(Parser)]
 #[command(name = "rivet", about = "SDLC artifact traceability and validation", version = build_version())]
 struct Cli {
-    /// Path to the project directory (containing rivet.yaml).
-    /// NOTE: not `global` — clap debug-asserts when a global arg coexists with
-    /// subcommands that take positionals (next-id/link/snapshot diff/…), so
-    /// `--project` must precede the subcommand: `rivet -p X validate`, not
-    /// `rivet validate -p X`. See #500 (reverted REQ-209).
+    // Not `global`: clap debug-asserts when a global arg coexists with
+    // subcommands that take positionals (next-id <type>, link <a> <b>,
+    // snapshot diff <x>, …). So this must precede the subcommand. See #500
+    // (REQ-209 attempted `global = true` and was reverted in #502).
+    /// Path to the project directory (containing rivet.yaml). Pass it BEFORE the
+    /// subcommand: `rivet -p <dir> validate` (not `rivet validate -p <dir>`).
     #[arg(short, long, default_value = ".")]
     project: PathBuf,
 
-    /// Path to schemas directory (precedes the subcommand, like `--project`).
+    /// Path to schemas directory. Like `--project`, pass it BEFORE the
+    /// subcommand (`rivet --schemas <dir> validate`).
     #[arg(long)]
     schemas: Option<PathBuf>,
 


### PR DESCRIPTION
Small docs follow-up to the #502 revert. That revert left clap-internals jargon ("debug-asserts … next-id/link/snapshot diff") in the **user-facing `--help`** for `--project`. This moves the rationale to a plain `//` maintainer comment and makes the `///` help user-facing: pass `--project`/`--schemas` **before** the subcommand (`rivet -p <dir> validate`), like `git -C <dir> <cmd>`.

Addresses the UX confusion in **#500** (a misplaced `--project` errors with empty stdout) by surfacing the convention in `--help`. Leaves #500 open for the maintainer's call on whether to additionally support per-subcommand `--project`.

Doc-comment only, no logic change. Verified: `cargo test -p rivet-cli --test cli_commands` → **127 passed, 0 failed** (full suite incl. help tests — applying last hour's lesson) · fmt/clippy exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)