### PR TITLE
feat(schema): per-type status enum overrides the global lifecycle (#550)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7163,3 +7163,42 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-23T13:30:00Z
+
+  - id: REQ-224
+    type: requirement
+    title: "An artifact type may declare a per-type `status` enum that overrides the global lifecycle (#550)"
+    status: implemented
+    description: |
+      Finding (#550, jess downstream — slice 3 of #522). The base `status` field
+      declares one global lifecycle enum (draft→…→released, +accepted). But some
+      types have their own lifecycle: an `ai-found-defect` moves
+      open → triaged → resolved. A downstream store (jess) using `status: open` /
+      `status: resolved` on its defects hit 27 `status-allowed-values` ERRORs and
+      could not upgrade off its v0.15.0 pin.
+
+      Fix: a type may declare its OWN `status` field with `allowed-values`; the
+      status check (validate-time, `rivet add`/`modify`, and the remediation
+      help) prefers the type's status enum and falls back to the global
+      base-field enum. `common.yaml` declares `status: [open, triaged, resolved]`
+      on `ai-found-defect` (distinct from its release-gating `triage-status`
+      field). common schema 0.1.0 → 0.2.0.
+
+      Acceptance:
+        - An `ai-found-defect` with `status: open` or `resolved` validates clean;
+          `status: bogus` errors against `[open, triaged, resolved]`.
+        - A `requirement` still validates against the global enum.
+        - `rivet add`/`modify` honor the per-type enum; the remediation help
+          lists the per-type values, not the global ones.
+        - `cargo test -p rivet-core` passes; fmt + clippy clean.
+    tags: [schema, status, validation, downstream, dogfooding]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.18.0-track
+    links:
+      - type: traces-to
+        target: REQ-135
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-23T14:30:00Z

--- a/rivet-core/src/mutate.rs
+++ b/rivet-core/src/mutate.rs
@@ -203,7 +203,7 @@ pub fn validate_add(artifact: &Artifact, store: &Store, schema: &Schema) -> Resu
     // field; when the schema declares `allowed-values` on it, reject values
     // outside the set at mutation time (so a typo never reaches a file).
     if let Some(status) = artifact.status.as_deref() {
-        check_status_allowed(status, schema)?;
+        check_status_allowed(status, &artifact.artifact_type, schema)?;
     }
 
     // Validate link types
@@ -408,7 +408,7 @@ pub fn validate_modify(
 
     // REQ-135: a `--set-status` value must be in the declared status enum.
     if let Some(status) = params.set_status.as_deref() {
-        check_status_allowed(status, schema)?;
+        check_status_allowed(status, &artifact.artifact_type, schema)?;
     }
 
     Ok(())
@@ -417,11 +417,14 @@ pub fn validate_modify(
 /// REQ-135: reject a status outside the `status` base-field's declared
 /// `allowed-values`. Inert (Ok) when no enum is declared — keeps status
 /// free-form for schemas that don't opt in.
-fn check_status_allowed(status: &str, schema: &Schema) -> Result<(), Error> {
+fn check_status_allowed(status: &str, artifact_type: &str, schema: &Schema) -> Result<(), Error> {
+    // #550: a type may override the global lifecycle enum with its own `status`
+    // field allowed-values (e.g. ai-found-defect: open/triaged/resolved). Prefer
+    // the type's own status field; fall back to the base-field enum.
     if let Some(allowed) = schema
-        .base_fields
-        .iter()
-        .find(|f| f.name == "status")
+        .artifact_type(artifact_type)
+        .and_then(|t| t.fields.iter().find(|f| f.name == "status"))
+        .or_else(|| schema.base_fields.iter().find(|f| f.name == "status"))
         .and_then(|f| f.allowed_values.as_ref())
     {
         if !allowed.is_empty() && !allowed.iter().any(|a| a == status) {

--- a/rivet-core/src/remediation.rs
+++ b/rivet-core/src/remediation.rs
@@ -132,10 +132,12 @@ fn status_allowed_values(diag: &Diagnostic, schema: &Schema, store: &Store) -> O
     let source_id = diag.artifact_id.as_deref()?;
     let artifact = store.get(source_id)?;
     let status = artifact.status.as_deref()?;
+    // #550: prefer the artifact type's own `status` field (per-type override,
+    // e.g. ai-found-defect uses open/triaged/resolved) over the global enum.
     let allowed = schema
-        .base_fields
-        .iter()
-        .find(|f| f.name == "status")
+        .artifact_type(&artifact.artifact_type)
+        .and_then(|t| t.fields.iter().find(|f| f.name == "status"))
+        .or_else(|| schema.base_fields.iter().find(|f| f.name == "status"))
         .and_then(|f| f.allowed_values.as_ref())?;
     let allowed_list = allowed.join(", ");
     Some(Remediation {

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -801,12 +801,16 @@ pub fn validate_structural_with_externals_and_variant(
         // `allowed-values` on the `status` base-field, enforce it here; with
         // no values declared the check is inert (backward compatible).
         if let Some(status) = artifact.status.as_deref() {
-            if let Some(allowed) = schema
-                .base_fields
+            // #550: a type may declare its OWN `status` field with
+            // `allowed-values` to override the global lifecycle enum (e.g.
+            // `ai-found-defect` uses open/triaged/resolved, not draft→released).
+            // Prefer the type's own status field; fall back to the base-field.
+            let status_field = type_def
+                .fields
                 .iter()
                 .find(|f| f.name == "status")
-                .and_then(|f| f.allowed_values.as_ref())
-            {
+                .or_else(|| schema.base_fields.iter().find(|f| f.name == "status"));
+            if let Some(allowed) = status_field.and_then(|f| f.allowed_values.as_ref()) {
                 if !allowed.is_empty() && !allowed.iter().any(|a| a == status) {
                     diagnostics.push(Diagnostic {
                         source_file: None,
@@ -2798,6 +2802,52 @@ then:
         );
         assert_eq!(status_diags[0].artifact_id.as_deref(), Some("REQ-2"));
         assert!(status_diags[0].message.contains("implmented"));
+    }
+
+    // #550: a type may declare its OWN `status` field allowed-values, which
+    // override the global lifecycle enum for artifacts of that type.
+    #[test]
+    fn per_type_status_field_overrides_global_enum() {
+        let mut file = minimal_schema("defect");
+        file.base_fields = vec![FieldDef {
+            name: "status".into(),
+            field_type: "enum".into(),
+            allowed_values: Some(vec!["draft".into(), "approved".into()]),
+            ..Default::default()
+        }];
+        file.artifact_types = vec![ArtifactTypeDef {
+            name: "ai-found-defect".into(),
+            fields: vec![FieldDef {
+                name: "status".into(),
+                field_type: "enum".into(),
+                allowed_values: Some(vec!["open".into(), "triaged".into(), "resolved".into()]),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+        let schema = Schema::merge(&[file]);
+
+        let mut store = Store::new();
+        // `open` is valid for the type (not in the global enum).
+        let mut good = minimal_artifact("DEF-1", "ai-found-defect");
+        good.status = Some("open".to_string());
+        store.insert(good).unwrap();
+        // `draft` is a GLOBAL value but NOT in the per-type set -> rejected.
+        let mut bad = minimal_artifact("DEF-2", "ai-found-defect");
+        bad.status = Some("draft".to_string());
+        store.insert(bad).unwrap();
+
+        let graph = LinkGraph::build(&store, &schema);
+        let status_diags: Vec<_> = validate_structural(&store, &schema, &graph)
+            .into_iter()
+            .filter(|d| d.rule == "status-allowed-values")
+            .collect();
+        assert_eq!(
+            status_diags.len(),
+            1,
+            "per-type enum: `open` ok, `draft` rejected; got {status_diags:?}"
+        );
+        assert_eq!(status_diags[0].artifact_id.as_deref(), Some("DEF-2"));
     }
 
     // Backward-compatibility: with no `allowed-values` declared on `status`

--- a/rivet-core/tests/integration.rs
+++ b/rivet-core/tests/integration.rs
@@ -1337,7 +1337,8 @@ fn test_schema_metadata_loading() {
     let common_path = schemas_dir.join("common.yaml");
     let common = Schema::load_file(&common_path).expect("load common schema");
     assert_eq!(common.schema.name, "common");
-    assert_eq!(common.schema.version, "0.1.0");
+    // 0.2.0: ai-found-defect gained a per-type `status` enum (#550 / REQ-224).
+    assert_eq!(common.schema.version, "0.2.0");
     assert!(
         common.schema.description.is_some(),
         "common schema should have a description"

--- a/schemas/common.yaml
+++ b/schemas/common.yaml
@@ -10,7 +10,7 @@
 
 schema:
   name: common
-  version: "0.1.0"
+  version: "0.2.0"
   description: >
     Base field definitions and common link types for lifecycle traceability.
     All domain schemas implicitly extend this schema.
@@ -295,6 +295,19 @@ artifact-types:
       raises rivet's TD claim (Tool error Detection per ISO 26262-8
       §11.4.5.4) when the upstream author is non-human.
     fields:
+      # #550: per-type override of the global lifecycle `status` enum. A defect
+      # found by an AI step moves open -> triaged -> resolved, NOT the
+      # draft->...->released chain. Declaring a `status` field on the type makes
+      # `rivet validate` enforce this set instead of the base lifecycle (so a
+      # downstream store using `status: open|resolved` validates clean). The
+      # separate `triage-status` field below is the release-gating disposition.
+      - name: status
+        type: enum
+        required: false
+        allowed-values: [open, triaged, resolved]
+        description: >
+          Defect lifecycle: open -> triaged -> resolved. Per-type override of
+          the global status enum (#550).
       - name: severity
         type: string
         required: true


### PR DESCRIPTION
## What

The base `status` field declares **one** global lifecycle (`draft → … → released`, `+accepted`), but some types have their own. An **`ai-found-defect`** moves `open → triaged → resolved`. So a downstream store (**jess**) using `status: open` / `resolved` on its defects hit **27 `status-allowed-values` ERRORs** and couldn't upgrade off its v0.15.0 pin. This is slice 3 of #522 (jess confirmed slices 1–2 cleared by v0.17.0).

## How

A type may now declare its **own `status` field with `allowed-values`**; the status check prefers the type's enum and falls back to the global base-field enum. Applied at all three surfaces:
- validate-time (`status-allowed-values` diagnostic)
- `rivet add` / `rivet modify` (`check_status_allowed`)
- the remediation help text (lists the per-type values, not the global ones)

`common.yaml` declares `status: [open, triaged, resolved]` on `ai-found-defect` (distinct from its release-gating `triage-status` field). common `0.1.0 → 0.2.0`.

## Verified

- `ai-found-defect` with `status: open`/`resolved` → validates clean; `status: bogus` → errors against `[open, triaged, resolved]`.
- A `requirement` still validates against the **global** enum (no regression).
- New `per_type_status_field_overrides_global_enum` test; `cargo test -p rivet-core` green; fmt + clippy clean; `rivet validate` + `docs check` PASS.

Closes #550. Implements REQ-224 (`Verifies: REQ-135`). v0.18.0 (`baseline: v0.18.0-track`). Unblocks jess off its v0.15.0 pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)