### PR TITLE
fix(variant): check --variant accepts the form init scaffolds (REQ-217, #514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **REQ-217 / #514 — `variant check` accepts the form `variant init` writes.**
+  `rivet variant init` scaffolds a `variant:`-wrapped bindings file (and prints
+  the `variant check --variant <that file>` command to run), but `check` parsed
+  `--variant` strictly as the flat `{name, selects}` form and rejected it with
+  `missing field 'name'`. `VariantConfig::from_yaml_str` now accepts both forms
+  across every `--variant` path, so the init→check happy path works.
+
 ## [0.16.0] - 2026-06-09
 
 ### Added

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6796,3 +6796,43 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-10T08:00:00Z
+
+  - id: REQ-217
+    type: requirement
+    title: "`rivet variant check --variant` accepts the wrapped binding form that `rivet variant init` scaffolds (#514)"
+    status: implemented
+    description: |
+      Finding (#514, kiln variant setup). `rivet variant init <name>` scaffolds
+      `bindings/<name>.yaml` in the feature-model-bindings form — a top-level
+      `variant: { name, selects }` wrapper plus a `bindings:` block — and even
+      prints `rivet variant check --model … --variant bindings/<name>.yaml` as
+      the next step. But `variant check` parsed `--variant` strictly as the flat
+      `VariantConfig` (`name:`/`selects:` at top level), so it rejected init's
+      own output with `missing field 'name'`. The scaffold and the checker
+      disagreed, breaking the init→check happy path.
+
+      Fix: `VariantConfig::from_yaml_str` accepts EITHER form — flat, or the
+      `variant:`-wrapped bindings form (extract the `variant:` block; the
+      `bindings:` block is ignored for a selection check). Wired into every
+      `--variant <file>` parse site (check, check-all, list --variant, and the
+      resolve_variant_arg paths). Malformed configs still error.
+
+      Acceptance:
+        - `rivet variant init kiln` then the exact `rivet variant check --model
+          … --variant bindings/kiln.yaml` it prints exits 0 (PASS).
+        - A flat `{name, selects}` variant file still checks correctly.
+        - `VariantConfig::from_yaml_str` unit test covers flat + wrapped + a
+          malformed (error) case.
+        - `cargo test -p rivet-core` + `-p rivet-cli --test cli_commands` pass.
+        - `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.
+    tags: [cli, variant, feature-model, dx, dogfooding]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-083
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-13T15:30:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -5156,8 +5156,8 @@ fn cmd_validate(
 
             let variant_yaml = std::fs::read_to_string(vp)
                 .with_context(|| format!("reading variant config {}", vp.display()))?;
-            let vc: rivet_core::feature_model::VariantConfig =
-                serde_yaml::from_str(&variant_yaml).context("parsing variant config")?;
+            let vc = rivet_core::feature_model::VariantConfig::from_yaml_str(&variant_yaml)
+                .context("parsing variant config")?;
 
             let resolved = rivet_core::feature_model::solve(&fm, &vc).map_err(|errs| {
                 let msgs: Vec<String> = errs.iter().map(|e| format!("{e}")).collect();
@@ -5961,7 +5961,7 @@ fn resolve_variant_arg(
     if direct.is_file() {
         let yaml = std::fs::read_to_string(&direct)
             .with_context(|| format!("reading {}", direct.display()))?;
-        let vc: rivet_core::feature_model::VariantConfig = serde_yaml::from_str(&yaml)
+        let vc = rivet_core::feature_model::VariantConfig::from_yaml_str(&yaml)
             .with_context(|| format!("parsing variant config {}", direct.display()))?;
         return Ok((direct, vc.name));
     }
@@ -5972,7 +5972,7 @@ fn resolve_variant_arg(
     if candidate.is_file() {
         let yaml = std::fs::read_to_string(&candidate)
             .with_context(|| format!("reading {}", candidate.display()))?;
-        let vc: rivet_core::feature_model::VariantConfig = serde_yaml::from_str(&yaml)
+        let vc = rivet_core::feature_model::VariantConfig::from_yaml_str(&yaml)
             .with_context(|| format!("parsing variant config {}", candidate.display()))?;
         // Sanity check: the file's `name:` should equal the lookup
         // name. If it doesn't, prefer the on-disk name (it's the
@@ -12840,8 +12840,8 @@ fn cmd_variant_check(
 
     let variant_yaml = std::fs::read_to_string(variant_path)
         .with_context(|| format!("reading {}", variant_path.display()))?;
-    let variant: rivet_core::feature_model::VariantConfig =
-        serde_yaml::from_str(&variant_yaml).context("parsing variant config")?;
+    let variant = rivet_core::feature_model::VariantConfig::from_yaml_str(&variant_yaml)
+        .context("parsing variant config")?;
 
     match rivet_core::feature_model::solve(&model, &variant) {
         Ok(resolved) => {
@@ -13039,8 +13039,8 @@ fn cmd_variant_solve(
 
     let variant_yaml = std::fs::read_to_string(variant_path)
         .with_context(|| format!("reading {}", variant_path.display()))?;
-    let variant: rivet_core::feature_model::VariantConfig =
-        serde_yaml::from_str(&variant_yaml).context("parsing variant config")?;
+    let variant = rivet_core::feature_model::VariantConfig::from_yaml_str(&variant_yaml)
+        .context("parsing variant config")?;
 
     let resolved = rivet_core::feature_model::solve(&model, &variant).map_err(|errs| {
         let msgs: Vec<String> = errs.iter().map(|e| format!("{e:?}")).collect();
@@ -13170,8 +13170,8 @@ fn load_and_solve_variant(
     let model = load_feature_model_via_project(model_path)?;
     let variant_yaml = std::fs::read_to_string(variant_path)
         .with_context(|| format!("reading {}", variant_path.display()))?;
-    let variant: rivet_core::feature_model::VariantConfig =
-        serde_yaml::from_str(&variant_yaml).context("parsing variant config")?;
+    let variant = rivet_core::feature_model::VariantConfig::from_yaml_str(&variant_yaml)
+        .context("parsing variant config")?;
     let resolved = rivet_core::feature_model::solve(&model, &variant).map_err(|errs| {
         let msgs: Vec<String> = errs.iter().map(|e| format!("{e:?}")).collect();
         anyhow::anyhow!(
@@ -13496,8 +13496,8 @@ fn cmd_variant_manifest(
 
     let variant_yaml = std::fs::read_to_string(variant_path)
         .with_context(|| format!("reading {}", variant_path.display()))?;
-    let variant: rivet_core::feature_model::VariantConfig =
-        serde_yaml::from_str(&variant_yaml).context("parsing variant config")?;
+    let variant = rivet_core::feature_model::VariantConfig::from_yaml_str(&variant_yaml)
+        .context("parsing variant config")?;
 
     let binding_yaml = std::fs::read_to_string(binding_path)
         .with_context(|| format!("reading {}", binding_path.display()))?;
@@ -13598,7 +13598,7 @@ fn cmd_variant_matrix(
         for path in paths {
             let yaml = std::fs::read_to_string(&path)
                 .with_context(|| format!("reading {}", path.display()))?;
-            let vc: rivet_core::feature_model::VariantConfig = serde_yaml::from_str(&yaml)
+            let vc = rivet_core::feature_model::VariantConfig::from_yaml_str(&yaml)
                 .with_context(|| format!("parsing variant file {}", path.display()))?;
             if !existing.insert(vc.name.clone()) {
                 anyhow::bail!(

--- a/rivet-core/src/feature_model.rs
+++ b/rivet-core/src/feature_model.rs
@@ -153,6 +153,32 @@ pub struct VariantConfig {
     pub selects: Vec<String>,
 }
 
+impl VariantConfig {
+    /// Parse a variant config from EITHER the flat form (`name:` / `selects:`
+    /// at the top level) OR the feature-model-bindings form that `rivet
+    /// variant init` scaffolds, where the same fields live under a top-level
+    /// `variant:` key alongside `bindings:`. Accepting both lets `rivet
+    /// variant check --variant <file>` work on the file `init` actually writes
+    /// (#514): the two used to disagree (init wrapped, check expected flat).
+    pub fn from_yaml_str(yaml: &str) -> Result<Self, serde_yaml::Error> {
+        match serde_yaml::from_str::<VariantConfig>(yaml) {
+            Ok(vc) => Ok(vc),
+            Err(flat_err) => {
+                #[derive(Deserialize)]
+                struct Wrapped {
+                    variant: VariantConfig,
+                }
+                // Fall back to the wrapped form; if that also fails, surface the
+                // flat error — it's the more direct diagnostic for a config the
+                // caller likely intended as flat.
+                serde_yaml::from_str::<Wrapped>(yaml)
+                    .map(|w| w.variant)
+                    .map_err(|_| flat_err)
+            }
+        }
+    }
+}
+
 /// Origin of a feature in a resolved variant — why did the solver
 /// include it in the effective set?
 ///
@@ -1634,6 +1660,27 @@ pub fn load_variant_configs_from_dir(dir: &std::path::Path) -> Result<Vec<Varian
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #514: `VariantConfig::from_yaml_str` must accept both the flat form and
+    // the `variant:`-wrapped feature-model-bindings form that `rivet variant
+    // init` scaffolds, so init→check stops disagreeing.
+    #[test]
+    fn variant_config_accepts_flat_and_wrapped_forms() {
+        let flat = "name: a\nselects: [x, y]\n";
+        let vc = VariantConfig::from_yaml_str(flat).expect("flat form must parse");
+        assert_eq!(vc.name, "a");
+        assert_eq!(vc.selects, ["x", "y"]);
+
+        // The exact shape `rivet variant init` writes: variant: wrapper +
+        // a bindings: block (which the variant check ignores).
+        let wrapped = "variant:\n  name: kiln\n  selects: [telemetry]\nbindings:\n  telemetry:\n    artifacts: []\n";
+        let vc = VariantConfig::from_yaml_str(wrapped).expect("wrapped form must parse");
+        assert_eq!(vc.name, "kiln");
+        assert_eq!(vc.selects, ["telemetry"]);
+
+        // A genuinely malformed config still errors (no silent acceptance).
+        assert!(VariantConfig::from_yaml_str("selects: [x]\n").is_err());
+    }
 
     fn vehicle_model_yaml() -> &'static str {
         r#"


### PR DESCRIPTION
Closes #514.

## Bug
`rivet variant init <name>` scaffolds `bindings/<name>.yaml` in the feature-model-bindings form (`variant: { name, selects }` + `bindings:`) and even prints `rivet variant check --model … --variant bindings/<name>.yaml` as the next step. But `check` parsed `--variant` strictly as the **flat** `VariantConfig` (`name:`/`selects:` top-level), so it rejected init's own output:

```
error: parsing variant config bindings/kiln.yaml: missing field `name` at line 7 column 1
```

## Fix
`VariantConfig::from_yaml_str` accepts **either** form — flat, or the `variant:`-wrapped bindings form (extracts the `variant:` block; the `bindings:` block is irrelevant to a selection check). Wired into all six `--variant`/variant-file parse sites (`check`, `check-all`, `list --variant`, and the `resolve_variant_arg` paths) so the behaviour is consistent. Malformed configs still error.

```console
$ rivet variant init kiln
$ rivet variant check --model feature-model.yaml --variant bindings/kiln.yaml
Variant 'kiln': PASS          # was: missing field `name`
```

## Verification (REQ-217 acceptance)
- init→check happy path PASSes; a flat variant file still checks.
- New `variant_config_accepts_flat_and_wrapped_forms` unit test (flat + wrapped + malformed-errors).
- `cargo test -p rivet-core` (55 feature_model) + `-p rivet-cli --test cli_commands` (130) pass; fmt + clippy clean; `rivet validate` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)