### PR TITLE
chore(release-plan): scope v0.16.0 via baseline field + document the convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,26 @@ Use `rivet validate --format json` for machine-readable output.
 - Always include traceability links when creating artifacts
 - Run `rivet validate` before committing
 
+### Release planning (the `baseline` field is the release field)
+
+rivet's release plan lives in the **`baseline`** field on requirement /
+design-decision / feature artifacts — it is the schema-declared, queryable
+"which version is this targeted for" field. (This is the field the
+release-planning skill calls `release:`; rivet's name for it is `baseline`,
+and #512's "add a release field" is answered by this convention, not a new
+field.)
+
+- **In progress:** `baseline: vX.Y.Z-track` while the release is being built.
+- **Shipped:** drop the `-track` suffix (`baseline: vX.Y.Z`) when the release
+  is cut.
+- **Scope a release** = `rivet list --filter '(= baseline "vX.Y.Z-track")'`.
+- **Readiness is a query:** a release is cuttable only when every artifact in
+  its scope is `verified`/`accepted` (the V closed) — not when it's merely
+  `implemented`. Check with
+  `rivet list --filter '(and (= baseline "vX.Y.Z-track") (= status "implemented"))'`
+  (anything returned is still-to-verify).
+- Tag in bulk without races via `rivet modify --where '<filter>' --set-field baseline=vX.Y.Z-track`.
+
 ## Commit Traceability
 
 This project enforces commit-to-artifact traceability.

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6147,6 +6147,7 @@ artifacts:
     fields:
       priority: must
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-196
@@ -6180,6 +6181,7 @@ artifacts:
     fields:
       priority: must
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-007
@@ -6278,6 +6280,7 @@ artifacts:
     fields:
       priority: should
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-007
@@ -6321,6 +6324,7 @@ artifacts:
     fields:
       priority: should
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-159
@@ -6370,6 +6374,7 @@ artifacts:
     fields:
       priority: should
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-177
@@ -6410,6 +6415,7 @@ artifacts:
     fields:
       priority: should
       category: non-functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-054
@@ -6448,6 +6454,7 @@ artifacts:
     fields:
       priority: should
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: FEAT-001
@@ -6490,6 +6497,7 @@ artifacts:
     fields:
       priority: should
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-007
@@ -6540,6 +6548,7 @@ artifacts:
     fields:
       priority: should
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-051
@@ -6589,6 +6598,7 @@ artifacts:
     fields:
       priority: should
       category: functional
+      baseline: v0.16.0-track
     links:
       - type: traces-to
         target: REQ-007


### PR DESCRIPTION
Plans the next release **in rivet** (release-planning skill), driven by the work/issues we have.

## Decision: `baseline` is the release field

rivet already has a queryable "which version is this targeted for" field — **`baseline`** (243 artifacts use it, `vX.Y.Z-track` while in progress). So #512's "add a `release` field" is answered by **documenting this convention**, not adding a parallel field (avoids two competing version fields). AGENTS.md now records it.

## v0.16.0 scope (tagged `baseline: v0.16.0-track`)

The 10 implemented-since-v0.15.0 requirements, tagged in one pass via `rivet modify --where … --set-field` (round-trip verified — only the baseline line added, links/provenance preserved):

REQ-200/201 (export HTML AADL + single-page), REQ-203 (add provenance), REQ-204 (deterministic ordering), REQ-205/206 (schema surfacing + version-bump warn), REQ-207 (serve presentation mode), REQ-208 (`validate --new-since`), REQ-210 (init-hooks fmt gate), REQ-211 (`list --full`).

Plus, landing via open PRs (tagged when they merge): **REQ-213** (schema presets, #515) and **REQ-051/212** (traceability gate, #513).

## Readiness is a query

```
rivet list --filter '(= baseline "v0.16.0-track")'   → 10 artifacts
  all status=implemented, 0 verified  → NOT yet cuttable
```

Per the V-model gate, v0.16.0 ships only when its scope is `verified`. The blocker is **verification confirmation**, which is CI's job — and the self-hosted runner pool is offline (#509). So v0.16.0 is feature-complete but **verification-blocked by the CI outage**, not by outstanding dev work.

> ⚠️ CI can't run this (runners offline, #509). Artifact+docs only; `rivet validate` PASS locally.

Refs #512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)