### PR TITLE
feat(cli): rivet verify <ID> advances to verified on verifying evidence (#559)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7244,3 +7244,45 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-23T15:30:00Z
+
+  - id: REQ-226
+    type: requirement
+    title: "`rivet verify <ID>` advances an implemented artifact to verified when it has verifying evidence (#559)"
+    status: implemented
+    description: |
+      Finding (#559, kiln V-right-side). Nothing advanced a requirement's status
+      to `verified` from its test evidence — `import-results` is a separate
+      run-log, and `coverage --tests` mapped markers but never wrote status. So a
+      requirement stayed `implemented` no matter how many passing tests verified
+      it, and a release-readiness query couldn't tell `implemented` from
+      `verified`.
+
+      Fix (maintainer's chosen design — source markers only, explicit command, no
+      auto-advance): `rivet verify <ID>` advances an `implemented` artifact to
+      `verified` iff it has verifying evidence — an incoming `verifies` link OR a
+      `// rivet: verifies <ID>` source marker (scanned from src/ + tests/, or
+      `--scan <path>`). Refuses with an actionable message when there's no
+      evidence; no-ops if already verified; rejects non-implemented states. The
+      write reuses the `modify --set-status` path (schema-validated YAML edit).
+
+      Acceptance:
+        - An implemented requirement with a `verifies` marker -> `rivet verify`
+          advances it to `verified` (file updated).
+        - No evidence -> refuses, non-zero, explains how to add evidence.
+        - `cargo test -p rivet-cli --test cli_commands` passes; fmt + clippy clean.
+      Note: #559's other ask — folding marker coverage into a single combined
+      V-closure metric in `rivet coverage` — is partly served already (#555 put a
+      `requirement-verification` rule into the coverage report); the combined
+      satisfied-AND-verified number is a fast-follow slice.
+    tags: [cli, verify, v-model, status, dogfooding]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.18.0-track
+    links:
+      - type: traces-to
+        target: REQ-007
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-23T16:30:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -552,6 +552,22 @@ enum Command {
         qualification: bool,
     },
 
+    /// Advance a requirement to `verified` when it has verifying test evidence.
+    ///
+    /// #559: closes the right side of the V explicitly. The requirement must
+    /// currently be `implemented` and have at least one piece of verifying
+    /// evidence — an incoming `verifies` link, OR a `// rivet: verifies <ID>`
+    /// source marker. No auto-advance: this is the opt-in, auditable command.
+    Verify {
+        /// Requirement (or other artifact) ID to advance to `verified`.
+        id: String,
+
+        /// Extra source paths to scan for `verifies` markers (default: src/,
+        /// tests/, else the project root).
+        #[arg(long = "scan", value_name = "PATH")]
+        scan: Vec<PathBuf>,
+    },
+
     /// Show traceability coverage report
     Coverage {
         /// S-expression filter to scope coverage
@@ -2278,6 +2294,7 @@ fn run(cli: Cli) -> Result<bool> {
                 cmd_stats(&cli, filter.as_deref(), format, baseline.as_deref())
             }
         }
+        Command::Verify { id, scan } => cmd_verify(&cli, id, scan),
         Command::Coverage {
             filter,
             format,
@@ -7064,6 +7081,89 @@ fn cmd_stats_qualification(cli: &Cli) -> Result<bool> {
     });
     println!("{}", serde_json::to_string_pretty(&output).unwrap());
     Ok(true)
+}
+
+/// #559: advance an artifact to `verified` when it has verifying evidence —
+/// an incoming `verifies` link, OR a `// rivet: verifies <ID>` source marker.
+/// Opt-in and auditable (no auto-advance); the artifact must be `implemented`.
+fn cmd_verify(cli: &Cli, id: &str, scan: &[std::path::PathBuf]) -> Result<bool> {
+    use rivet_core::test_scanner;
+
+    // Scope the loaded store/graph borrows so cmd_modify can reload below.
+    let link_count = {
+        let ctx = ProjectContext::load(cli)?;
+        let artifact = ctx
+            .store
+            .get(id)
+            .ok_or_else(|| anyhow::anyhow!("artifact '{id}' not found"))?;
+        match artifact.status.as_deref() {
+            Some("verified") => {
+                println!("{id} is already verified — nothing to do.");
+                return Ok(true);
+            }
+            Some("implemented") => {}
+            other => anyhow::bail!(
+                "refusing to verify '{id}': status is '{}', expected 'implemented'. \
+                 Only an implemented artifact can be advanced to verified.",
+                other.unwrap_or("(none)")
+            ),
+        }
+        ctx.graph.backlinks_of_type(id, "verifies").len()
+    };
+
+    // Source-marker evidence: `// rivet: verifies <ID>`. Default scan dirs match
+    // `coverage --tests`: src/ + tests/, else the project root.
+    let paths: Vec<std::path::PathBuf> = if scan.is_empty() {
+        let mut p: Vec<std::path::PathBuf> = ["src", "tests"]
+            .iter()
+            .map(|d| cli.project.join(d))
+            .filter(|c| c.is_dir())
+            .collect();
+        if p.is_empty() {
+            p.push(cli.project.clone());
+        }
+        p
+    } else {
+        scan.to_vec()
+    };
+    let markers = test_scanner::scan_source_files(&paths, &test_scanner::default_patterns());
+    let marker_hits: Vec<&test_scanner::TestMarker> = markers
+        .iter()
+        .filter(|m| m.target_id == id && m.link_type == "verifies")
+        .collect();
+
+    if link_count == 0 && marker_hits.is_empty() {
+        anyhow::bail!(
+            "refusing to verify '{id}': no verifying evidence. Add an incoming \
+             `verifies` link from a test/verification artifact, or a \
+             `// rivet: verifies {id}` marker in a test, then re-run."
+        );
+    }
+    if link_count > 0 {
+        println!("  evidence: {link_count} incoming `verifies` link(s)");
+    }
+    if let Some(first) = marker_hits.first() {
+        println!(
+            "  evidence: {} source `verifies` marker(s) (e.g. {}:{})",
+            marker_hits.len(),
+            first.file.display(),
+            first.line
+        );
+    }
+
+    // Advance via the shared modify write-path (validation + YAML edit).
+    cmd_modify(
+        cli,
+        Some(id),
+        None,
+        false,
+        Some("verified"),
+        None,
+        None,
+        &[],
+        &[],
+        &[],
+    )
 }
 
 /// Show traceability coverage report.

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -5939,6 +5939,66 @@ fn validate_emits_single_skip_warn_for_malformed_source() {
     );
 }
 
+/// #559: `rivet verify <REQ>` advances an implemented requirement to `verified`
+/// when a verifying source-marker (`// rivet: verifies <ID>`) exists, and
+/// refuses when there's no evidence.
+#[test]
+fn verify_advances_on_marker_evidence_and_refuses_without() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    let run = |args: &[&str]| {
+        Command::new(rivet_bin())
+            .args(["--project", dirs])
+            .args(args)
+            .output()
+            .expect("run rivet")
+    };
+    assert!(
+        Command::new(rivet_bin())
+            .args(["init", "--preset", "dev", "--dir", dirs])
+            .output()
+            .expect("init")
+            .status
+            .success()
+    );
+    std::fs::write(
+        dir.join("artifacts/reqs.yaml"),
+        "artifacts:\n  - id: REQ-9\n    type: requirement\n    title: T\n    status: implemented\n  - id: REQ-8\n    type: requirement\n    title: U\n    status: implemented\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("tests")).unwrap();
+    std::fs::write(
+        dir.join("tests/t.rs"),
+        "// rivet: verifies REQ-9\nfn t() {}\n",
+    )
+    .unwrap();
+
+    // REQ-9 has a marker -> verify advances it.
+    let ok = run(&["verify", "REQ-9"]);
+    assert!(
+        ok.status.success(),
+        "verify REQ-9 must succeed with marker evidence; stderr: {}",
+        String::from_utf8_lossy(&ok.stderr)
+    );
+    let reqs = std::fs::read_to_string(dir.join("artifacts/reqs.yaml")).unwrap();
+    assert!(
+        reqs.contains("id: REQ-9") && reqs.contains("status: verified"),
+        "REQ-9 must now be verified; got:\n{reqs}"
+    );
+
+    // REQ-8 has no evidence -> verify refuses (non-zero).
+    let no = run(&["verify", "REQ-8"]);
+    assert!(
+        !no.status.success(),
+        "verify REQ-8 must refuse without evidence"
+    );
+    assert!(
+        String::from_utf8_lossy(&no.stderr).contains("no verifying evidence"),
+        "refusal must explain the missing evidence"
+    );
+}
+
 /// #552: `rivet add --type <T>` must create a default file for the type when
 /// none exists yet, instead of erroring "no existing file found … use --file".
 /// You shouldn't need --file just to add the FIRST artifact of a type.


### PR DESCRIPTION
## What

Nothing advanced a requirement's status to `verified` from its test evidence — `import-results` is a separate run-log and `coverage --tests` mapped markers but never wrote status. A requirement stayed `implemented` no matter how many passing tests verified it, so release-readiness couldn't tell the two apart (kiln field report, #559).

## How (your chosen design)

- **Source markers only** + **explicit command** + **no auto-advance**.
- `rivet verify <ID>` advances an `implemented` artifact to `verified` **iff** it has verifying evidence: an incoming `verifies` link **OR** a `// rivet: verifies <ID>` source marker (scanned from `src/`+`tests/`, or `--scan <path>`).
- Refuses with an actionable message when there's no evidence; no-ops if already verified; rejects non-`implemented` states. The write reuses the schema-validated `modify --set-status` path.

## Verified

- Implemented REQ + marker → `verify` advances it to `verified` (file updated).
- No evidence → refuses, non-zero, explains how to add evidence.
- New `verify_advances_on_marker_evidence_and_refuses_without`; full `cargo test -p rivet-cli --test cli_commands` (135) green; fmt + clippy + docs-check clean; `rivet validate` PASS.

## Scope note

#559's other ask — a single combined **V-closure** number in `rivet coverage` — is partly served already: #555 put a `requirement-verification` entry into the coverage report. The combined satisfied-AND-verified metric is a noted fast-follow. This PR delivers the status-advance mechanism, the part that had no mechanism at all.

Closes #559. Implements REQ-226. **v0.18.0's 6th and final item.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)