### PR TITLE
fix(wasm): `rivet-core --features wasm` test build compiles (#543)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7286,3 +7286,41 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-23T16:30:00Z
+
+  - id: REQ-227
+    type: requirement
+    title: "`rivet-core --features wasm` test build must compile (WIT `Link` has no host-only `external` field) (#543)"
+    status: implemented
+    description: |
+      Finding (#543, dogfooding). `cargo test -p rivet-core --features wasm
+      --tests` failed to compile (E0560): a `#[cfg(test)]` constructor and the
+      host->WIT conversion in `wasm_runtime.rs` built the WIT-generated
+      `pulseengine:rivet/types.Link` with `external: None`, but the WIT `record
+      link` carries only `link-type` + `target`. The host `model::Link` gained
+      an `external: Option<...>` field (the prefix:ID externals composition
+      work), and an "add it everywhere" pass leaked the host-only field into the
+      WIT-side constructors.
+
+      Fix: drop `external` from the two `wit::Link` constructors. `external` is a
+      host-side composition concept (cross-repo prefix:ID links) that the wasm
+      guest ABI deliberately does not model, so the host->WIT conversion simply
+      omits it; the WIT-generated `types::Link` is unchanged (no spar regen — the
+      .wit is the source of truth for the guest contract). The host-side
+      constructor (WIT->host) keeps `external: None`, which is correct.
+
+      Acceptance:
+        - `cargo check -p rivet-core --features wasm --tests` compiles (was E0560).
+        - `cargo test -p rivet-core --features wasm --lib wasm_runtime` passes.
+        - The default (no-wasm) build is unaffected.
+    tags: [wasm, wit, build, features, dogfooding]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.19.0-track
+    links:
+      - type: traces-to
+        target: REQ-008
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-23T18:00:00Z

--- a/rivet-core/src/wasm_runtime.rs
+++ b/rivet-core/src/wasm_runtime.rs
@@ -576,7 +576,6 @@ fn convert_host_artifact_to_wit(
         .map(|l| wit::Link {
             link_type: l.link_type.clone(),
             target: l.target.clone(),
-            external: None,
         })
         .collect();
 
@@ -800,7 +799,6 @@ mod tests {
             links: vec![wit::Link {
                 link_type: "satisfies".into(),
                 target: "REQ-000".into(),
-                external: None,
             }],
             fields: vec![wit::FieldEntry {
                 key: "priority".into(),


### PR DESCRIPTION
Fixes #543.

## Problem

`cargo test -p rivet-core --features wasm --tests` failed to compile:

```
error[E0560]: struct `...types::Link` has no field named `external`
   --> rivet-core/src/wasm_runtime.rs
```

The host `model::Link` gained an `external: Option<…>` field (prefix:ID externals
composition work), and an "add it everywhere" pass put `external: None` on the
WIT-generated `types::Link` too — but the WIT `record link` carries only
`link-type` + `target`.

## Fix

Drop `external` from the two `wit::Link` constructors (`convert_host_artifact_to_wit`
and the `convert_wit_artifact_roundtrip` test). `external` is a host-side
composition concept (cross-repo prefix:ID links) the wasm guest ABI deliberately
doesn't model, so the host→WIT conversion omits it. The WIT→host constructor keeps
`external: None` (correct — host Link has the field). **The `.wit` is unchanged** —
it's the source of truth for the guest contract, so no spar regen.

## Verification

- `cargo check -p rivet-core --features wasm --tests` → compiles (was E0560)
- `cargo test -p rivet-core --features wasm --lib wasm_runtime` → 13/13 pass
- default (no-wasm) build unaffected; `rivet validate` PASS; fmt + clippy clean

Filed as REQ-227 (traces-to REQ-008 "WASM component adapters"); first item of the
v0.19.0 "Release & CI hardening" track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)