### PR TITLE
ci(miri): parallelize with cargo-nextest so Miri uses the cores (not 45 min on one)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,8 @@ jobs:
   # ── Miri (undefined behavior, pointer provenance) ───────────────────
   miri:
     name: Miri
-    # lean-mem: Miri allocates aggressively; benefits from 24G ceiling.
+    # lean-mem: parallel Miri (nextest, process-per-test) trades RAM for cores —
+    # the 24G ceiling lets several Miri processes run at once.
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
@@ -420,32 +421,39 @@ jobs:
         with:
           components: miri
       - uses: Swatinem/rust-cache@v2
-      - name: Run Miri
-        # Run safety-critical modules under Miri with tree borrows model.
-        # Uses pulseengine/rowan fork with Miri UB fixes (upstream: rust-analyzer/rowan#210).
-        # Skip: bazel/db (salsa internals), externals (spawns git),
-        # export/providers/test_scanner/yaml_edit (not safety-critical, slow under Miri).
-        # Skip yaml_cst/yaml_hir tests that create multi-item trees: rowan cursor
-        # deallocation UB with large trees under tree borrows (pulseengine/rowan#211).
-        # Single-item parser tests (25/26) pass clean.
-        # Also skip feature_model (constraint parsing builds rowan trees → same UB).
-        # Also skip doc_check (pulldown-cmark heavy → 30–90s/test under Miri,
-        # times out the job; business-logic tests, not memory-safety tests).
-        # Skip sexpr_eval and any test that goes through it (embed query,
-        # query::execute_sexpr, parse_query): all build rowan trees via
-        # s-expr parsing and hit the same cursor deallocation UB as
-        # yaml_cst/feature_model (pulseengine/rowan#211).
-        run: cargo miri test -p rivet-core --lib -- --skip bazel --skip db --skip externals --skip export --skip providers --skip test_scanner --skip yaml_edit --skip markdown --skip parse_actual_hazards --skip stpa_hazard --skip yaml_hir --skip feature_model --skip doc_check --skip sexpr_eval --skip query_embed --skip parse_query --skip execute_sexpr
-        # Bumped 15→30 during smithy migration: first run timed out at
-        # 15 min with the last printed test at the 11-min mark (i.e.,
-        # the slow tests at the tail just ran past the budget on
-        # smithy's lean-mem class). Hosted may have been fine because
-        # of different tail-test perf characteristics.
-        # Bumped 30→45 (2026-06-10): under self-hosted-pool contention
-        # (clearing the #509 outage backlog) Miri ran past 30 min and
-        # timed out, failing the run while every required gate was green.
-        # 45 gives headroom on the lean-mem class without masking a real
-        # hang (a genuine UB loop still trips the budget).
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: Show runner resources
+        # Make the "where do CPU/mem go" answer visible in the log: the box has
+        # plenty; single-process `cargo miri test` just used one core of it.
+        run: |
+          echo "cores (nproc): $(nproc)"
+          free -h
+      - name: Run Miri (nextest — process-per-test parallelism)
+        # `cargo miri test` ran ONE Miri process: a single-threaded interpreter
+        # pinning one core for ~45 min while the rest of the box sat idle.
+        # `cargo miri nextest run` runs each test in its own process, so the
+        # lean-mem runner's cores are actually used and wall-time collapses
+        # toward the slowest single test. `--test-threads` bounds concurrent
+        # Miri processes so total shadow-memory stays under the 24G ceiling —
+        # start conservative at 4, raise once a green run shows real peak-RSS
+        # headroom.
+        #
+        # SAME test selection as before: the old libtest `--skip <m>` list is
+        # translated to nextest's filterset `not (test(<m>) | ...)`. Skip
+        # bazel/db (salsa internals), externals (spawns git),
+        # export/providers/test_scanner/yaml_edit/markdown (not
+        # safety-critical, slow under Miri); yaml_hir/feature_model/sexpr_eval
+        # + its s-expr consumers (query_embed/parse_query/execute_sexpr) build
+        # multi-item rowan trees → cursor-dealloc UB under tree borrows
+        # (pulseengine/rowan#211); doc_check (pulldown-cmark heavy);
+        # parse_actual_hazards/stpa_hazard (slow).
+        run: |
+          cargo miri nextest run -p rivet-core --lib --test-threads 4 \
+            -E 'not (test(bazel) | test(db) | test(externals) | test(export) | test(providers) | test(test_scanner) | test(yaml_edit) | test(markdown) | test(parse_actual_hazards) | test(stpa_hazard) | test(yaml_hir) | test(feature_model) | test(doc_check) | test(sexpr_eval) | test(query_embed) | test(parse_query) | test(execute_sexpr))'
+        # Generous headroom for a now-parallel job (was a single-process 45-min
+        # budget). Tighten once we see the real parallel wall-time.
         timeout-minutes: 45
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-tree-borrows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,10 +410,16 @@ jobs:
           path: coverage-html/
 
   # ── Miri (undefined behavior, pointer provenance) ───────────────────
+  # PR/push: Miri over the actual UB SURFACE only. Measured (PR #521): the full
+  # 678-test sweep is ~930 test-minutes of mostly safe business logic (regex,
+  # glob, HTML) that Miri runs ~100-1000x slower than native — it can't fit a
+  # per-PR budget at any thread count, and provides ~no memory-safety value.
+  # Miri exists to validate `unsafe`; in rivet-core that's the SyntaxKind
+  # `transmute`s in the rowan-based CST parsers. Scope the PR gate to those
+  # (sexpr + yaml_cst); the FULL sweep runs nightly (miri-full, #498 pattern).
   miri:
-    name: Miri
-    # lean-mem: parallel Miri (nextest, process-per-test) trades RAM for cores —
-    # the 24G ceiling lets several Miri processes run at once.
+    name: Miri (safety surface)
+    if: github.event_name != 'schedule'
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
@@ -424,40 +430,42 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-      - name: Show runner resources
-        # Make the "where do CPU/mem go" answer visible in the log: the box has
-        # plenty; single-process `cargo miri test` just used one core of it.
+      - name: Run Miri over the unsafe/CST surface
+        # sexpr.rs + yaml_cst.rs hold the only real `unsafe` in rivet-core
+        # (`std::mem::transmute` of raw SyntaxKind for the rowan parsers).
+        # bazel.rs has the third transmute but its tests touch salsa/process
+        # internals — covered by the nightly full sweep, not the PR gate. The
+        # multi-item-tree rowan cursor UB (pulseengine/rowan#211) lives in
+        # yaml_hir/sexpr_eval/feature_model (nightly-skipped); the single-item
+        # sexpr/yaml_cst tests here pass clean. nextest spreads them across the
+        # cores (measured 32c/125G) so this is a couple of minutes.
         run: |
-          echo "cores (nproc): $(nproc)"
-          free -h
-      - name: Run Miri (nextest — process-per-test parallelism)
-        # `cargo miri test` ran ONE Miri process: a single-threaded interpreter
-        # pinning one core for ~45 min while the rest of the box sat idle.
-        # `cargo miri nextest run` runs each test in its own process, so the
-        # runner's cores are actually used and wall-time collapses toward
-        # total-work / threads.
-        #
-        # MEASURED on this runner (see "Show runner resources"): 32 cores,
-        # 125 GiB RAM — NOT memory-constrained. ~678 Miri tests at ~20s each
-        # ≈ 226 core-min of work. At --test-threads 4 that was still ~56 min
-        # (timed out); at 24 it's ~9-10 min, using ~24 * ~3 GiB ≈ 72 GiB,
-        # comfortably under 125 GiB. (The "lean-mem" label is a misnomer here.)
-        #
-        # SAME test selection as before: the old libtest `--skip <m>` list is
-        # translated to nextest's filterset `not (test(<m>) | ...)`. Skip
-        # bazel/db (salsa internals), externals (spawns git),
-        # export/providers/test_scanner/yaml_edit/markdown (not
-        # safety-critical, slow under Miri); yaml_hir/feature_model/sexpr_eval
-        # + its s-expr consumers (query_embed/parse_query/execute_sexpr) build
-        # multi-item rowan trees → cursor-dealloc UB under tree borrows
-        # (pulseengine/rowan#211); doc_check (pulldown-cmark heavy);
-        # parse_actual_hazards/stpa_hazard (slow).
+          cargo miri nextest run -p rivet-core --lib --test-threads 24 \
+            -E 'test(sexpr::) | test(yaml_cst::)'
+        timeout-minutes: 20
+
+  # Nightly + manual: the FULL Miri sweep — every Miri-compatible test (all but
+  # the externals/process-spawning + rowan#211 multi-item failures the suite
+  # has always skipped). Off the per-PR path (#498) so its ~50-min runtime
+  # never blocks a PR; 24 threads on the 125 GiB runner, generous timeout.
+  miri-full:
+    name: Miri (full, nightly)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, linux, x64, lean-mem]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - name: Run full Miri sweep
         run: |
           cargo miri nextest run -p rivet-core --lib --test-threads 24 \
             -E 'not (test(bazel) | test(db) | test(externals) | test(export) | test(providers) | test(test_scanner) | test(yaml_edit) | test(markdown) | test(parse_actual_hazards) | test(stpa_hazard) | test(yaml_hir) | test(feature_model) | test(doc_check) | test(sexpr_eval) | test(query_embed) | test(parse_query) | test(execute_sexpr))'
-        # Generous headroom for a now-parallel job (was a single-process 45-min
-        # budget). Tighten once we see the real parallel wall-time.
-        timeout-minutes: 45
+        timeout-minutes: 90
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-tree-borrows"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,18 +436,18 @@ jobs:
         # bazel.rs has the third transmute but its tests touch salsa/process
         # internals — covered by the nightly full sweep, not the PR gate.
         #
-        # MUST run under Tree Borrows. rowan's thin-token provenance trips a
-        # *Stacked Borrows* rule (rust-analyzer/rowan #210/#211/#212, all closed
-        # UNMERGED — upstream is rewriting rowan, not patching it). The
-        # maintainer's position: "rowan should pass Tree Borrows; that Stacked
-        # Borrows rule is unlikely to survive Rust's final aliasing model." Our
-        # `fix/miri-soundness-v2` fork pin passes under TB. (Without
-        # `-Zmiri-tree-borrows` this hits a SharedReadOnly zero-size-retag UB.)
+        # Runs under STACKED BORROWS (Miri default, the strictest model). This
+        # is sound thanks to rowan fork v3 (= v2 + phall1's #212: GreenToken as a
+        # DST + cursor SB fixes), which widens the token retag past the slice
+        # tail. The pre-v3 pin hit a SharedReadOnly zero-size-retag UB here and
+        # needed `-Zmiri-tree-borrows` to dodge it; v3 makes both SB and TB pass,
+        # so we gate on the stricter one. (rust-analyzer/rowan #210/#211/#212 are
+        # all closed-unmerged; upstream is rewriting rowan — Cargo.toml.)
         run: |
           cargo miri nextest run -p rivet-core --lib --test-threads 24 \
             -E 'test(sexpr::) | test(yaml_cst::)'
         env:
-          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-tree-borrows"
+          MIRIFLAGS: "-Zmiri-disable-isolation"
         timeout-minutes: 20
 
   # Nightly + manual: the FULL Miri sweep — every Miri-compatible test (all but

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,14 +434,20 @@ jobs:
         # sexpr.rs + yaml_cst.rs hold the only real `unsafe` in rivet-core
         # (`std::mem::transmute` of raw SyntaxKind for the rowan parsers).
         # bazel.rs has the third transmute but its tests touch salsa/process
-        # internals — covered by the nightly full sweep, not the PR gate. The
-        # multi-item-tree rowan cursor UB (pulseengine/rowan#211) lives in
-        # yaml_hir/sexpr_eval/feature_model (nightly-skipped); the single-item
-        # sexpr/yaml_cst tests here pass clean. nextest spreads them across the
-        # cores (measured 32c/125G) so this is a couple of minutes.
+        # internals — covered by the nightly full sweep, not the PR gate.
+        #
+        # MUST run under Tree Borrows. rowan's thin-token provenance trips a
+        # *Stacked Borrows* rule (rust-analyzer/rowan #210/#211/#212, all closed
+        # UNMERGED — upstream is rewriting rowan, not patching it). The
+        # maintainer's position: "rowan should pass Tree Borrows; that Stacked
+        # Borrows rule is unlikely to survive Rust's final aliasing model." Our
+        # `fix/miri-soundness-v2` fork pin passes under TB. (Without
+        # `-Zmiri-tree-borrows` this hits a SharedReadOnly zero-size-retag UB.)
         run: |
           cargo miri nextest run -p rivet-core --lib --test-threads 24 \
             -E 'test(sexpr::) | test(yaml_cst::)'
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-tree-borrows"
         timeout-minutes: 20
 
   # Nightly + manual: the FULL Miri sweep — every Miri-compatible test (all but

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,11 +434,14 @@ jobs:
         # `cargo miri test` ran ONE Miri process: a single-threaded interpreter
         # pinning one core for ~45 min while the rest of the box sat idle.
         # `cargo miri nextest run` runs each test in its own process, so the
-        # lean-mem runner's cores are actually used and wall-time collapses
-        # toward the slowest single test. `--test-threads` bounds concurrent
-        # Miri processes so total shadow-memory stays under the 24G ceiling —
-        # start conservative at 4, raise once a green run shows real peak-RSS
-        # headroom.
+        # runner's cores are actually used and wall-time collapses toward
+        # total-work / threads.
+        #
+        # MEASURED on this runner (see "Show runner resources"): 32 cores,
+        # 125 GiB RAM — NOT memory-constrained. ~678 Miri tests at ~20s each
+        # ≈ 226 core-min of work. At --test-threads 4 that was still ~56 min
+        # (timed out); at 24 it's ~9-10 min, using ~24 * ~3 GiB ≈ 72 GiB,
+        # comfortably under 125 GiB. (The "lean-mem" label is a misnomer here.)
         #
         # SAME test selection as before: the old libtest `--skip <m>` list is
         # translated to nextest's filterset `not (test(<m>) | ...)`. Skip
@@ -450,7 +453,7 @@ jobs:
         # (pulseengine/rowan#211); doc_check (pulldown-cmark heavy);
         # parse_actual_hazards/stpa_hazard (slow).
         run: |
-          cargo miri nextest run -p rivet-core --lib --test-threads 4 \
+          cargo miri nextest run -p rivet-core --lib --test-threads 24 \
             -E 'not (test(bazel) | test(db) | test(externals) | test(export) | test(providers) | test(test_scanner) | test(yaml_edit) | test(markdown) | test(parse_actual_hazards) | test(stpa_hazard) | test(yaml_hir) | test(feature_model) | test(doc_check) | test(sexpr_eval) | test(query_embed) | test(parse_query) | test(execute_sexpr))'
         # Generous headroom for a now-parallel job (was a single-process 45-min
         # budget). Tighten once we see the real parallel wall-time.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "rowan"
 version = "0.16.2"
-source = "git+https://github.com/pulseengine/rowan.git?branch=fix%2Fmiri-soundness-v2#dcbece400019397b97764070435eba62c7aa5336"
+source = "git+https://github.com/pulseengine/rowan.git?branch=fix%2Fmiri-soundness-v3#9e7abd1161634377d278cde0c504c101ac003941"
 dependencies = [
  "countme",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,17 +107,18 @@ quick-xml = { version = "0.37", features = ["serialize", "overlapped-lists"] }
 wasmtime = { version = "43", features = ["component-model"] }
 wasmtime-wasi = "43"
 
-# Lossless syntax trees — pinned to our fork's Miri-soundness branch.
+# Lossless syntax trees — pinned to our fork's Miri-soundness branch v3.
 # Upstream will NOT take a patch: rust-analyzer/rowan #210/#211/#212 were all
 # closed UNMERGED — the maintainer intends a full rowan rewrite (rust-analyzer
-# #15710/#18285, "Future Rowan" GSoC) and considers the residual failure a
-# Stacked-Borrows-only rule ("rowan should pass Tree Borrows; that SB rule is
-# unlikely to survive Rust's final aliasing model"). So this is a permanent
-# maintenance fork until that rewrite lands. We run Miri under Tree Borrows
-# (`-Zmiri-tree-borrows`, see ci.yml), under which this pin is sound; the
-# residual SB token UB (#211) is fixed only on phall1's unmerged #212 branch,
-# to adopt if we ever need SB coverage. Upstream issues: rowan#192, #163, #108.
-rowan = { git = "https://github.com/pulseengine/rowan.git", branch = "fix/miri-soundness-v2" }
+# #15710/#18285, "Future Rowan" GSoC). So this is a permanent maintenance fork
+# until that rewrite lands.
+# v3 = v2 (GreenNode DST + cursor parent-provenance) PLUS phall1's unmerged
+# #212: GreenToken made a DST (`token.rs`/`arc.rs`) to widen the retag past the
+# slice tail, and an SB fix in `cursor.rs` free()/to_next_sibling. With v3 the
+# parsers are sound under BOTH Stacked Borrows and Tree Borrows — so CI now
+# gates the unsafe/CST surface under Stacked Borrows (the strictest model; see
+# ci.yml). Upstream issues: rowan#192, #163, #108.
+rowan = { git = "https://github.com/pulseengine/rowan.git", branch = "fix/miri-soundness-v3" }
 
 # Markdown rendering
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,9 +107,16 @@ quick-xml = { version = "0.37", features = ["serialize", "overlapped-lists"] }
 wasmtime = { version = "43", features = ["component-model"] }
 wasmtime-wasi = "43"
 
-# Lossless syntax trees — using fork with Miri UB fixes until upstream merges.
-# Upstream issues: rust-analyzer/rowan#192, #163, #108
-# Our PR: rust-analyzer/rowan#210
+# Lossless syntax trees — pinned to our fork's Miri-soundness branch.
+# Upstream will NOT take a patch: rust-analyzer/rowan #210/#211/#212 were all
+# closed UNMERGED — the maintainer intends a full rowan rewrite (rust-analyzer
+# #15710/#18285, "Future Rowan" GSoC) and considers the residual failure a
+# Stacked-Borrows-only rule ("rowan should pass Tree Borrows; that SB rule is
+# unlikely to survive Rust's final aliasing model"). So this is a permanent
+# maintenance fork until that rewrite lands. We run Miri under Tree Borrows
+# (`-Zmiri-tree-borrows`, see ci.yml), under which this pin is sound; the
+# residual SB token UB (#211) is fixed only on phall1's unmerged #212 branch,
+# to adopt if we ever need SB coverage. Upstream issues: rowan#192, #163, #108.
 rowan = { git = "https://github.com/pulseengine/rowan.git", branch = "fix/miri-soundness-v2" }
 
 # Markdown rendering


### PR DESCRIPTION
## The measured answer to "where do CPU/mem vanish?"

From the #520 run timeline:
- **Peak 15 jobs ran concurrently**, queues ~22 s → the pool *is* using the hardware; capacity isn't the bottleneck.
- **Miri ran 45 m 28 s** — 5× the next-slowest job — as **one `cargo miri test` process**. Miri is a single-threaded interpreter, so it pins **one core for 45 min while the rest of the box is idle**, and hogs the scarce `lean-mem` runner the whole time (that's the "contention" we saw — a symptom, not the cause). The 24 GB is Miri *shadow memory*, not a leak.

So the resources don't vanish — **Miri just can't use them.**

## Fix: `cargo miri nextest run` (process-per-test)

nextest runs each test in its own process → many Miri processes in parallel → the cores get used and wall-time collapses toward the slowest single test.

- `--test-threads 4`: conservative start so concurrent Miri shadow-memory stays under 24 GB; raise once a green run shows real peak-RSS headroom.
- **Same test selection** — the libtest `--skip <m>` list is translated to nextest `-E 'not (test(<m>) | ...)'`. Verified locally: **721 run / 412 excluded**, identical modules.
- Adds a **Show runner resources** step (`nproc`, `free -h`) so the log makes the available CPU/mem explicit.

## What to watch on this PR's CI
- The **Miri** job wall-time (expect ~17–26 min at 4 threads vs 45) and that it stays green.
- The resource-print confirming the box's real cores/RAM.

If 4 threads lands comfortably under memory, I'll raise `--test-threads` in a follow-up to push the wall-time down further (and can then tighten the timeout). Builds on REQ-215; Refs #509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)