### PR TITLE
fix(cli): next-id/add hard-fail on a parse-broken source (REQ-216, #518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **REQ-216 / #518 — mutating commands refuse on a parse-broken source.** A
+  source file dropped from the graph by a YAML parse error (merge conflict,
+  manual edit, or an unquoted-colon title pre-REQ-198) is invisible to the
+  loader, so `next-id` allocated IDs against the *partial* store — colliding
+  with the unparsed file's artifacts (the report saw five artifacts share one
+  id) — and `add` exited 0 on the error. `rivet next-id` and `rivet add` now
+  hard-fail (non-zero) with an actionable message when any source failed to
+  parse; read-only commands still warn-and-continue.
+
 ## [0.16.0] - 2026-06-09
 
 ### Added

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6796,3 +6796,45 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-10T08:00:00Z
+
+  - id: REQ-216
+    type: requirement
+    title: "Mutating / ID-allocating commands hard-fail when a source file failed to parse (no silent skip → duplicate-ID corruption) (#518)"
+    status: implemented
+    description: |
+      Finding (#518, spar release planning). One unquoted colon in a title made
+      `rivet add` write invalid YAML (fixed separately by REQ-198 escaping), but
+      the deeper, still-live damage was the resilience failure: a source file
+      dropped from the graph by ANY parse error (merge conflict, manual edit,
+      another tool) is invisible to the loader, yet `next-id` kept computing
+      against the partial store and `add` kept allocating — so it handed out IDs
+      that COLLIDE with the unparsed file's artifacts (the report saw five
+      artifacts all allocated the same id), and `add` exited 0 on the error.
+
+      Read-only commands may tolerate a parse-skip (warn + continue); MUTATING /
+      ID-allocating commands must REFUSE. Added `ProjectContext::ensure_no_parse_skips`
+      (reuses the existing parse-skip scan behind `warn_parse_error_skips`) and
+      call it in `cmd_next_id` and `cmd_add` right after load, before any ID is
+      allocated or any file is written. It bails non-zero with an actionable
+      message pointing at `rivet validate`.
+
+      Acceptance:
+        - In a project whose `artifacts/*.yaml` has a YAML parse error,
+          `rivet next-id <type>` and `rivet add --type <type> --title ...` both
+          exit non-zero with a message containing "refusing" and "parse".
+        - On a clean store both still succeed (no behavior change).
+        - `cargo test -p rivet-cli --test cli_commands` passes (incl. the new
+          `mutating_commands_refuse_on_parse_broken_source`).
+        - `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.
+        - `rivet validate` on the rivet repo still PASS.
+    tags: [cli, add, next-id, data-integrity, dogfooding]
+    fields:
+      priority: must
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-007
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-13T15:00:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -14054,12 +14054,12 @@ impl ProjectContext {
     /// skips (the existing REQ-062 channel) and prints a concise loud block to
     /// stderr pointing at `rivet validate`. No-op when nothing was skipped;
     /// emitted regardless of log level because it signals data loss.
-    fn warn_parse_error_skips(&self, cli: &Cli) {
-        // Re-walk each `generic` source's directory and classify failed files
-        // via `scan_skipped_files` directly (rather than
-        // `load_artifacts_with_skips`, which would re-run `load_artifacts` and
-        // re-emit its per-file `log::warn!`). This adds the consolidated
-        // summary without doubling the existing warning noise.
+    /// Re-walk each `generic` source's directory and return the files dropped
+    /// from the loaded graph by a PARSE error. Used both for the read-only
+    /// warning and for the mutating-command hard-fail guard. `scan_skipped_files`
+    /// (rather than `load_artifacts_with_skips`) avoids re-emitting the per-file
+    /// `log::warn!`.
+    fn parse_error_skips(&self, cli: &Cli) -> Vec<rivet_core::SkippedFile> {
         let mut skips: Vec<rivet_core::SkippedFile> = Vec::new();
         for source in &self.config.sources {
             if !matches!(source.format.as_str(), "generic" | "generic-yaml") {
@@ -14074,6 +14074,11 @@ impl ProjectContext {
                 );
             }
         }
+        skips
+    }
+
+    fn warn_parse_error_skips(&self, cli: &Cli) {
+        let skips = self.parse_error_skips(cli);
         if skips.is_empty() {
             return;
         }
@@ -14085,6 +14090,30 @@ impl ProjectContext {
         for s in &skips {
             eprintln!("  - {}: {}", s.path.display(), s.reason);
         }
+    }
+
+    /// Hard-fail guard for MUTATING / ID-allocating commands (#518). A source
+    /// file dropped by a parse error is invisible to the link graph, so
+    /// `next-id` would compute against a partial store and hand out an ID that
+    /// collides with the unparsed file's artifacts — and `add`/`modify` would
+    /// write against that partial view. Read-only commands tolerate this (warn
+    /// + continue); anything that allocates IDs or writes must REFUSE.
+    fn ensure_no_parse_skips(&self, cli: &Cli, action: &str) -> Result<()> {
+        let skips = self.parse_error_skips(cli);
+        if skips.is_empty() {
+            return Ok(());
+        }
+        let list = skips
+            .iter()
+            .map(|s| format!("  - {}: {}", s.path.display(), s.reason))
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!(
+            "refusing to {action}: {} artifact source(s) failed to parse and are NOT loaded, \
+             so a new ID could collide with artifacts inside them (#518). Fix the parse \
+             error(s) first — `rivet validate` shows details:\n{list}",
+            skips.len()
+        )
     }
 
     /// Load project with artifacts, schema, and link graph.
@@ -14661,6 +14690,9 @@ fn cmd_next_id(
     use rivet_core::mutate;
 
     let ctx = ProjectContext::load(cli)?;
+    // #518: a parse-broken source is invisible here, so allocating an ID
+    // against this partial store would collide with the unparsed artifacts.
+    ctx.ensure_no_parse_skips(cli, "allocate an ID")?;
     let store = ctx.store;
 
     // The positional `target` is a shorthand for --type (it routes through
@@ -14737,6 +14769,10 @@ fn cmd_add(
     });
 
     let ctx = ProjectContext::load(cli)?;
+    // #518: refuse to add when a source failed to parse — otherwise the new ID
+    // is allocated against a partial store (collides with the unparsed file's
+    // artifacts) and we'd append to a possibly-broken file.
+    ctx.ensure_no_parse_skips(cli, "add an artifact")?;
     let (store, schema) = (ctx.store, ctx.schema);
 
     // Resolve prefix for the type

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6326,3 +6326,76 @@ fn variant_solve_accepts_bare_variant_name() {
         String::from_utf8_lossy(&by_path.stderr)
     );
 }
+
+/// #518: a source file broken by a parse error must make MUTATING / ID-allocating
+/// commands (next-id, add) HARD-FAIL — not silently skip the file and allocate an
+/// ID that collides with its (now-invisible) artifacts.
+#[test]
+fn mutating_commands_refuse_on_parse_broken_source() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dirs])
+        .output()
+        .expect("init");
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // Sanity: next-id succeeds on the clean store.
+    let ok = Command::new(rivet_bin())
+        .args(["--project", dirs, "next-id", "requirement"])
+        .output()
+        .expect("next-id");
+    assert!(
+        ok.status.success(),
+        "next-id should succeed on a clean store"
+    );
+
+    // Corrupt an artifacts source with a YAML parse error (an unquoted colon).
+    let target = std::fs::read_dir(dir.join("artifacts"))
+        .expect("artifacts dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .find(|p| p.extension().map(|x| x == "yaml").unwrap_or(false))
+        .expect("an artifacts yaml");
+    let mut content = std::fs::read_to_string(&target).unwrap();
+    content.push_str("\n  - id: REQ-BROKEN\n    title: bad: unquoted colon\n");
+    std::fs::write(&target, content).unwrap();
+
+    // next-id must now REFUSE (non-zero) and explain why.
+    let nid = Command::new(rivet_bin())
+        .args(["--project", dirs, "next-id", "requirement"])
+        .output()
+        .expect("next-id");
+    assert!(
+        !nid.status.success(),
+        "next-id must hard-fail when a source failed to parse (#518)"
+    );
+    let err = String::from_utf8_lossy(&nid.stderr);
+    assert!(
+        err.contains("refusing") && err.contains("parse"),
+        "next-id refusal must explain the parse skip; got: {err}"
+    );
+
+    // add must also REFUSE.
+    let add = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "add",
+            "--type",
+            "requirement",
+            "--title",
+            "x",
+        ])
+        .output()
+        .expect("add");
+    assert!(
+        !add.status.success(),
+        "add must hard-fail when a source failed to parse (#518)"
+    );
+}


### PR DESCRIPTION
Closes #518.

## Triage
The original repro — an unquoted-colon title corrupting the file (**failure 1**) — is **already fixed on main** (REQ-198 escapes special-char titles; verified: 7 adversarial titles + colon-descriptions all round-trip to valid YAML). But #518's deeper teeth — **failures 2 & 3** — are still live and are the data-corruption vector:

- A source file dropped from the graph by **any** parse error (merge conflict, manual edit, another tool) is invisible to the loader.
- `next-id` kept computing against the **partial** store → handed out an id colliding with the unparsed file's artifacts (the report saw *five* artifacts share one id).
- `add` exited **0** on the error.

## Fix
Read-only commands may warn-and-continue; **mutating / ID-allocating commands must refuse.** New `ProjectContext::ensure_no_parse_skips` (reuses the existing parse-skip scan) is called in `cmd_next_id` and `cmd_add` after load, before any id is allocated or file written:

```
$ rivet next-id requirement        # with a parse-broken artifacts file
error: refusing to allocate an ID: 1 artifact source(s) failed to parse and are
NOT loaded, so a new ID could collide with artifacts inside them (#518). Fix the
parse error(s) first — `rivet validate` shows details:
  - artifacts/requirements.yaml: YAML parse error: mapping values are not allowed …
```
Both `next-id` and `add` now exit non-zero; clean stores are unaffected.

## Verification (REQ-216 acceptance)
- New `mutating_commands_refuse_on_parse_broken_source` test; full `cli_commands` suite **130 passed**.
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean; `rivet validate` PASS.

Follow-up worth noting: the same guard could extend to `modify`/`link`/`unlink` (they target existing ids, so they fail-closed "not found" rather than corrupt — lower priority). Scoped here to the two ID-allocating commands the report hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)