### PR TITLE
feat(schema): cited-source usable on any type incl. verification (#556)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7202,3 +7202,45 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-23T14:30:00Z
+
+  - id: REQ-225
+    type: requirement
+    title: "`cited-source` is a base field, usable (and drift-checked) on any artifact type incl. verification types (#556)"
+    status: implemented
+    description: |
+      Finding (#556, relay test-traceability work). `cited-source` (sha256-stamped,
+      drift-checked by `rivet validate` / `rivet check sources`) was only declared
+      on requirement-ish types, so on a verification artifact
+      (sw/unit/sys-verification) it was flagged `unknown-field` — even though the
+      requirement→test→evidence chain is exactly where a tamper-evident citation
+      is wanted. The drift checker (`validate_cited_sources`) already discovers
+      the field by NAME on every artifact, so the only blocker was the
+      `unknown-field` rule consulting per-type fields only.
+
+      Fix: declare `cited-source` as a `common` base-field (the maintainer's
+      choice — generic, no per-schema duplication), and teach the `unknown-field`
+      check to treat base-field names as known on every type (struct base-fields
+      like id/title never appear in `fields`, so this is harmless). Now any type,
+      including the verification types, may carry a `cited-source` and it is
+      drift-checked. common 0.2.0 → 0.3.0.
+
+      Acceptance:
+        - An ASPICE `sw-verification` artifact with a `cited-source` field
+          validates with NO `unknown-field` flag (other schema rules still apply).
+        - The cited-source drift check still runs on it (field-name discovery).
+        - `cargo test -p rivet-core` passes; fmt + clippy clean; `rivet validate`
+          on the repo still PASS.
+      Out of scope (separate slice, folds into #559): the `named-test-exists`
+      check that a referenced test name actually exists.
+    tags: [schema, cited-source, verification, drift, dogfooding]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.18.0-track
+    links:
+      - type: traces-to
+        target: REQ-010
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-23T15:30:00Z

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -1117,8 +1117,17 @@ pub fn validate_structural_with_externals_and_variant(
             continue;
         }
         if let Some(type_def) = schema.artifact_type(&artifact.artifact_type) {
-            let known_fields: std::collections::HashSet<&str> =
-                type_def.fields.iter().map(|f| f.name.as_str()).collect();
+            // #556: a base-field declared in `common.yaml` (e.g. `cited-source`)
+            // is valid on EVERY type — that's what "base" means — so a
+            // verification artifact carrying `cited-source` must not be flagged
+            // `unknown-field`. Struct base-fields (id/title/…) never appear in
+            // `artifact.fields`, so chaining them in is harmless.
+            let known_fields: std::collections::HashSet<&str> = type_def
+                .fields
+                .iter()
+                .chain(schema.base_fields.iter())
+                .map(|f| f.name.as_str())
+                .collect();
             for field_name in artifact.fields.keys() {
                 if !known_fields.contains(field_name.as_str()) {
                     diagnostics.push(Diagnostic {
@@ -2848,6 +2857,40 @@ then:
             "per-type enum: `open` ok, `draft` rejected; got {status_diags:?}"
         );
         assert_eq!(status_diags[0].artifact_id.as_deref(), Some("DEF-2"));
+    }
+
+    // #556: a base-field (e.g. `cited-source`) is valid on EVERY type, so an
+    // artifact of a type that doesn't redeclare it must NOT be flagged
+    // `unknown-field`.
+    #[test]
+    fn base_field_is_accepted_on_any_type() {
+        let mut file = minimal_schema("verification");
+        file.base_fields = vec![FieldDef {
+            name: "cited-source".into(),
+            field_type: "cited-source".into(),
+            ..Default::default()
+        }];
+        file.artifact_types = vec![ArtifactTypeDef {
+            name: "verification".into(),
+            ..Default::default() // declares NO fields of its own
+        }];
+        let schema = Schema::merge(&[file]);
+
+        let mut store = Store::new();
+        let mut art = minimal_artifact("V-1", "verification");
+        art.fields
+            .insert("cited-source".into(), serde_yaml::Value::String("x".into()));
+        store.insert(art).unwrap();
+
+        let graph = LinkGraph::build(&store, &schema);
+        let unknown: Vec<_> = validate_structural(&store, &schema, &graph)
+            .into_iter()
+            .filter(|d| d.rule == "unknown-field")
+            .collect();
+        assert!(
+            unknown.is_empty(),
+            "a base-field must be accepted on any type, got {unknown:?}"
+        );
     }
 
     // Backward-compatibility: with no `allowed-values` declared on `status`

--- a/rivet-core/tests/integration.rs
+++ b/rivet-core/tests/integration.rs
@@ -1338,7 +1338,7 @@ fn test_schema_metadata_loading() {
     let common = Schema::load_file(&common_path).expect("load common schema");
     assert_eq!(common.schema.name, "common");
     // 0.2.0: ai-found-defect gained a per-type `status` enum (#550 / REQ-224).
-    assert_eq!(common.schema.version, "0.2.0");
+    assert_eq!(common.schema.version, "0.3.0");
     assert!(
         common.schema.description.is_some(),
         "common schema should have a description"

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -39,6 +39,8 @@ docs-check:
     - "0.1.0"
     # Example/historical schema versions referenced in topic bodies.
     - "0.2.0"
+    # common 0.3.0 (#556: cited-source base-field).
+    - "0.3.0"
     # ASPICE process IDs that look like X.Y.Z (e.g. SYS.2.1.7) — false
     # positives from the regex but stable upstream identifiers.
     - "2.1.7"

--- a/schemas/common.yaml
+++ b/schemas/common.yaml
@@ -10,7 +10,7 @@
 
 schema:
   name: common
-  version: "0.2.0"
+  version: "0.3.0"
   description: >
     Base field definitions and common link types for lifecycle traceability.
     All domain schemas implicitly extend this schema.
@@ -75,6 +75,22 @@ base-fields:
     type: mapping
     required: false
     description: AI provenance metadata (created-by, model, session-id, timestamp, reviewed-by)
+
+  # #556: cited-source is a base field, so ANY artifact type can carry a
+  # sha256-stamped, drift-checked reference to an external source — including
+  # the verification types (sw/unit/sys-verification) where the
+  # requirement→test→evidence chain wants a tamper-evident citation. The drift
+  # check (`rivet validate` / `rivet check sources`) already discovers the field
+  # by name on every artifact; declaring it here stops `unknown-field` from
+  # flagging it on types that don't redeclare it.
+  - name: cited-source
+    type: cited-source
+    required: false
+    description: >
+      Typed cited-source field — sha256-stamped reference to an external
+      source. Shape: { uri, kind, sha256, last-checked }, where kind is one of
+      file | url | github | oslc | reqif | polarion. Phase 1 verifies kind:
+      file. See `rivet docs schema-cited-sources` for the full reference.
 
 # ──────────────────────────────────────────────────────────────────────────
 # Common link types — reusable across all domains.


### PR DESCRIPTION
## What

`cited-source` (sha256-stamped, drift-checked by `rivet validate` / `rivet check sources`) was declared only on requirement-ish types, so on a **verification artifact** (`sw`/`unit`/`sys-verification`) it was flagged `unknown-field` — even though the requirement→test→**evidence** chain is exactly where a tamper-evident citation belongs (relay field report, #556).

## How (your call: common base)

- Declare `cited-source` as a **`common` base-field** — generic, no per-schema duplication; every type (incl. all verification types) can carry it.
- Teach the `unknown-field` check to treat base-field names as known on every type. Struct base-fields (`id`/`title`/…) never appear in `fields`, so this is harmless; only non-struct base-fields like `cited-source` are newly accepted.
- The drift checker (`validate_cited_sources`) already discovers the field **by name** on every artifact, so it now runs on verification artifacts with no further change.

common `0.2.0 → 0.3.0`.

## Verified

An ASPICE `sw-verification` with a `cited-source` validates with **no `unknown-field` flag** (its own `verifies`-required rule still applies). New `base_field_is_accepted_on_any_type` test; `cargo test -p rivet-core` green; fmt + clippy + docs-check clean; `rivet validate` PASS.

## Scope

This is the `cited-source` half of #556 (your decided scope). The `named-test-exists` check folds into **#559** (test→requirement verification), in progress. Closes the cited-source part of #556. Implements REQ-225. v0.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)