### PR TITLE
ci(release): make VSIX Marketplace publish non-blocking so npm publish isn't skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,6 +503,14 @@ jobs:
     name: Publish VSIX to VS Code Marketplace
     needs: [create-release]
     runs-on: ubuntu-latest
+    # The VS Code Marketplace is a SEPARATE distribution channel (RELEASING.md):
+    # a failure here (e.g. an expired VSCE PAT) must NOT fail the overall Release
+    # run, because `release-npm.yml` triggers on `workflow_run.conclusion ==
+    # 'success'` — so a red marketplace job was silently SKIPPING the npm publish
+    # (v0.17.0 shipped binaries but npm froze at 0.16.1 until a manual backfill).
+    # `build-test-evidence` is already continue-on-error for the same reason; the
+    # core release (binaries + GitHub Release via create-release) still gates.
+    continue-on-error: true
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Problem (root cause of the v0.17.0 npm freeze)

`release-npm.yml` triggers on `workflow_run.conclusion == 'success'` of the Release workflow. But `publish-vsix-marketplace` had **no `continue-on-error`**, so when it failed (expired VSCE PAT), the **entire Release run concluded `failure`** — and npm publish **silently skipped**.

Result for v0.17.0: the signed tag, binaries, SBOM/SLSA, and GitHub Release all published, but **npm froze at 0.16.1** until a manual `workflow_dispatch` backfill. This is the same class as the historical "npm sat at 0.10.1 for ~6 releases" incident.

## Fix

Mark `publish-vsix-marketplace` `continue-on-error: true` — matching the existing `build-test-evidence` job. The VS Code Marketplace is a **separate distribution channel** (per RELEASING.md); its health must not gate the binary/npm release. The **core path still gates**: `build-binaries` + `create-release` (GitHub Release) failing will still fail the run.

After this, a down marketplace token degrades to "VSIX not published this release" instead of "npm silently frozen."

actionlint clean. `Trace: skip` (ci).

> Follow-up worth considering: the expired **VSCE marketplace PAT** itself (separate from the npm token you just rotated) — the marketplace publish will keep failing until it's refreshed, just non-fatally now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)