### PR TITLE
release(v0.16.0): bump version + finalize CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,29 @@
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-09
+
 ### Added
+
+- **REQ-213 / #510 — `rivet schema presets`.** Lists every built-in schema
+  preset you can declare in `rivet.yaml`'s `schemas:` (name, version,
+  artifact-type count, description), so the enableable standard set —
+  DO-178C / ISO 26262 / IEC 61508 / EN 50128 and the rest — is discoverable
+  instead of undocumented. Needs no project; works in a bare directory.
+- **REQ-211 / #506, #511 — `rivet list --format json --full`.** Emits each
+  artifact's `description`, `tags`, and `fields` in bulk, so a machine-readable
+  query for a custom field value (e.g. `release`/`baseline`) no longer needs one
+  `rivet get` per artifact or a raw YAML parse.
+- **REQ-212 / REQ-051, #436 — CI traceability gate.** A `traceability` job in
+  `ci.yml` runs `rivet validate` (fail on errors) + `rivet commits` (orphan /
+  broken-trailer gate on PRs): the traceability tool now gates its own PRs. The
+  in-CI mechanism of REQ-051 (marking it a *required* check remains an operator
+  step, #436).
+- **Release planning via the `baseline` field (#512).** Documented in AGENTS.md
+  that `baseline` is rivet's release field (`vX.Y.Z-track` while in progress →
+  `vX.Y.Z` when shipped); readiness is the query
+  `rivet list --filter '(= baseline "vX.Y.Z-track")'`. v0.16.0 is the first
+  release scoped this way.
 
 - **REQ-162 / #352, #355 — canonical status lifecycle is now enforced.** The
   shared `schemas/common.yaml` `status` base-field declares

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts **v0.16.0**. Bumps workspace version 0.15.0 → 0.16.0 (Cargo.toml, vscode-rivet/package.json, Cargo.lock) and finalizes the CHANGELOG `[0.16.0]` section.

## v0.16.0 highlights
- **`rivet schema presets`** (REQ-213 / #510) — discover the declarable built-in schemas (DO-178C/ISO 26262/IEC 61508/EN 50128 …).
- **`rivet list --format json --full`** (REQ-211 / #506, #511) — bulk description/tags/fields for machine-readable queries.
- **CI traceability gate** (REQ-212 / REQ-051, #436) — the tool gates its own PRs on `rivet validate` + `rivet commits`.
- **Release planning via `baseline`** (#512) — documented; v0.16.0 is the first release scoped this way (`(= baseline "v0.16.0-track")`).
- Plus the accumulated [Unreleased] scope since v0.15.0 (export AADL honesty, deterministic ordering, schema surfacing, presentation mode, `validate --new-since`, init-hooks fmt gate, …).

## Verification
- `rivet validate` PASS; `rivet docs check` PASS (VersionConsistency green — all version files at 0.16.0).
- Main CI green on the merged scope (Format/Clippy/Test/Docs/YAML/Traceability).

Tagging `v0.16.0` after this merges triggers `release.yml` (GitHub Release + SBOM/SLSA) and `release-npm.yml` (npm publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)