### PR TITLE
ci(traceability): gate PRs on rivet validate + commits (REQ-212, part of REQ-051)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,54 @@ jobs:
       - name: Subcommand-coverage gate (warn-only)
         run: cargo run --release -p rivet-cli -- docs check --coverage --warn-only
 
+  # ── Traceability gate (REQ-051) ───────────────────────────────────────
+  # The project that BUILDS the traceability tool must gate its own PRs on
+  # traceability — dogfooding, and the CI half REQ-051 mandates (local git
+  # hooks are convenience only; only CI enforcement is auditor-grade).
+  #
+  # NOTE (operator step): this job RUNS on every push/PR, but it only
+  # *blocks* a merge once it is added to branch protection's required status
+  # checks (currently empty — see #436). The job is the mechanism; marking it
+  # required is a repo-settings action that cannot live in this file.
+  traceability:
+    name: Traceability (rivet validate + commits)
+    runs-on: [self-hosted, linux, x64, rust-cpu]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # `commits --range base..HEAD` needs real history, not a shallow clone.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Gate 1: the trace graph must carry no ERRORs (broken links, duplicate
+      # ids, bad link targets, cardinality, schema-rule inconsistencies).
+      # Coverage/lint WARNINGS do not fail — `validate` exits 1 only at or
+      # above `--fail-on` (default: error).
+      - name: rivet validate (fail on errors)
+        run: cargo run --release -p rivet-cli -- validate
+      # Gate 2: no ORPHAN commits and no BROKEN trailer refs introduced by
+      # THIS PR. Scoped to the PR's own commits (base..HEAD). NOT `--strict`,
+      # which promotes whole-store "artifact has no commit coverage" findings
+      # to errors and so can never pass on a narrow range. CLAUDE.md makes
+      # artifact trailers mandatory for rivet-core/src + rivet-cli/src: an
+      # orphan is a non-exempt code commit missing them; a broken ref is a
+      # trailer pointing at an unknown id (e.g. a reverted REQ).
+      - name: rivet commits — no orphan/broken trailers in this PR
+        if: github.event_name == 'pull_request'
+        run: |
+          range="${{ github.event.pull_request.base.sha }}..HEAD"
+          echo "Commit traceability over ${range}"
+          json="$(cargo run --release -q -p rivet-cli -- commits --range "${range}" --format json)"
+          counts="$(printf '%s' "${json}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(len(d.get("orphans",[])), len(d.get("broken_refs",[])))')"
+          orphans="${counts% *}"
+          broken="${counts#* }"
+          echo "orphan commits: ${orphans}, broken trailer refs: ${broken}"
+          if [ "${orphans}" -gt 0 ] || [ "${broken}" -gt 0 ]; then
+            echo "::error::Commit traceability gate failed: ${orphans} orphan commit(s), ${broken} broken trailer ref(s). Add artifact trailers (Implements/Fixes/Verifies/Refs) or 'Trace: skip'. See CLAUDE.md 'Commit Traceability'."
+            cargo run --release -q -p rivet-cli -- commits --range "${range}"
+            exit 1
+          fi
+
   # ── Tests ─────────────────────────────────────────────────────────────
   test:
     name: Test

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -1278,6 +1278,18 @@ artifacts:
       hooks do not provide security assurance — only CI enforcement does.
       A rivet validate --check-hooks flag should report whether hooks are
       installed, but hook absence must not block local development.
+
+      Status (2026-06-06): the in-CI gating MECHANISM is now wired — see
+      REQ-212, which added a `traceability` job to ci.yml running `rivet
+      validate` (fail on errors) + `rivet commits` (orphan/broken-ref gate on
+      PRs). The hook-security documentation clause is met (CLAUDE.md "Hook
+      Security Model"). REMAINING before this can flip to implemented:
+      (1) the job must be added to branch protection's REQUIRED status checks
+      so it actually blocks merges (operator/repo-settings action, can't live
+      in-repo; the empty required-checks set is tracked in #436); and (2) the
+      `rivet validate --check-hooks` flag does not yet exist. Kept `draft`
+      until both are done — the job running but not blocking is exactly the
+      advisory-gate trap #436 describes.
     tags: [ci, hooks, security, tool-qualification]
     links:
       - type: constraint-satisfies
@@ -6596,3 +6608,54 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-06T11:00:00Z
+
+  - id: REQ-212
+    type: requirement
+    title: "CI runs `rivet validate` + `rivet commits` as a gating job — the traceability tool gates its own PRs (the in-CI mechanism of REQ-051)"
+    status: implemented
+    description: |
+      Finding (bootstrap-verification audit of rivet-as-tool). The project
+      that BUILDS the traceability tool did not gate its own PRs on
+      traceability: `ci.yml` ran `rivet docs check` but neither `rivet
+      validate` nor `rivet commits`. `rivet validate` ran only at release
+      time (`release.yml`), so a graph error or an untraced code commit could
+      land on `main` and only surface at release. This is the in-CI mechanism
+      REQ-051 calls for; REQ-051 stays the broader (and still-`draft`) parent
+      because it additionally requires the job be a *branch-protection
+      required check* (operator action, see #436) and a `validate
+      --check-hooks` flag (not yet implemented).
+
+      A new `traceability` job in `ci.yml`:
+        - Gate 1: `cargo run -p rivet-cli -- validate` — exits 1 on ERRORs
+          (broken links, dup ids, bad targets, cardinality); coverage/lint
+          WARNINGS do not fail (default `--fail-on error`).
+        - Gate 2 (pull_request only): `rivet commits --range <base.sha>..HEAD
+          --format json`, fail if `orphans` or `broken_refs` is non-empty —
+          i.e. a non-exempt code commit missing trailers, or a trailer
+          pointing at an unknown id. NOT `--strict`, which promotes
+          whole-store "artifact has no commit coverage" to errors and so can
+          never pass on a narrow PR range (calibrated: `--strict` over the 3
+          clean recent merges still exits 1 on uncovered-artifact findings).
+
+      Acceptance:
+        - `.github/workflows/ci.yml` defines a `traceability` job that runs
+          `rivet validate` and (on pull_request) the `rivet commits`
+          orphan/broken-ref check; `actionlint` is clean (modulo the
+          pre-existing custom runner-label false positives).
+        - `rivet validate` exits non-zero on a tree with a dangling link and
+          0 on the current rivet tree (PASS, warnings only) — verified.
+        - The commit gate's bash passes on a clean range (orphans=0,
+          broken=0 → exit 0) and fails on a range containing the reverted
+          REQ-209 trailer (broken_refs=2 → exit 1) — verified locally.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [ci, traceability, gate, dogfooding, req-051]
+    fields:
+      priority: must
+      category: non-functional
+    links:
+      - type: traces-to
+        target: REQ-051
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-06T11:30:00Z


### PR DESCRIPTION
## Why

Surfaced by the **bootstrap-verification audit of rivet-as-tool**: the project that *builds* the traceability tool did not gate its own PRs on traceability. `ci.yml` ran `rivet docs check` but **neither `rivet validate` nor `rivet commits`** — `rivet validate` ran only at release (`release.yml`), so a graph error or an untraced code commit could land on `main` and surface only at release. This is the in-CI mechanism **REQ-051** has long called for.

## Change — new `traceability` job

- **Gate 1 — `rivet validate`:** exits 1 on **errors** (broken links, dup ids, bad link targets, cardinality, schema-rule inconsistencies). Coverage/lint **warnings don't fail** (default `--fail-on error`). rivet's own tree PASSes today (0 errors, 269 warnings).
- **Gate 2 — `rivet commits` (PRs only):** `--range <base.sha>..HEAD --format json`, fails if `orphans` **or** `broken_refs` is non-empty — a non-exempt code commit missing trailers, or a trailer pointing at an unknown id.
  - **Deliberately NOT `--strict`:** I calibrated it — `--strict` promotes whole-store *"artifact has no commit coverage"* findings to errors, so it exits 1 even on the 3 clean recent merges (3 commits can't cover 918 artifacts). The scoped orphan/broken-ref check is the correct per-PR gate.

## Verification (REQ-212 acceptance)

- `actionlint .github/workflows/ci.yml` — clean apart from the pre-existing custom self-hosted runner-label false positives.
- Gate bash tested locally: **passes** on a clean range (`orphans=0, broken=0` → exit 0); **fails** on a range containing the reverted **REQ-209** trailer (`broken_refs=2` → exit 1).
- `rivet validate` PASS; new artifacts validate.

## Status honesty

**REQ-212** (this job) → `implemented`, traces to **REQ-051**. **REQ-051 stays `draft`** on purpose: it *also* requires (1) the job be a **branch-protection REQUIRED check** so it actually blocks merges — an operator/repo-settings action that can't live in this file (empty required-checks set tracked in **#436**), and (2) a `rivet validate --check-hooks` flag (not yet implemented). A running-but-non-blocking gate is exactly the advisory-gate trap #436 describes, so the parent isn't "implemented" yet.

> ⚠️ **Operator follow-ups:** (a) add **Traceability (rivet validate + commits)** to `main`'s required status checks once green; (b) the self-hosted runner pool is currently offline (#509), so this job — like all CI — won't execute until runners are back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)