### PR TITLE
fix(schema): restore `accepted` to canonical status enum (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,19 @@
 
 ### Fixed
 
+- **REQ-162 / #522 — restore `accepted` to the canonical status enum.** v0.16.0
+  declared the canonical lifecycle (`draft → … → released` + `deprecated` /
+  `rejected`) but dropped `accepted`, the documented terminal state for
+  `design-decision` / `external-anchor` / requirement-meta artifacts. Downstream
+  stores that followed the documented chain (e.g. the jess hardware-integration
+  store, 12 of 21 errors on upgrade) flipped from PASS to FAIL on the 0.15 → 0.16
+  bump with no migration path. `accepted` is now re-admitted in
+  `schemas/common.yaml`, so stores upgrade cleanly; the `status-allowed-values`
+  guard still fires on genuinely typo'd values (covered by
+  `common_status_accepts_accepted_and_still_rejects_typos`). The wider
+  migration / per-schema enum questions raised in #522 (slices 1 and 3) are
+  tracked separately.
+
 - **REQ-168 / #428 — `rivet bundle --incoming`.** `bundle` built the closure
   from *outgoing* links only, so bundling a requirement (a graph sink —
   everything links *to* it, it links *out* to nothing) returned just the bare

--- a/rivet-core/tests/schema_validation_rules.rs
+++ b/rivet-core/tests/schema_validation_rules.rs
@@ -413,3 +413,75 @@ fn aspice_phase_9_scales_to_100_verifiers() {
         "full validate of 200-artifact store took {elapsed:?}; suspected O(N²) regression"
     );
 }
+
+/// #522 slice 2 regression: `status: accepted` is the documented terminal
+/// state for design-decision / external-anchor / requirement-meta artifacts.
+/// Dropping it from the canonical enum in 0.16.0 flipped existing stores
+/// that followed the documented lifecycle (12 of 21 errors on the jess
+/// store) from PASS to FAIL. Confirm the enum re-admits it and the
+/// `status-allowed-values` rule still fires on a genuinely off-vocabulary
+/// value so the typo-guard isn't widened to "anything goes."
+// rivet: verifies REQ-162
+#[test]
+fn common_status_accepts_accepted_and_still_rejects_typos() {
+    let schema = Schema::merge(&[parse_schema("common"), parse_schema("dev")]);
+
+    // Acceptance bullet 3: introspection surface must agree with the
+    // diagnostic. The status field is a schema-wide base-field
+    // (`schemas/common.yaml` → `base-fields:`); `rivet schema show <type>`
+    // surfaces it via `Schema::base_fields`. That list must include
+    // `accepted`.
+    let status_field = schema
+        .base_fields
+        .iter()
+        .find(|f| f.name == "status")
+        .expect("status must be declared as a common.yaml base-field");
+    let allowed = status_field
+        .allowed_values
+        .as_ref()
+        .expect("status base-field must declare allowed-values");
+    assert!(
+        allowed.iter().any(|v| v == "accepted"),
+        "common.yaml status enum must include `accepted` (documented terminal \
+         state for design-decision / external-anchor / requirement-meta); got {allowed:?}"
+    );
+
+    let mut store = Store::default();
+    // Acceptance bullet 2: a design-decision with `status: accepted` must
+    // validate cleanly — no `allowed-values` / `status-allowed-values`
+    // diagnostic on it.
+    store.upsert(artifact("DD-ACCEPTED", "design-decision", "accepted", &[]));
+    // Negative control: a typo'd status must still fire the rule so the
+    // canonical-enum guard isn't accidentally widened.
+    store.upsert(artifact("DD-TYPO", "design-decision", "implmented", &[]));
+
+    let graph = LinkGraph::build(&store, &schema);
+    let diags = validate(&store, &schema, &graph);
+
+    let dd_accepted_status_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| {
+            d.artifact_id.as_deref() == Some("DD-ACCEPTED")
+                && (d.rule == "allowed-values" || d.rule == "status-allowed-values")
+        })
+        .collect();
+    assert!(
+        dd_accepted_status_diags.is_empty(),
+        "design-decision with `status: accepted` must not produce a status \
+         allowed-values diagnostic; got {dd_accepted_status_diags:#?}"
+    );
+
+    let dd_typo_status_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| {
+            d.artifact_id.as_deref() == Some("DD-TYPO")
+                && (d.rule == "allowed-values" || d.rule == "status-allowed-values")
+        })
+        .collect();
+    assert_eq!(
+        dd_typo_status_diags.len(),
+        1,
+        "design-decision with a typo'd status must still fire the status \
+         allowed-values guard exactly once; got {dd_typo_status_diags:#?}"
+    );
+}

--- a/schemas/common.yaml
+++ b/schemas/common.yaml
@@ -50,6 +50,11 @@ base-fields:
     # (`schemas/aspice.yaml` uses `(= status "released")`) and the
     # tool-qualification defect flow gates. Absent status is allowed (the check
     # only fires when a status is present).
+    # #522: `accepted` is the documented terminal state for design-decision /
+    # external-anchor / requirement-meta artifacts (the lifecycle docs and
+    # downstream agent guidance use it) — kept here so stores that followed
+    # the documented chain `... -> verified -> accepted` don't flip to FAIL
+    # on the 0.15 -> 0.16 bump.
     allowed-values:
       - draft
       - proposed
@@ -57,6 +62,7 @@ base-fields:
       - implemented
       - verified
       - released
+      - accepted
       - deprecated
       - rejected
 


### PR DESCRIPTION
Closes #522 — first slice only (slice 2: re-add `accepted`).

## Why

v0.16.0 declared the canonical status lifecycle in `schemas/common.yaml` (REQ-162, #352, #355, PR #419) but dropped `accepted`, the documented terminal state for `design-decision` / `external-anchor` / requirement-meta artifacts. Stores that followed the published chain `… → verified → accepted` flipped from PASS to FAIL on the 0.15 → 0.16 bump with no migration path — the jess hardware-integration store hit 12 of 21 errors from this alone.

This restores `accepted` to the enum and documents its terminal role in the inline schema comment. It does **not** widen the typo-guard: a genuinely off-vocabulary status (`implmented`) still fires `status-allowed-values`, which the regression test asserts as a negative control.

## Acceptance criteria (from #522)

- [x] **`schemas/common.yaml` canonical status enum re-includes `accepted`** alongside `verified` / `released` / `deprecated` / `rejected`, with a one-line schema comment naming `accepted` as the documented terminal state for design-decision / external-anchor / requirement-meta artifacts (`schemas/common.yaml:43-67`).
- [x] **Regression fixture: a project store with a `design-decision` whose `status: accepted` validates cleanly** — `common_status_accepts_accepted_and_still_rejects_typos` in `rivet-core/tests/schema_validation_rules.rs` builds a `Store` with `DD-ACCEPTED` (status `accepted`) and `DD-TYPO` (status `implmented`), runs `validate(...)`, and asserts the former produces zero `status-allowed-values` / `allowed-values` diagnostics while the latter still produces exactly one.
- [x] **`rivet schema info common` / `rivet schema show common` prints `accepted` in the allowed-values list** — the test also asserts that `Schema::base_fields` (the introspection surface that `schema info` / `schema show` query) reports `accepted` among the `status` field's `allowed-values`, so the diagnostic and the introspection layer can't drift again. (CLI surfacing of base-field allowed-values in `schema show TYPE` output is a separate UX gap that doesn't block slice 2.)
- [x] **`rivet validate` PASS on the rivet repo** — `Result: PASS (271 warnings)` post-rebase against `origin/main` (`e60a3a9`).
- [x] **`cargo test -p rivet-core --test schema_validation_rules` green** — all 6 tests pass including the new regression (`common_status_accepts_accepted_and_still_rejects_typos ... ok`). `cargo test -p rivet-cli --bin rivet`: 125/125 pass. (Note: the pre-existing `rivet_core::externals::tests::is_working_tree_dirty_detects_tracked_edits_not_untracked` lib test fails on this sandbox **on a clean checkout of main as well**, so it's a sandbox flake unrelated to this slice.)
- [x] **`cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean** (exit 0; only pre-existing MSRV-mismatch meta warning from `clippy.toml`).
- [x] **Commit trailer**: `Fixes: REQ-162` + `Refs: #352, #419, #522` (on `117e9c7`).

## Out of scope (per #522 body — file separately)

- **Slice 1**: `rivet migrate` status-remap / `validate --fix` with a default-mapping policy for `open` / `resolved` from `ai-found-defect` — needs a distinct command and a policy decision.
- **Slice 3**: per-schema status enums so `ai-found-defect` can keep its `open` / `triaged` / `resolved` triage vocabulary distinct from the document lifecycle — schema-level discriminator vs. dedicated enum is its own design call.
- The `rivet 0.16.0 upgrade` docs page.

## Why this is a draft

The hard rule in the triage workflow requires consulting <https://pulseengine.eu/blog/> before opening a PR — process posts there are authoritative. The blog has been HTTP 503 throughout this run (and across the recent triage threads on #420, #522, #516, …, per the carried side-rail note). I couldn't verify against the published process posts, so the PR is parked as a draft pending maintainer review against that guidance once the blog is reachable.

Slice 2 itself is otherwise complete: one-line schema addition + 6-line comment, regression test (positive + negative control), CHANGELOG entry.

---
_Generated by [Claude Code](https://claude.ai/code) — issue-triage agent run 2026-06-10._

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhudovHoKwey4MokN6C89v)_