### PR TITLE
feat(init): --vendor-schemas pins built-in schemas on-disk against upgrades (#431)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -6940,3 +6940,50 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-14T12:00:00Z
+
+  - id: REQ-220
+    type: requirement
+    title: "`rivet init --vendor-schemas` writes the resolved built-in schemas on-disk to pin validation against rivet upgrades (#431)"
+    status: implemented
+    description: |
+      Finding (#431, maintainer-reported). A project that lists only built-in
+      schema NAMES in `rivet.yaml` (no local `schemas/` dir) validates against
+      whatever schema definitions are compiled into the installed rivet binary
+      (`embedded::load_schemas_with_fallback` prefers on-disk, else the embedded
+      copy). So every release that tightens or adds a rule to a built-in schema
+      silently changes validation for embedded-schema consumers — the same
+      `rivet validate` that passed now flags unchanged artifacts. The schema
+      `version:` field is surfaced (REQ-176/177, #442/#443/#483) and CI warns on
+      an unbumped schema change (REQ-206, #487), but nothing lets a project PIN
+      the schema set it validates against.
+
+      Fix (this slice): `rivet init --vendor-schemas` writes the resolved schema
+      set — the names in `schemas:` plus their auto-discovered bridges — from the
+      binary's embedded copies into the project's `schemas/<name>.yaml`. Because
+      the loader prefers on-disk over embedded, the vendored set is committed to
+      the project's git and is immune to release-to-release rule drift. Vendoring
+      never overwrites an existing schema file (a locally-edited schema is kept).
+
+      Acceptance:
+        - `rivet init --preset aspice --vendor-schemas --dir D` writes
+          `D/schemas/common.yaml` and `D/schemas/aspice.yaml`.
+        - `rivet --project D validate` then reports those schemas as `(on-disk)`
+          (resolved from the vendored copies, not embedded) and PASSes.
+        - Re-running the vendor path over an existing, locally-edited
+          `schemas/<name>.yaml` leaves it untouched.
+        - `cargo test -p rivet-cli --test cli_commands` passes; `cargo fmt
+          --check` + `cargo clippy --all-targets -- -D warnings` clean.
+      Out of scope (separate slice): a `rivet.yaml`-recorded expected-version
+      pin with a validate-time drift diagnostic, and a `rivet schema vendor`
+      command for already-initialized projects.
+    tags: [cli, schema, init, stability, dogfooding]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-010
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-14T14:30:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -293,6 +293,14 @@ enum Command {
         /// only if you really want to regenerate them.
         #[arg(long, requires = "agents")]
         bootstrap: bool,
+
+        /// Vendor the resolved built-in schemas (and their auto-discovered
+        /// bridges) into the project's `schemas/` directory, pinning validation
+        /// against rivet upgrades (#431). The loader prefers on-disk schemas
+        /// over the binary's embedded copies, so a vendored set is immune to
+        /// release-to-release rule drift. Existing files are not overwritten.
+        #[arg(long)]
+        vendor_schemas: bool,
     },
 
     /// Validate artifacts against schemas
@@ -1990,6 +1998,7 @@ fn run(cli: Cli) -> Result<bool> {
         yes: _yes,
         hooks,
         bootstrap,
+        vendor_schemas,
     } = &cli.command
     {
         if *agents {
@@ -2002,7 +2011,7 @@ fn run(cli: Cli) -> Result<bool> {
         if *hooks {
             return cmd_init_hooks(dir);
         }
-        return cmd_init(name.as_deref(), preset, schema, dir);
+        return cmd_init(name.as_deref(), preset, schema, dir, *vendor_schemas);
     }
     if let Command::Docs {
         topic,
@@ -3785,6 +3794,7 @@ fn cmd_init(
     preset: &str,
     schema_override: &[String],
     dir: &std::path::Path,
+    vendor_schemas: bool,
 ) -> Result<bool> {
     let dir = if dir == std::path::Path::new(".") {
         std::env::current_dir().context("resolving current directory")?
@@ -3854,6 +3864,40 @@ sources:
         for bridge in &bridges {
             println!("    + {bridge}");
         }
+    }
+
+    // #431: vendor the resolved schema set (plus bridges) on-disk so validation
+    // is pinned against rivet upgrades. The loader prefers `schemas/<name>.yaml`
+    // over the embedded copy, so a vendored project is immune to release-to-
+    // release rule drift. Existing files are left untouched (never clobber a
+    // locally-edited schema).
+    if vendor_schemas {
+        let schemas_dir = dir.join("schemas");
+        std::fs::create_dir_all(&schemas_dir)
+            .with_context(|| format!("creating {}", schemas_dir.display()))?;
+        println!("\n  vendoring schemas (pinned against upgrades):");
+        let mut wrote = 0usize;
+        for name in rivet_core::embedded::schema_names_with_bridges(&schemas) {
+            let content = rivet_core::embedded::embedded_schema(&name)
+                .or_else(|| rivet_core::embedded::embedded_bridge(&name));
+            let Some(content) = content else {
+                eprintln!("    ! {name}: no embedded schema to vendor — skipping");
+                continue;
+            };
+            let path = schemas_dir.join(format!("{name}.yaml"));
+            if path.exists() {
+                println!("    = {} (exists, kept)", path.display());
+                continue;
+            }
+            std::fs::write(&path, content)
+                .with_context(|| format!("writing {}", path.display()))?;
+            println!("    + {}", path.display());
+            wrote += 1;
+        }
+        println!(
+            "  vendored {wrote} schema file(s) into {}",
+            schemas_dir.display()
+        );
     }
 
     // Create artifacts/ directory with preset-specific sample files

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -305,6 +305,83 @@ fn schema_presets_lists_declarable_standards_without_a_project() {
 
 // ── rivet init ──────────────────────────────────────────────────────────
 
+/// #431: `rivet init --vendor-schemas` writes the resolved built-in schemas
+/// on-disk so validation is pinned against rivet upgrades (the loader prefers
+/// `schemas/<name>.yaml` over the embedded copy), and is idempotent (won't
+/// clobber an existing/edited schema file).
+#[test]
+fn init_vendor_schemas_pins_schemas_on_disk() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "init",
+            "--preset",
+            "aspice",
+            "--vendor-schemas",
+            "--dir",
+            dirs,
+        ])
+        .output()
+        .expect("run rivet init --vendor-schemas");
+    assert!(
+        out.status.success(),
+        "init --vendor-schemas must exit 0. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The resolved set (common + aspice) must be written on-disk.
+    let schemas_dir = dir.join("schemas");
+    let common = schemas_dir.join("common.yaml");
+    let aspice = schemas_dir.join("aspice.yaml");
+    assert!(common.exists(), "common.yaml must be vendored");
+    assert!(aspice.exists(), "aspice.yaml must be vendored");
+
+    // validate must now resolve schemas from on-disk (pinned), not embedded.
+    let val = Command::new(rivet_bin())
+        .args(["--project", dirs, "validate"])
+        .output()
+        .expect("run rivet validate");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&val.stdout),
+        String::from_utf8_lossy(&val.stderr)
+    );
+    assert!(
+        combined.contains("on-disk"),
+        "validate must report schemas resolved on-disk after vendoring; got:\n{combined}"
+    );
+
+    // Idempotent: a locally-edited schema must survive a re-vendor. `init`
+    // refuses when rivet.yaml exists, so remove it (keeping schemas/) to let the
+    // vendor path run again and exercise its exists-guard.
+    std::fs::write(&common, "# locally edited sentinel\n").expect("edit vendored schema");
+    std::fs::remove_file(dir.join("rivet.yaml")).expect("remove rivet.yaml");
+    let out2 = Command::new(rivet_bin())
+        .args([
+            "init",
+            "--preset",
+            "aspice",
+            "--vendor-schemas",
+            "--dir",
+            dirs,
+        ])
+        .output()
+        .expect("re-run init --vendor-schemas");
+    assert!(
+        out2.status.success(),
+        "re-run init must exit 0. stderr: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    let kept = std::fs::read_to_string(&common).expect("read vendored schema");
+    assert!(
+        kept.contains("locally edited sentinel"),
+        "re-vendoring must not overwrite an existing schema file"
+    );
+}
+
 /// `rivet init --preset stpa` creates rivet.yaml and artifacts in a temp dir.
 #[test]
 fn init_stpa_preset() {


### PR DESCRIPTION
## What

A project that lists only built-in schema *names* in `rivet.yaml` (no local `schemas/`) validates against whatever schema definitions are compiled into the **installed rivet binary**. So every release that tightens or adds a rule to a built-in schema **silently changes validation** for embedded-schema consumers — the same `rivet validate` that passed now flags unchanged artifacts (#431).

The version is already *surfaced* (REQ-176/177, #483) and CI warns on unbumped schema changes (REQ-206), but nothing let a project **pin** the schema set it validates against. This adds the one-step pin.

## How

`rivet init --vendor-schemas` writes the resolved schema set — the names in `schemas:` **plus auto-discovered bridges** — from the binary's embedded copies into `schemas/<name>.yaml`. The loader already prefers on-disk over embedded, so the vendored set is committed to the project's git and **immune to release-to-release drift**. Vendoring **never overwrites** an existing schema file (a locally-edited schema is kept).

```
$ rivet init --preset aspice --vendor-schemas --dir proj
  ...
  vendoring schemas (pinned against upgrades):
    + proj/schemas/common.yaml
    + proj/schemas/aspice.yaml
$ rivet --project proj validate
  Schemas: common@0.1.0 (on-disk), aspice@0.2.0 (on-disk)   # ← pinned, not embedded
  Result: PASS
```

## Tests

`init_vendor_schemas_pins_schemas_on_disk`: vendors common+aspice, asserts the files exist, that `validate` reports them `(on-disk)`, and that a locally-edited vendored schema survives a re-vendor (idempotency guard). `cargo test -p rivet-cli --test cli_commands` 132 pass; clippy `--all-targets -D warnings` + fmt clean.

## Scope

This is the cheapest high-value slice of #431 (the issue's "mitigation that already works today", now one command). **Out of scope** (separate slices): a `rivet.yaml`-recorded expected-version pin with a validate-time drift diagnostic, and a `rivet schema vendor` command for already-initialized projects.

Refs #431. Implements REQ-220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)