### PR TITLE
fix(init): pre-commit hook runs cargo fmt --check on staged Rust (REQ-210, #438)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6497,3 +6497,53 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-06T01:49:27Z
+
+  - id: REQ-210
+    type: requirement
+    title: "`rivet init --hooks` pre-commit runs `cargo fmt --check` (language-agnostic) so AI/dev commits don't pass locally and fail CI Format"
+    status: implemented
+    description: |
+      Finding (issue #438). The single most common first-push CI failure is a
+      formatting diff, and AI agents routinely hit it: they edit Rust, commit,
+      and the commit "passes" locally because the only pre-commit gate is
+      `rivet validate` — then CI's `cargo fmt --check` job goes red.
+
+      Root cause: the hook installed by the SHIPPED command `rivet init --hooks`
+      (`cmd_init_hooks`, rivet-cli/src/main.rs) only runs `rivet validate`. It
+      does NOT run `cargo fmt --check`. The fmt-checking pre-commit hook that
+      lives in THIS repo was installed by the dev-only `scripts/install-hooks.sh`
+      (and the `templates/pre-commit/.pre-commit-config.yaml`), neither of which
+      `rivet init --hooks` uses. So every project that adopts hooks the shipped
+      way gets no formatting gate.
+
+      Fix: `cmd_init_hooks` writes a pre-commit hook that, BEFORE the existing
+      `rivet validate` step, runs `cargo fmt --all -- --check` — but only when
+      both (a) `cargo` is on PATH and (b) the commit stages at least one `.rs`
+      file (`git diff --cached --name-only --diff-filter=ACM | grep -q '\.rs$'`).
+      The guard keeps the hook language-agnostic: a non-Rust rivet project (or a
+      machine without cargo) skips the fmt step silently, so the hook never
+      blocks commits in unrelated repositories. Mirrors the proven logic already
+      in `scripts/install-hooks.sh`. Convenience only; CI remains the real gate
+      (REQ-051) and `--no-verify` still bypasses it.
+
+      Acceptance:
+        - In a temp git repo with a `rivet.yaml`, `rivet init --hooks` writes a
+          `.git/hooks/pre-commit` whose body contains `cargo fmt --all -- --check`
+          guarded by a staged-`.rs` check (`grep -q '\.rs$'`) and a
+          `command -v cargo` test.
+        - The generated hook still runs `rivet validate --format json` and blocks
+          on `errors > 0` (existing behaviour preserved).
+        - `cargo test -p rivet-cli --test cli_commands` passes (full CLI suite).
+        - `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [hooks, init, cargo-fmt, ci-parity, dogfooding, dx]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-051
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-06T10:30:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -4198,13 +4198,21 @@ fn cmd_init_hooks(dir: &std::path::Path) -> Result<bool> {
     // survives relocation of the project within the working tree (a
     // hard-coded `-p <path>` would silently validate the wrong directory
     // or skip validation after a move).
+    //
+    // Formatting gate (REQ-210, #438): a misformatted-Rust diff is the most
+    // common first-push CI failure, and AI agents kept hitting it because the
+    // hook only ran `rivet validate`. Run `cargo fmt --all -- --check` BEFORE
+    // validate — but only when cargo is on PATH and the commit actually stages
+    // a `.rs` file, so the hook stays language-agnostic and never blocks
+    // commits in non-Rust rivet projects. Convenience only; CI is the real
+    // gate (REQ-051) and `--no-verify` still bypasses this.
     let pre_commit_path = hooks_dir.join("pre-commit");
     install_hook(
         &pre_commit_path,
         &format!(
             r#"#!/usr/bin/env bash
 # Installed by: rivet init --hooks
-# Runs rivet validate and blocks on errors.
+# Runs cargo fmt --check (staged Rust) + rivet validate; blocks on errors.
 #
 # Marker discovery: walk up from $PWD until we find rivet.yaml, then cd
 # into that directory before running rivet. This keeps the hook working
@@ -4219,6 +4227,18 @@ if [ ! -f "$dir/rivet.yaml" ]; then
     exit 0
 fi
 cd "$dir" || exit 0
+
+# Formatting gate: only when cargo is present AND the commit stages Rust.
+# A misformatted diff is the most common first-push CI failure; catching it
+# here (~1s) keeps local commits in parity with the CI Format job. Skipped
+# silently for non-Rust projects.
+if command -v cargo >/dev/null 2>&1 \
+    && git diff --cached --name-only --diff-filter=ACM | grep -q '\.rs$'; then
+    if ! cargo fmt --all -- --check; then
+        echo "cargo fmt: formatting issues. Run 'cargo fmt --all', then re-stage."
+        exit 1
+    fi
+fi
 
 output=$("{rivet_bin}" validate --format json 2>/dev/null)
 errors=$(echo "$output" | python3 -c "import json,sys; print(json.load(sys.stdin).get('errors',0))" 2>/dev/null || echo "0")


### PR DESCRIPTION
## Problem (#438)

`rivet init --hooks` installs a pre-commit hook that runs **only `rivet validate`** — there is **no formatting gate**. A misformatted-Rust diff is the single most common first-push CI failure, and AI agents kept hitting it: the commit "passes" locally (validate is clean), then CI's `cargo fmt --check` job goes red.

The fmt-checking pre-commit hook that *this* repo actually uses was installed by the **dev-only `scripts/install-hooks.sh`** — which `rivet init --hooks` does not use. So every project that adopts hooks the shipped way gets no formatting gate. (The original issue framed it as the *Claude Code* hook missing fmt; the accurate root cause is the **shipped `cmd_init_hooks`** template.)

## Fix

`cmd_init_hooks` (`rivet-cli/src/main.rs`) now writes a pre-commit hook that runs `cargo fmt --all -- --check` **before** the existing `rivet validate` step — guarded to stay **language-agnostic**:

```bash
if command -v cargo >/dev/null 2>&1 \
    && git diff --cached --name-only --diff-filter=ACM | grep -q '\.rs$'; then
    if ! cargo fmt --all -- --check; then
        echo "cargo fmt: formatting issues. Run 'cargo fmt --all', then re-stage."
        exit 1
    fi
fi
```

The fmt step runs **only** when cargo is on PATH **and** the commit stages at least one `.rs` file, so non-Rust rivet projects (and cargo-less machines) skip it silently and are never blocked. Mirrors the proven logic in `scripts/install-hooks.sh`. Convenience only — CI remains the real gate (REQ-051) and `--no-verify` still bypasses it.

## Verification (acceptance, REQ-210)

- Temp-repo `rivet init --hooks` → generated `.git/hooks/pre-commit` contains the fmt step + the `.rs` guard + the `command -v cargo` guard, preserves the `rivet validate --format json` step, and passes `bash -n`.
- `cargo test -p rivet-cli --test cli_commands` — **127 passed, 0 failed** (the full CLI suite, per the REQ-209 lesson).
- `cargo fmt --check` + `cargo clippy -p rivet-cli --all-targets -- -D warnings` — exit 0.
- `rivet validate` — PASS.

REQ-210 filed and flipped to `implemented` in the same commit (repo convention, cf. REQ-208).

Closes #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)