### PR TITLE
fix(variants): skip feature-model binding files in load_variant_configs_from_dir (#532)

### DIFF
--- a/rivet-core/src/feature_model.rs
+++ b/rivet-core/src/feature_model.rs
@@ -1640,6 +1640,16 @@ pub fn load_variant_configs_from_dir(dir: &std::path::Path) -> Result<Vec<Varian
     for path in &paths {
         let yaml = std::fs::read_to_string(path)
             .map_err(|e| Error::Io(format!("reading {}: {e}", path.display())))?;
+        // A feature-model binding file (the `bindings:` map + optional
+        // `variants:` list shape of `FeatureBinding`) can legitimately live
+        // beside the single-variant configs it binds. Detect and skip it so
+        // the loader doesn't fail trying to parse it as `VariantConfig`
+        // (#532). The discriminator is a top-level `bindings:` key with
+        // neither `name:` (flat variant config) nor `variant:` (wrapped
+        // variant config from `rivet variant init`, see #514) present.
+        if is_feature_binding_file(&yaml) {
+            continue;
+        }
         let vc: VariantConfig = serde_yaml::from_str(&yaml).map_err(|e| {
             Error::Schema(format!("parsing variant config {}: {e}", path.display()))
         })?;
@@ -1653,6 +1663,25 @@ pub fn load_variant_configs_from_dir(dir: &std::path::Path) -> Result<Vec<Varian
         configs.push(vc);
     }
     Ok(configs)
+}
+
+/// True when `yaml` is structurally a feature-model binding file (a
+/// top-level `bindings:` map with no `name:`/`variant:` siblings), as
+/// opposed to a single-variant config. Used by `load_variant_configs_from_dir`
+/// to skip binding files that share the `artifacts/variants/` directory
+/// with the variant configs they bind (#532). Unparseable YAML returns
+/// `false` so the caller's existing error path still fires.
+fn is_feature_binding_file(yaml: &str) -> bool {
+    let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(yaml) else {
+        return false;
+    };
+    let serde_yaml::Value::Mapping(map) = value else {
+        return false;
+    };
+    let key = |k: &str| serde_yaml::Value::String(k.to_string());
+    map.contains_key(key("bindings"))
+        && !map.contains_key(key("name"))
+        && !map.contains_key(key("variant"))
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -2482,6 +2511,82 @@ bindings:
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         std::fs::write(dir.join("bad.yaml"), "name: 12345\nselects: not-a-list\n").unwrap();
+        let err = load_variant_configs_from_dir(dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("parsing variant config"), "got: {msg}");
+    }
+
+    // #532: a feature-model binding file (`variants:` list + `bindings:` map)
+    // can legitimately live in artifacts/variants/ beside the single-variant
+    // configs it binds. The loader must skip it rather than fail with
+    // "missing field `name`".
+    #[test]
+    fn load_variant_configs_from_dir_skips_binding_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // The repro from #532: real single-variant configs beside a binding
+        // file. Only the named configs should load; the binding file is
+        // silently skipped.
+        std::fs::write(
+            dir.join("sem-m3-gcc.yaml"),
+            "name: sem-m3-gcc\nselects: [m3, gcc]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("sem-smp-x86.yaml"),
+            "name: sem-smp-x86\nselects: [smp, x86]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("bindings.yaml"),
+            r#"
+variants:
+  - name: sem-m3-gcc
+    selects: [m3, gcc]
+bindings:
+  m3:
+    artifacts: []
+  gcc:
+    artifacts: []
+"#,
+        )
+        .unwrap();
+        let got = load_variant_configs_from_dir(dir).expect("binding file must not fail the load");
+        let names: Vec<&str> = got.iter().map(|v| v.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["sem-m3-gcc", "sem-smp-x86"],
+            "binding file must be skipped; only single-variant configs load"
+        );
+    }
+
+    // The wrapped variant config form `rivet variant init` writes (#514) has
+    // a top-level `variant:` key alongside a `bindings:` block. The skip
+    // discriminator must NOT confuse it with a pure binding file — and the
+    // loader must still surface its parse failure (it's not in flat form),
+    // not silently drop it. This is the regression guard for the discriminator.
+    #[test]
+    fn load_variant_configs_from_dir_does_not_skip_wrapped_variant_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(
+            dir.join("init.yaml"),
+            r#"
+variant:
+  name: kiln
+  selects: [telemetry]
+bindings:
+  telemetry:
+    artifacts: []
+"#,
+        )
+        .unwrap();
+        // The loader currently uses flat-form parsing, so this surfaces as a
+        // parse error rather than silently disappearing — that's the
+        // contract we need to preserve. (If/when the loader adopts
+        // `VariantConfig::from_yaml_str`, this test should flip to assert
+        // the wrapped form loads, which is fine — but the binding-file
+        // skip must not have absorbed it.)
         let err = load_variant_configs_from_dir(dir).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("parsing variant config"), "got: {msg}");


### PR DESCRIPTION
## What

`rivet validate` globs every `*.yaml` in `artifacts/variants/` and parses each
as a flat single-variant config (which requires top-level `name:`). When a
feature-model **binding file** (the natural co-location: `bindings:` map +
optional `variants:` list — the `FeatureBinding` shape) lives in that directory
beside the single-variant configs it binds, the parse fails and the CLI prints:

```
warning: failed to load variant configs from ./artifacts/variants:
  Schema error: parsing variant config ./artifacts/variants/bindings.yaml:
    missing field `name` at line 18 column 1
```

Benign (validate still PASSes) but noise that any product-line consumer
co-locating its binding file hits.

## How

`load_variant_configs_from_dir` (`rivet-core/src/feature_model.rs`) now
pre-parses each candidate as `serde_yaml::Value` and **silently skips** files
whose top-level shape is a binding file. The discriminator is:

- top-level **`bindings:` key present**, **and**
- no top-level `name:` (would be a flat single-variant config), **and**
- no top-level `variant:` (would be the wrapped form `rivet variant init`
  scaffolds — preserved per #514).

Unparseable YAML still surfaces through the existing typed-parse error path,
so a malformed variant config doesn't get absorbed by the skip.

## How the kill-criterion is met

> Fixed when `rivet validate` on the layout above emits 0 warnings about
> `bindings.yaml` (loads or cleanly skips it).

Reproduced the issue's exact layout (`sem-m3-gcc.yaml` + `sem-smp-x86.yaml` +
`bindings.yaml` with `variants:`/`bindings:` top-level keys) against the
debug-built binary:

```
=== rivet validate output ===

No issues found.

Result: PASS (0 warnings)
Schemas: common@0.1.0 (embedded)

=== exit code: 0
=== checking for the #532 warning ===
(none — kill-criterion met)
```

## Tests

- `load_variant_configs_from_dir_skips_binding_files` — issue's exact repro
  shape; only the two named single-variant configs load, `bindings.yaml` is
  silently skipped.
- `load_variant_configs_from_dir_does_not_skip_wrapped_variant_form` —
  regression guard so the `variant:`-wrapped form (#514) is NOT swallowed by
  the binding-file skip; it still flows through the typed parse and surfaces a
  parse error rather than disappearing.

Confirmed: 57 `feature_model` lib tests pass, 8 `variant_phase2` CLI
integration tests pass, `cargo clippy --all-targets -- -D warnings` clean,
`cargo fmt --all -- --check` clean.

## Draft note (process)

Opened as **draft** because `https://pulseengine.eu/blog/` is returning HTTP
503 right now, so the routine that opened this PR could not consult the
authoritative process guidance the maintainer requires before opening a PR.
The technical work and the kill-criterion are complete; please move out of
draft once the blog is reachable and a quick process check passes (or if the
local AGENTS.md guidance is sufficient — `cargo fmt`/`cargo clippy --all-targets
-D warnings` were both run per the "Before You Push (Rust)" section, and the
`Fixes: REQ-004` trailer is on the commit per CLAUDE.md).

Closes #532.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3GqKnGE6f1nc7yCbNf5DQ)_