### PR TITLE
ci: move mutants-cli off lean-mem to rust-cpu (#523)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,10 +588,16 @@ jobs:
   # fast and per-push while the heavy 16-shard rivet-core sweep moved to nightly
   # (#498). Tuning rationale (timeout 30 / --jobs 2) is documented on
   # mutants-core's identical step.
+  # Runner pool: `rust-cpu`, not `lean-mem` (#523). `rivet-cli` is the small
+  # crate with `--jobs 2`; rust-cpu's 16 G `MemoryHigh` headroom + 7 idle
+  # runners handle it comfortably, and pinning a per-PR job to the 4-runner
+  # lean-mem pool was starving Miri/Verus (median lean-mem wait ~64 min,
+  # p95 ~23 h on a 14-day audit). Keep `lean-mem` reserved for the genuinely
+  # RAM-bound gating jobs (Miri, Verus) and the nightly mutants-core fan-out.
   mutants-cli:
     name: Mutation Testing (rivet-cli)
     needs: [test]
-    runs-on: [self-hosted, linux, x64, lean-mem]
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #523 — implements the "Recommended fix (cheapest first)" option 1 from the issue body (author's stated "strongly preferred" choice).

## Why

`mutants-cli` was running per-PR + per-push pinned to the 4-runner `lean-mem` pool. The 14-day audit in #523 measured it as the single largest consumer of that class (488 instances over 14 days against 4 runners), and the operator-visible consequence was that Miri (~17 h median wait, 43% fail rate) and Verus (~18 h median wait, 94% fail rate) were starving — queueing for a runner against the per-PR mutation churn while `rust-cpu` sat 86% idle.

This PR makes the one-line runner-pool change the issue body recommends and expands the surrounding comment block so the rationale survives drift.

## Acceptance criteria (from #523)

- [x] **`mutants-cli` no longer runs on `lean-mem`.** `runs-on:` on `.github/workflows/ci.yml:597` now resolves to `[self-hosted, linux, x64, rust-cpu]`. Grep confirms `mutants-cli` is the only `lean-mem` user removed; Miri (line 416), nightly `mutants-core` (line 496), and the other comment-only references to `lean-mem` are untouched.
- [ ] **lean-mem median job wait drops back under a few minutes; Miri/Verus stop hitting multi-hour queues.** This is environmental: only verifiable by operator observation against the runner pool after this lands. Once merged, the same query that produced the audit table in #523 (`gh api ... jobs?status=completed`, filter by `runner_labels`) should show the lean-mem median fall back from ~64 min to single-digit minutes within a day or two.

## Why this is a draft

Same reason as #525 (and as carried across the recent triage threads): the hard triage rule requires consulting <https://pulseengine.eu/blog/> before opening a PR, and the blog has been HTTP 503 throughout this run. The fix itself matches the author's "strongly preferred" option in the issue body verbatim, so the draft state is purely about clearing the workflow-guidance hard rule once the blog is reachable.

The change is small, comment-heavy, and reversible:

```diff
   mutants-cli:
     name: Mutation Testing (rivet-cli)
     needs: [test]
-    runs-on: [self-hosted, linux, x64, lean-mem]
+    runs-on: [self-hosted, linux, x64, rust-cpu]
```
(plus a 6-line comment block above documenting why this pool, so drift doesn't quietly re-pin.)

## Related

- #509 — self-hosted pool fragility / single-point-of-failure theme.
- #521 — Miri parallelization via nextest, also targeting lean-mem starvation from the *consumer* side; complementary to this change (this removes a starver; #521 makes Miri use its share of lean-mem more efficiently).

---
_Generated by [Claude Code](https://claude.ai/code) — issue-triage agent run 2026-06-10._

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhudovHoKwey4MokN6C89v)_