### PR TITLE
fix(next-id): honor IDs claimed in git history, never reissue a burned ID (#479)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6877,3 +6877,54 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-13T15:30:00Z
+
+  - id: REQ-218
+    type: requirement
+    title: "`rivet next-id` honors IDs claimed in git history, never reissuing a reverted/in-flight ID (#479)"
+    status: implemented
+    description: |
+      Finding (#479, hourly dogfooding loop). `next-id`/`add` allocated the next
+      ID by scanning only the working tree, so in any multi-branch or
+      reverted-commit workflow they handed out IDs already claimed elsewhere —
+      producing two artifacts with the same ID. Verified in-tree: REQ-209 was
+      claimed by a commit, reverted (#502), and the next allocation reissued
+      REQ-209 against a divergent definition. Distinct from #422 (textual EOF
+      conflicts): this is logical ID collision even when the two artifacts live
+      in different files and never textually conflict.
+
+      Fix: ID allocation now also considers IDs claimed in git history. The CLI
+      harvests `{prefix}-N` IDs from every ref (`git log --all`), counting an ID
+      only in an *allocation context* — a traceability trailer line
+      (`Implements:`/`Fixes:`/`Verifies:`/`Satisfies:`/`Refs:`/…) or a
+      parenthetical subject tag (`… (REQ-213, #510)`) — so free-prose mentions
+      (`REQ-001 → REQ-999`) never poison allocation. rivet-core stays IO-free:
+      the new `mutate::next_id_considering(store, prefix, extra_ids)` raises the
+      floor from the supplied burned IDs while keeping the store's own zero-pad
+      width. A skip past the working-tree maximum prints an explanatory stderr
+      note. Best-effort and overridable: outside a git repo, or with
+      `RIVET_NEXTID_NO_GIT=1`, behavior falls back to the working tree only
+      (the REQ-051 hook/CI model — tooling assists, never gates local work).
+
+      Acceptance:
+        - In a git repo where a commit trailer claims `REQ-994` but no such
+          artifact exists in the tree, `rivet next-id requirement` returns
+          `REQ-995` (skips the burned ID) and emits a stderr note.
+        - `RIVET_NEXTID_NO_GIT=1 rivet next-id requirement` ignores git history
+          and allocates from the working-tree maximum.
+        - A free-prose `REQ-999` mention in an unrelated commit body does NOT
+          raise the floor (only trailer / parenthetical IDs count).
+        - `mutate::next_id_considering` unit test covers burned-above,
+          burned-below, other-prefix, and width cases.
+        - `cargo test -p rivet-core` + `-p rivet-cli --test cli_commands` pass.
+        - `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.
+    tags: [cli, next-id, traceability, git, dx, dogfooding]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-031
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-14T12:00:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -11872,6 +11872,96 @@ fn git_in(project: &Path, args: &[&str]) -> Result<std::process::Output> {
         .with_context(|| format!("running git {}", args.join(" ")))
 }
 
+/// Trailer keys that record an artifact-ID *allocation* in a commit message
+/// (the project's mandated traceability trailers — see CLAUDE.md). An ID on one
+/// of these lines is a real claim; an ID in free prose ("changed target
+/// REQ-001 → REQ-999") is not.
+const ALLOC_TRAILER_KEYS: &[&str] = &[
+    "Implements",
+    "Fixes",
+    "Verifies",
+    "Satisfies",
+    "Refs",
+    "Closes",
+    "Resolves",
+    "Depends",
+    "Relates",
+    "Trace",
+];
+
+/// #479: harvest artifact IDs of the given `prefix` that have been *claimed in
+/// git history* but may be absent from the working tree — IDs burned by an open
+/// PR/branch or by a commit that was later reverted (the REQ-209 trap that bit
+/// this very project). We scan every commit reachable from any ref (`--all`, so
+/// local branches AND fetched remote-tracking refs), but count an ID as claimed
+/// only in an *allocation context*: a traceability trailer line (`Implements:
+/// REQ-994`, `Fixes: REQ-12`), or a parenthetical subject tag (`feat(schema): …
+/// (REQ-213, #510)`). Free-prose mentions are deliberately ignored, or a commit
+/// that merely discusses `REQ-99999` as an example would poison every future
+/// allocation.
+///
+/// Over-claiming (leaving an ID gap) is the safe failure mode; under-claiming
+/// risks two divergent branches defining the same ID. Returns an empty vec when
+/// not in a git repo, when git is unavailable, or when `RIVET_NEXTID_NO_GIT` is
+/// set — git awareness is best-effort, never a hard dependency (the REQ-051
+/// hook/CI model: tooling assists, it does not gate local work).
+fn git_claimed_ids(project: &Path, prefix: &str) -> Vec<String> {
+    if std::env::var_os("RIVET_NEXTID_NO_GIT").is_some() {
+        return Vec::new();
+    }
+    let out = match git_in(project, &["log", "--all", "--format=%B"]) {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    let text = String::from_utf8_lossy(&out.stdout);
+    let id_re = match regex::Regex::new(&format!(r"{}-\d+", regex::escape(prefix))) {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut ids: Vec<String> = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        let is_trailer = ALLOC_TRAILER_KEYS.iter().any(|k| {
+            trimmed
+                .strip_prefix(k)
+                .is_some_and(|rest| rest.trim_start().starts_with(':'))
+        });
+        if is_trailer {
+            // The whole trailer value is an allocation list: take every ID.
+            ids.extend(id_re.find_iter(line).map(|m| m.as_str().to_string()));
+        } else {
+            // Otherwise only IDs that immediately follow a `(` (subject tags).
+            for (idx, m) in id_re.find_iter(line).map(|m| (m.start(), m)) {
+                if line[..idx].trim_end().ends_with('(') {
+                    ids.push(m.as_str().to_string());
+                }
+            }
+        }
+    }
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// Allocate the next ID for `prefix`, honoring IDs burned in git history
+/// (#479). Emits a one-line stderr note when a burned ID forces the allocation
+/// past the working-tree maximum, so the skip is never silent.
+fn next_id_git_aware(project: &Path, store: &Store, prefix: &str) -> String {
+    let claimed = git_claimed_ids(project, prefix);
+    let with_git = rivet_core::mutate::next_id_considering(store, prefix, &claimed);
+    let tree_only = rivet_core::mutate::next_id(store, prefix);
+    if with_git != tree_only {
+        eprintln!(
+            "note: allocating {prefix} {with_git}, not {tree_only} — higher IDs are \
+             already claimed in git history (an open branch or a reverted commit) \
+             though absent from the working tree. Set RIVET_NEXTID_NO_GIT=1 to \
+             allocate from the working tree only."
+        );
+    }
+    with_git
+}
+
 /// Resolve `--since` default: try `git merge-base origin/main HEAD`, fall
 /// back to `HEAD~50` if the merge-base lookup fails (no origin remote, no
 /// origin/main, shallow clone, etc.).
@@ -14709,7 +14799,7 @@ fn cmd_next_id(
         ),
     };
 
-    let next = mutate::next_id(&store, &resolved_prefix);
+    let next = next_id_git_aware(&cli.project, &store, &resolved_prefix);
 
     if format == "json" {
         let json = serde_json::json!({
@@ -14778,8 +14868,9 @@ fn cmd_add(
     // Resolve prefix for the type
     let prefix = mutate::prefix_for_type(artifact_type, &store);
 
-    // Generate ID
-    let id = mutate::next_id(&store, &prefix);
+    // Generate ID (git-aware: never reissue an ID burned by an open branch or
+    // a reverted commit — #479).
+    let id = next_id_git_aware(&cli.project, &store, &prefix);
 
     // Build fields map
     let mut fields_map: BTreeMap<String, serde_yaml::Value> = BTreeMap::new();

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6399,3 +6399,91 @@ fn mutating_commands_refuse_on_parse_broken_source() {
         "add must hard-fail when a source failed to parse (#518)"
     );
 }
+
+/// #479: next-id must not reissue an ID that is claimed in git history (a
+/// commit trailer / subject) but absent from the working tree — the
+/// reverted-but-burned trap (e.g. REQ-209). Git awareness is best-effort and
+/// can be disabled with RIVET_NEXTID_NO_GIT.
+#[test]
+fn next_id_skips_ids_burned_in_git_history() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dirs])
+        .output()
+        .expect("init");
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // Establish a git repo and commit a message that *claims* a REQ id far above
+    // anything in the working tree, then leave that id absent from the store —
+    // exactly the shape of a reverted commit or an unmerged branch.
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git");
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    git(&["init", "-q"]);
+    git(&["config", "user.email", "t@example.com"]);
+    git(&["config", "user.name", "t"]);
+    git(&["add", "-A"]);
+    git(&[
+        "commit",
+        "-q",
+        "-m",
+        "feat: burn an id\n\nImplements: REQ-994",
+    ]);
+
+    let next_id = |env_no_git: bool| -> (String, String) {
+        let mut cmd = Command::new(rivet_bin());
+        cmd.args(["--project", dirs, "next-id", "requirement"]);
+        if env_no_git {
+            cmd.env("RIVET_NEXTID_NO_GIT", "1");
+        }
+        let out = cmd.output().expect("next-id");
+        assert!(
+            out.status.success(),
+            "next-id must succeed. stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (
+            String::from_utf8_lossy(&out.stdout).trim().to_string(),
+            String::from_utf8_lossy(&out.stderr).to_string(),
+        )
+    };
+
+    // Git-aware: must clear the burned REQ-994 -> REQ-995, with a stderr note.
+    let (id, stderr) = next_id(false);
+    assert_eq!(
+        id, "REQ-995",
+        "next-id must skip past the git-burned REQ-994; got {id}"
+    );
+    assert!(
+        stderr.contains("git history") && stderr.contains("REQ-995"),
+        "a skip must emit an explanatory stderr note; got: {stderr}"
+    );
+
+    // Escape hatch: RIVET_NEXTID_NO_GIT ignores git history entirely, so the
+    // allocation falls back to the (much lower) working-tree maximum.
+    let (bare, _) = next_id(true);
+    assert_ne!(
+        bare, "REQ-995",
+        "RIVET_NEXTID_NO_GIT must allocate from the working tree only, ignoring REQ-994"
+    );
+    assert!(
+        bare.starts_with("REQ-") && bare.as_str() < "REQ-994",
+        "tree-only id must be below the burned id; got {bare}"
+    );
+}

--- a/rivet-core/src/mutate.rs
+++ b/rivet-core/src/mutate.rs
@@ -93,34 +93,54 @@ pub fn prefix_for_type(artifact_type: &str, store: &Store) -> String {
 ///
 /// The prefix should NOT include the trailing dash — it is added automatically.
 pub fn next_id(store: &Store, prefix: &str) -> String {
-    let dash_prefix = format!("{prefix}-");
-    let mut max_num: u32 = 0;
+    next_id_considering(store, prefix, std::iter::empty::<&str>())
+}
 
+/// Like [`next_id`], but also considers a set of externally-claimed IDs when
+/// picking the next free number — IDs that are *not* in the working-tree store
+/// but have nonetheless been burned (e.g. claimed by an open PR/branch or by a
+/// commit that was later reverted). Issue #479: scanning only the local store
+/// hands out IDs already live elsewhere, producing two artifacts with the same
+/// ID. The caller (the CLI) supplies the burned IDs from git history; core
+/// stays IO-free.
+///
+/// `extra_ids` may contain IDs of any prefix and any shape; only those matching
+/// `{prefix}-{number}` contribute. The returned ID's zero-pad width is still
+/// derived from the *store* (the project's own convention), falling back to the
+/// width seen among the extra IDs, then to 3.
+pub fn next_id_considering<I, S>(store: &Store, prefix: &str, extra_ids: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let dash_prefix = format!("{prefix}-");
+
+    let parse_num = |id: &str| -> Option<(u32, usize)> {
+        id.strip_prefix(&dash_prefix)
+            .and_then(|suffix| suffix.parse::<u32>().ok().map(|n| (n, suffix.len())))
+    };
+
+    let mut max_num: u32 = 0;
+    // Width is taken from the store's own IDs first (the project convention).
+    let mut store_width: Option<usize> = None;
     for artifact in store.iter() {
-        if let Some(suffix) = artifact.id.strip_prefix(&dash_prefix) {
-            if let Ok(n) = suffix.parse::<u32>() {
-                if n > max_num {
-                    max_num = n;
-                }
-            }
+        if let Some((n, w)) = parse_num(&artifact.id) {
+            max_num = max_num.max(n);
+            store_width = Some(store_width.map_or(w, |cur: usize| cur.max(w)));
+        }
+    }
+
+    // Burned IDs raise the floor but only contribute width if the store had none.
+    let mut extra_width: Option<usize> = None;
+    for id in extra_ids {
+        if let Some((n, w)) = parse_num(id.as_ref()) {
+            max_num = max_num.max(n);
+            extra_width = Some(extra_width.map_or(w, |cur: usize| cur.max(w)));
         }
     }
 
     let next = max_num + 1;
-    // Determine zero-pad width from existing IDs (default 3)
-    let width = store
-        .iter()
-        .filter_map(|a| a.id.strip_prefix(&dash_prefix))
-        .filter_map(|s| {
-            if s.parse::<u32>().is_ok() {
-                Some(s.len())
-            } else {
-                None
-            }
-        })
-        .max()
-        .unwrap_or(3);
-
+    let width = store_width.or(extra_width).unwrap_or(3);
     format!("{prefix}-{next:0>width$}")
 }
 
@@ -709,6 +729,30 @@ mod tests {
         assert_eq!(next_id(&store, "REQ"), "REQ-003");
         assert_eq!(next_id(&store, "FEAT"), "FEAT-002");
         assert_eq!(next_id(&store, "DD"), "DD-001");
+    }
+
+    // #479: burned IDs (claimed in git history but absent from the working
+    // tree) must raise the allocation floor so next-id never reissues them.
+    // rivet: verifies REQ-031
+    #[test]
+    fn next_id_considering_skips_burned_ids() {
+        let store = make_test_store(); // REQ-001, REQ-002 present -> bare next is REQ-003.
+
+        // A reverted REQ-009 lingers only in git history: skip past it.
+        let burned = ["REQ-009", "FEAT-007", "junk", "REQ-xyz"];
+        assert_eq!(
+            next_id_considering(&store, "REQ", burned),
+            "REQ-010",
+            "must clear the highest burned REQ id, not just the store max"
+        );
+        // Other prefixes are unaffected by REQ burns.
+        assert_eq!(next_id_considering(&store, "DD", burned), "DD-001");
+
+        // Burned below the store max changes nothing.
+        assert_eq!(next_id_considering(&store, "REQ", ["REQ-001"]), "REQ-003");
+
+        // Width follows the store convention even when a burned id is wider.
+        assert_eq!(next_id_considering(&store, "REQ", ["REQ-0042"]), "REQ-043");
     }
 
     // rivet: verifies REQ-031


### PR DESCRIPTION
## What

`rivet next-id` / `rivet add` allocated the next artifact ID by scanning only the **working tree**, so a reverted commit or an in-flight branch would silently reissue an ID already claimed elsewhere — producing two artifacts with the same ID.

Reproduced in-tree: **REQ-209** was claimed by a commit, reverted (#502), and the next allocation reissued REQ-209 against a divergent definition. Distinct from #422 (textual EOF conflicts) — this is *logical* ID collision even when the two artifacts live in different files and never textually conflict.

## How

- **`rivet-core`**: new IO-free `mutate::next_id_considering(store, prefix, extra_ids)` raises the allocation floor from a set of externally-claimed IDs while keeping the store's own zero-pad width. `next_id` is now a thin wrapper.
- **`rivet-cli`**: harvests `{prefix}-N` IDs from `git log --all` (all local + fetched remote refs), counting an ID only in an **allocation context** — a traceability trailer line (`Implements:`/`Fixes:`/`Verifies:`/…) or a parenthetical subject tag (`… (REQ-213, #510)`). Free-prose mentions (`REQ-001 → REQ-999`) are ignored, so an illustrative ID in a commit body never poisons allocation.
- A skip past the working-tree maximum prints an explanatory **stderr note**.
- **Best-effort & overridable**: outside a git repo, when git is unavailable, or with `RIVET_NEXTID_NO_GIT=1`, behavior falls back to the working tree only (REQ-051 hook/CI model — tooling assists, never gates local work).

## Tests

- `next_id_considering_skips_burned_ids` (core): burned-above, burned-below, other-prefix, width cases.
- `next_id_skips_ids_burned_in_git_history` (cli): a trailer-claimed `REQ-994` absent from the tree → `next-id` returns `REQ-995` + stderr note; `RIVET_NEXTID_NO_GIT=1` falls back.
- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean; `rivet validate` PASS.

Closes #479. Filed as REQ-218 (`Verifies: REQ-031`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)