### PR TITLE
docs(npm): first-class npm/npx install path + sync stale package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,22 @@ evidence is born compliant instead of being reverse-engineered later.
 ## Install
 
 ```bash
-# From source (recommended while pre-1.0)
+# Via npm — no Rust toolchain needed; postinstall pulls the prebuilt
+# binary for your platform (macOS/Linux/Windows, x64/arm64).
+npm install -g @pulseengine/rivet        # `rivet` on your PATH
+npx @pulseengine/rivet --help            # …or run it without installing
+
+# From source (Rust toolchain)
 cargo install --path rivet-cli
 
-# Or from a release tag
-curl -L https://github.com/pulseengine/rivet/releases/download/v0.5.0/rivet-x86_64-unknown-linux-gnu.tar.gz | tar xz
-
-# Or via npm (for `npx @pulseengine/rivet mcp` in MCP clients)
-npm install -g @pulseengine/rivet
+# Or grab a prebuilt release binary directly (substitute your platform /
+# the current version — assets are named rivet-vX.Y.Z-<target>)
+curl -L https://github.com/pulseengine/rivet/releases/download/v0.16.1/rivet-v0.16.1-x86_64-unknown-linux-gnu.tar.gz | tar xz
 ```
+
+`npm`/`npx` is the zero-toolchain path — it fetches the same signed
+binary the release ships, so MCP clients can run `npx @pulseengine/rivet
+mcp` without a Rust install.
 
 ## 30-second demo
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,6 +20,20 @@ git push origin vX.Y.Z
 #    cosign-signed SHA256SUMS, GitHub Release page, VS Code Marketplace.
 ```
 
+## Version locations
+
+- **Authoritative:** `Cargo.toml [workspace.package].version` — the
+  release-prep PR bumps this (plus `Cargo.lock` and
+  `vscode-rivet/package.json` for the Marketplace listing).
+- **Workflow-managed, do NOT need a manual bump:** `npm/package.json` and
+  `platform-packages/*/package.json`. `release-npm.yml` rewrites their
+  `version` (and the root's `optionalDependencies`) to the tag at publish
+  time via `jq`, then publishes — the committed values are never read by
+  the published artifact. They are kept roughly in sync only so the repo
+  doesn't *look* abandoned (a stale `0.4.x` here previously caused exactly
+  that confusion); a drift between releases is harmless. The published
+  channel is `npm view @pulseengine/rivet version`, not these files.
+
 ## Why signed tags
 
 The release workflow keys publication off the tag push. An attacker

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/rivet",
-  "version": "0.9.0",
+  "version": "0.16.1",
   "description": "Rivet — SDLC traceability, validation, and MCP server for safety-critical systems (ISO 26262, DO-178C, ASPICE, STPA)",
   "main": "index.js",
   "bin": {
@@ -36,11 +36,11 @@
     "url": "https://github.com/pulseengine/rivet/issues"
   },
   "optionalDependencies": {
-    "@pulseengine/rivet-darwin-arm64": "0.4.1",
-    "@pulseengine/rivet-darwin-x64": "0.4.1",
-    "@pulseengine/rivet-linux-arm64": "0.4.1",
-    "@pulseengine/rivet-linux-x64": "0.4.1",
-    "@pulseengine/rivet-win32-x64": "0.4.1"
+    "@pulseengine/rivet-darwin-arm64": "0.16.1",
+    "@pulseengine/rivet-darwin-x64": "0.16.1",
+    "@pulseengine/rivet-linux-arm64": "0.16.1",
+    "@pulseengine/rivet-linux-x64": "0.16.1",
+    "@pulseengine/rivet-win32-x64": "0.16.1"
   },
   "engines": {
     "node": ">=14"

--- a/platform-packages/darwin-arm64/package.json
+++ b/platform-packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/rivet-darwin-arm64",
-  "version": "0.4.1",
+  "version": "0.16.1",
   "description": "Rivet CLI binary for macOS ARM64 (Apple Silicon)",
   "main": "index.js",
   "os": [

--- a/platform-packages/darwin-x64/package.json
+++ b/platform-packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/rivet-darwin-x64",
-  "version": "0.4.1",
+  "version": "0.16.1",
   "description": "Rivet CLI binary for macOS x64 (Intel)",
   "main": "index.js",
   "os": [

--- a/platform-packages/linux-arm64/package.json
+++ b/platform-packages/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/rivet-linux-arm64",
-  "version": "0.4.1",
+  "version": "0.16.1",
   "description": "Rivet CLI binary for Linux ARM64 (glibc)",
   "main": "index.js",
   "os": [

--- a/platform-packages/linux-x64/package.json
+++ b/platform-packages/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/rivet-linux-x64",
-  "version": "0.4.1",
+  "version": "0.16.1",
   "description": "Rivet CLI binary for Linux x64 (glibc)",
   "main": "index.js",
   "os": [

--- a/platform-packages/win32-x64/package.json
+++ b/platform-packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulseengine/rivet-win32-x64",
-  "version": "0.4.1",
+  "version": "0.16.1",
   "description": "Rivet CLI binary for Windows x64 (MSVC)",
   "main": "index.js",
   "os": [


### PR DESCRIPTION
## Context

Asked whether rivet's npm install is documented or has ever been tried. It turns out the channel is **fully live** — `npm view @pulseengine/rivet version` = `0.16.1`, auto-published by `release-npm.yml` after every release (the 0.16.1 run succeeded). A cold `npx -y @pulseengine/rivet@0.16.1 --version` prints `rivet 0.16.1`.

But the **repo made it look abandoned**, which is what prompted the doubt:
- README buried npm under a comment (`# Or via npm (for npx … mcp)`).
- The release-tarball `curl` example was pinned to **v0.5.0** with a wrong asset name (`rivet-x86_64-…` vs the real `rivet-v0.16.1-x86_64-…`).
- Committed `npm/package.json` sat at **0.9.0** and pinned platform deps at **0.4.1** (repo is at 0.16.1).

## Changes

- **README Install**: npm/npx listed **first** as the zero-toolchain path; fixed the tarball example to the real `rivet-vX.Y.Z-<target>` asset naming.
- **Version sync**: bumped `npm/package.json` (+ `optionalDependencies`) and all `platform-packages/*/package.json` to `0.16.1`. (`release-npm.yml` overwrites these at publish via `jq` regardless — this is purely so the repo stops looking stale.)
- **RELEASING.md**: new "Version locations" note — which files are authoritative (`Cargo.toml`) vs workflow-managed (`npm/`, `platform-packages/`), so a future drift isn't mistaken for a broken channel.

No code touched; docs/packaging only. `rivet docs check` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)