### PR TITLE
fix(schema): load bundled bridge schemas by name in a consumer's schemas: list (#530)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7080,3 +7080,46 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-23T12:00:00Z
+
+  - id: REQ-221
+    type: requirement
+    title: "Bundled bridge schemas (`*.bridge.yaml`) are loadable by name in a consumer project's `schemas:` list (#530)"
+    status: implemented
+    description: |
+      Finding (#530, tool-friction from the `wohl` consumer project). Bundled
+      bridge schemas (`stpa-dev.bridge`, `eu-ai-act-stpa.bridge`, …) define the
+      cross-domain trace links a consumer needs (e.g. `constraint-satisfies`,
+      `risk-identified-by-stpa`). They ship embedded in the rivet binary, but the
+      schema loader only ever *auto-discovered* them from the loaded schema set —
+      it never resolved a bridge by explicit name. So a consumer that listed
+      `stpa-dev.bridge` in its `rivet.yaml` `schemas:` failed with
+      `schema 'stpa-dev.bridge' not found on disk or as embedded schema`, with no
+      way to pull a bridge whose endpoints weren't both already loaded.
+
+      Fix: every schema-name resolution path (`load_schemas_with_fallback`, the
+      content loader, and `schema_sources`) now falls back to
+      `embedded_bridge(name)` after `embedded_schema(name)`, so a bridge resolves
+      by its `<a>-<b>.bridge` stem just like any built-in. Already-listed bridges
+      are skipped by the auto-discovery pass (no double-load). The not-found
+      error now points at the `.bridge` naming and `rivet schema presets`.
+
+      Acceptance:
+        - A project with `schemas: [common, stpa, stpa-dev.bridge]` and no local
+          `schemas/` dir validates PASS, and `validate` reports
+          `stpa-dev.bridge@… (embedded)`.
+        - `load_schemas_with_fallback` loads the bridge's own link types (e.g.
+          `constraint-satisfies`); an unknown `*.bridge` name still errors.
+        - `rivet schema sources` reports a bridge name as `Embedded`, not Missing.
+        - `cargo test -p rivet-core` passes; `cargo fmt --check` +
+          `cargo clippy --all-targets -- -D warnings` clean.
+    tags: [schema, bridge, embedded, consumer, tool-friction]
+    fields:
+      priority: should
+      category: functional
+    links:
+      - type: traces-to
+        target: REQ-010
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-22T19:00:00Z

--- a/rivet-core/src/embedded.rs
+++ b/rivet-core/src/embedded.rs
@@ -182,7 +182,8 @@ pub fn schema_sources(
             let path = schemas_dir.join(format!("{name}.yaml"));
             let source = if path.exists() {
                 SchemaSource::OnDisk(path)
-            } else if embedded_schema(name).is_some() {
+            } else if embedded_schema(name).is_some() || embedded_bridge(name).is_some() {
+                // #530: bridges resolve by name too (e.g. `stpa-dev.bridge`).
                 SchemaSource::Embedded
             } else {
                 SchemaSource::Missing
@@ -277,6 +278,9 @@ pub fn load_schema_contents(
                 result.push((name.clone(), content));
             }
         } else if let Some(content) = embedded_schema(name) {
+            result.push((name.clone(), content.to_string()));
+        } else if let Some(content) = embedded_bridge(name) {
+            // #530: bridges are loadable by explicit name too.
             result.push((name.clone(), content.to_string()));
         } else {
             log::warn!("schema '{name}' not found on disk or embedded");
@@ -409,9 +413,22 @@ pub fn load_schemas_with_fallback(
             let file: SchemaFile = serde_yaml::from_str(content)
                 .map_err(|e| Error::Schema(format!("embedded '{name}': {e}")))?;
             files.push(file);
+        } else if let Some(content) = embedded_bridge(name) {
+            // #530: a consumer project may list a bundled bridge schema (e.g.
+            // `stpa-dev.bridge`, `eu-ai-act-stpa.bridge`) by name in its
+            // `schemas:` to pull the cross-domain links it needs. Bridges are
+            // embedded, but resolution only auto-discovered them from the loaded
+            // schema set and never resolved them by explicit name — so a
+            // consumer's `schemas: [stpa-dev.bridge]` failed as "not found".
+            let file: SchemaFile = serde_yaml::from_str(content)
+                .map_err(|e| Error::Schema(format!("embedded bridge '{name}': {e}")))?;
+            files.push(file);
         } else {
             return Err(Error::Schema(format!(
-                "schema '{name}' not found on disk ({}) or as embedded schema",
+                "schema '{name}' not found on disk ({}) or as an embedded schema \
+                 or bridge. Built-in bridges are listed by their `<a>-<b>.bridge` \
+                 stem (e.g. `stpa-dev.bridge`); run `rivet schema presets` to see \
+                 declarable names.",
                 schemas_dir.join(format!("{name}.yaml")).display()
             )));
         }
@@ -570,5 +587,40 @@ mod tests {
             "expected bridge schemas to be appended, got {expanded:?}"
         );
         assert!(expanded.iter().any(|n| n.contains("bridge")));
+    }
+
+    // #530: a consumer project must be able to load a bundled bridge schema by
+    // its `<a>-<b>.bridge` name in `schemas:` — previously only auto-discovered,
+    // never resolvable by explicit name (failed as "not found").
+    #[test]
+    fn bundled_bridges_are_loadable_by_explicit_name() {
+        let empty = std::path::Path::new("/nonexistent-schemas-dir");
+
+        // The bridge resolves by name through the main loader (no on-disk dir).
+        let names = vec![
+            "common".to_string(),
+            "stpa".to_string(),
+            "stpa-dev.bridge".to_string(),
+        ];
+        let schema = load_schemas_with_fallback(&names, empty)
+            .expect("a bundled bridge must load by explicit name");
+        // The bridge's own link types are present (it defines the cross-domain
+        // links the consumer asked for — #530's `constraint-satisfies`).
+        assert!(
+            schema.link_types.contains_key("constraint-satisfies"),
+            "the stpa-dev bridge's link types must be loaded, got {:?}",
+            schema.link_types.keys().collect::<Vec<_>>()
+        );
+
+        // It also reports as Embedded (not Missing) in source resolution.
+        let sources = schema_sources(&["stpa-dev.bridge".to_string()], empty);
+        assert!(
+            matches!(sources[0].1, SchemaSource::Embedded),
+            "a bridge must resolve as Embedded by name, got {:?}",
+            sources[0].1
+        );
+
+        // A genuinely unknown name still errors.
+        assert!(load_schemas_with_fallback(&["no-such.bridge".to_string()], empty).is_err());
     }
 }


### PR DESCRIPTION
## What

Bundled bridge schemas (`stpa-dev.bridge`, `eu-ai-act-stpa.bridge`, …) ship embedded in the binary and define the cross-domain trace links a consumer project needs (`constraint-satisfies`, `risk-identified-by-stpa`, …). But the schema loader only ever **auto-discovered** them from the loaded schema set — it never resolved a bridge by **explicit name**. So a consumer (wohl) that put `stpa-dev.bridge` in its `rivet.yaml` `schemas:` got:

```
schema 'stpa-dev.bridge' not found on disk (./schemas/stpa-dev.bridge.yaml) or as embedded schema
```

…with no way to pull a bridge whose two endpoint domains weren't both already loaded.

## How

Every schema-name resolution path now falls back to `embedded_bridge(name)` after `embedded_schema(name)`:
- `load_schemas_with_fallback` (the actual loader)
- the raw content loader (was emitting a spurious `not found` WARN)
- `schema_sources` (so `rivet schema sources`/`info` report a bridge as `Embedded`, not `Missing`)

Already-listed bridges are skipped by the auto-discovery pass (no double-load). The not-found error now points at the `<a>-<b>.bridge` stem naming and `rivet schema presets`.

## Verification (reproduced #530's exact case)

```
$ rivet init --preset stpa --dir proj && echo "schemas: [..., stpa-dev.bridge]"
$ rivet --project proj validate
  Schemas: stpa-dev.bridge@0.1.0 (embedded), common@0.1.0 (embedded), stpa@0.1.0 (embedded)
  Result: PASS
```

New `bundled_bridges_are_loadable_by_explicit_name` test (loads the bridge's `constraint-satisfies` link type by name; unknown `*.bridge` still errors; reports `Embedded`). `cargo test -p rivet-core` green; clippy `--all-targets -D warnings` + fmt clean.

Closes #530. Implements REQ-221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)