### PR TITLE
release(v0.16.1): #514 + #518 fixes (gale unblock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-06-14
+
 ### Fixed
 
 - **REQ-217 / #514 — `variant check` accepts the form `variant init` writes.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch release so downstream **gale** can consume the two fixes it's waiting on:

- **#518 (REQ-216)** — `rivet next-id`/`add` now **hard-fail** on a parse-broken source instead of silently skipping it and allocating duplicate IDs.
- **#514 (REQ-217)** — `rivet variant check --variant` accepts the `variant:`-wrapped form that `variant init` scaffolds (init→check happy path).

Both are already merged to main (#527, #528). This bumps the version + finalizes `CHANGELOG [0.16.1]`.

`rivet validate` PASS; `rivet docs check` PASS (VersionConsistency — all version files at 0.16.1).

Note: the 0.16.0 status-enum regression (#522) is **not** in this patch — its fix (#525) is still a draft; it'll ride a later patch. v0.16.1 is a strict improvement over v0.16.0 and doesn't affect that issue.

Tagging `v0.16.1` after merge triggers the release pipeline (GitHub Release + SBOM/SLSA + npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)