### PR TITLE
fix(add): create a default file for a new artifact type instead of forcing --file (#552)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7123,3 +7123,43 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-22T19:00:00Z
+
+  - id: REQ-223
+    type: requirement
+    title: "`rivet add --type <T>` creates a default file for a new type instead of forcing --file (#552)"
+    status: implemented
+    description: |
+      Finding (#552, authoring a BYO-OS decision). `rivet add --type
+      design-decision` (a type the schema and `rivet add --help` both advertise)
+      failed with `no existing file found for type 'design-decision'. Use --file
+      to specify one` whenever no file already held that type — so you could not
+      add the FIRST artifact of a type without hand-picking a file. (The two
+      other parts of #552 were already resolved: field/link values with special
+      chars are YAML-quoted on write — REQ-198/199, verified across adversarial
+      inputs; the `next-id` prefix is learned from existing same-type artifacts,
+      which is intentional.)
+
+      Fix: when no file holds the type and no `--file` is given, `rivet add`
+      synthesizes a default path in the project's first generic-yaml source
+      (e.g. `artifacts/design-decisions.yaml` for `design-decision`), creating it
+      with an `artifacts:` header if absent, then appends. Existing routing
+      (an existing file for the type, or an explicit `--file`) is unchanged.
+
+      Acceptance:
+        - In a fresh `dev` project (requirements.yaml only), `rivet add --type
+          design-decision --title X --field rationale=Y` exits 0 and creates
+          `artifacts/design-decisions.yaml`.
+        - A subsequent add of the same type appends to that file.
+        - `cargo test -p rivet-cli --test cli_commands` passes; fmt + clippy clean.
+    tags: [cli, add, dx, dogfooding]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.18.0-track
+    links:
+      - type: traces-to
+        target: REQ-007
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-23T13:30:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -15162,14 +15162,44 @@ fn cmd_add(
     // Determine target file
     let target_file = if let Some(f) = file {
         cli.project.join(f)
+    } else if let Some(existing) = mutate::find_file_for_type(artifact_type, &store) {
+        existing
     } else {
-        mutate::find_file_for_type(artifact_type, &store).ok_or_else(|| {
-            anyhow::anyhow!(
-                "no existing file found for type '{}'. Use --file to specify one.",
-                artifact_type
-            )
-        })?
+        // #552: no file holds this type yet — synthesize a default in the
+        // project's first generic-yaml source (e.g. `design-decision` ->
+        // `artifacts/design-decisions.yaml`) instead of forcing the user to
+        // pass --file just to add the FIRST artifact of a type. Created with an
+        // `artifacts:` header below if absent.
+        let src = ctx
+            .config
+            .sources
+            .iter()
+            .find(|s| matches!(s.format.as_str(), "generic" | "generic-yaml"))
+            .map(|s| cli.project.join(&s.path))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no generic-yaml source in rivet.yaml to add a '{artifact_type}' to. \
+                     Use --file to specify a target."
+                )
+            })?;
+        if src.is_dir() {
+            src.join(format!("{artifact_type}s.yaml"))
+        } else {
+            src
+        }
     };
+
+    // #552: ensure the target file exists with an `artifacts:` list header, so
+    // the first artifact of a type can be added without --file.
+    if !target_file.exists() {
+        if let Some(parent) = target_file.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::write(&target_file, "artifacts:\n")
+            .with_context(|| format!("creating {}", target_file.display()))?;
+        println!("  created {}", target_file.display());
+    }
 
     // Write to file
     mutate::append_artifact_to_file(&artifact, &target_file)

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5939,6 +5939,48 @@ fn validate_emits_single_skip_warn_for_malformed_source() {
     );
 }
 
+/// #552: `rivet add --type <T>` must create a default file for the type when
+/// none exists yet, instead of erroring "no existing file found … use --file".
+/// You shouldn't need --file just to add the FIRST artifact of a type.
+#[test]
+fn add_creates_default_file_for_a_new_type() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dirs])
+        .output()
+        .expect("init");
+    assert!(init.status.success(), "init must succeed");
+
+    // The dev preset writes requirements.yaml but no design-decisions file.
+    assert!(!dir.join("artifacts/design-decisions.yaml").exists());
+
+    let add = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "add",
+            "--type",
+            "design-decision",
+            "--title",
+            "First decision",
+            "--field",
+            "rationale=because",
+        ])
+        .output()
+        .expect("add");
+    assert!(
+        add.status.success(),
+        "adding the first design-decision (no --file) must succeed; stderr: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    assert!(
+        dir.join("artifacts/design-decisions.yaml").exists(),
+        "add must have created a default design-decisions.yaml"
+    );
+}
+
 /// REQ-158 / #397: `rivet validate` emits a `near-duplicate-intent` INFO for a
 /// pair of same-type artifacts with highly similar titles, and NOT for a
 /// distinct one. `rivet add` emits a non-blocking note for a similar new title.


### PR DESCRIPTION
## What

`rivet add --type design-decision` (a type both the schema and `rivet add --help` advertise) failed with **"no existing file found for type … Use --file"** whenever no file already held that type — so you couldn't add the *first* artifact of a type without hand-picking a file. Real authoring friction (BYO-OS field report, #552).

## How

When no file holds the type **and** no `--file` is given, `rivet add` now synthesizes a default path in the project's first generic-yaml source (e.g. `artifacts/design-decisions.yaml` for `design-decision`), creates it with an `artifacts:` header if absent, then appends. Existing routing (a file already holding the type, or explicit `--file`) is unchanged.

## The other two parts of #552 — already resolved

- **Unquoted colon → invalid YAML:** fixed by REQ-198/199. **Verified here** across adversarial values (`: leadingcolon`, `*anchor`, `{brace`, `value #hash`, `yes`/`null`/`123`) — all quoted, `validate` PASS.
- **`next-id` prefix:** learned from existing same-type artifacts (intentional); the reporter's `SWARCH-SEM` came from their existing ids.

## Tests

`add_creates_default_file_for_a_new_type`: fresh dev project → `add --type design-decision` (no `--file`) exits 0 and creates `artifacts/design-decisions.yaml`. `cargo test -p rivet-cli --test cli_commands` green; fmt + clippy clean.

Closes #552. Implements REQ-223. v0.18.0 (`baseline: v0.18.0-track`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)