### PR TITLE
feat(coverage): combined V-closure metric — satisfied AND verified (REQ-228)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7324,3 +7324,45 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-23T18:00:00Z
+
+  - id: REQ-228
+    type: requirement
+    title: "`rivet coverage` reports a combined V-closure metric (satisfied AND verified) per source type"
+    status: verified
+    description: |
+      Fast-follow from #555/#559 (V-model). Per-rule coverage answers "how many
+      requirements are satisfied?" and, separately, "how many are verified?" —
+      but a release needs the intersection: a requirement is closed in the V only
+      when it is BOTH satisfied (left side) AND verified (right side). The
+      per-rule numbers hide this — a type can be 100% on each rule individually
+      yet have lower closure when different artifacts miss different rules.
+
+      `CoverageReport::v_closure()` computes, for every source type governed by
+      >1 traceability rule, the share of artifacts not strictly missing on ANY
+      applicable rule (covered OR external-boundary on each — the same 3-state
+      "accounted" convention as per-rule coverage; a supplier-delegated
+      derivative counts as closed). Single-rule types are omitted (their closure
+      is just that rule's coverage). `rivet coverage` prints a `V-closure:` line
+      per such type; `--format json` adds a `closure` array with
+      closed/total/open_ids/percentage/rule_names.
+
+      Acceptance:
+        - `rivet coverage` prints `V-closure: requirement (all N rules)  P%`
+          when requirements have both a satisfies and a verifies rule.
+        - The closure percentage is <= each contributing rule's percentage.
+        - `rivet coverage --format json` emits `closure[]` with per-type
+          closed/total/open_ids; a single-rule type produces no entry.
+        - `cargo test -p rivet-core --lib coverage` and the cli coverage suite
+          pass; fmt + clippy clean.
+    tags: [coverage, v-model, traceability, dogfooding]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.19.0-track
+    links:
+      - type: traces-to
+        target: REQ-004
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-23T18:30:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -7242,6 +7242,23 @@ fn cmd_coverage(
         let checks_covered: usize = report.entries.iter().map(|e| e.covered).sum();
         let external_boundary: usize = report.entries.iter().map(|e| e.external_boundary).sum();
         let overall_pct = (report.overall_coverage() * 10.0).round() / 10.0;
+        // V-closure: intersection of all rules per source type (both sides of
+        // the V). Each entry rounds its percentage to one decimal to match the
+        // text view and the `overall` block.
+        let closure_json: Vec<serde_json::Value> = report
+            .v_closure()
+            .into_iter()
+            .map(|c| {
+                serde_json::json!({
+                    "source_type": c.source_type,
+                    "rule_names": c.rule_names,
+                    "closed": c.closed,
+                    "total": c.total,
+                    "open_ids": c.open_ids,
+                    "percentage": (c.percentage() * 10.0).round() / 10.0,
+                })
+            })
+            .collect();
         let mut output = serde_json::json!({
             "command": "coverage",
             "rules": rules_json,
@@ -7251,6 +7268,7 @@ fn cmd_coverage(
                 "checks_total": checks_total,
                 "percentage": overall_pct,
             },
+            "closure": closure_json,
         });
         if let Some(ref name) = variant_name {
             output["variant"] = serde_json::Value::String(name.clone());
@@ -7311,6 +7329,26 @@ fn cmd_coverage(
         let overall = report.overall_coverage();
         println!("  {}", "-".repeat(80));
         println!("  {:<52} {:>7.1}%", "Overall (weighted)", overall);
+
+        // V-closure: for any source type governed by >1 rule, the share that
+        // satisfies EVERY rule (e.g. requirements that are both satisfied AND
+        // verified — both sides of the V closed). Strictly stronger than the
+        // per-rule numbers above, so it gets its own line.
+        let closure = report.v_closure();
+        for c in &closure {
+            let label = format!(
+                "V-closure: {} (all {} rules)",
+                c.source_type,
+                c.rule_names.len()
+            );
+            println!(
+                "  {:<52} {:>7.1}%  [{}/{}]",
+                label,
+                c.percentage(),
+                c.closed,
+                c.total
+            );
+        }
 
         // 3-state breakdown for the auditor — only printed when at least
         // one boundary exists, to keep the common case uncluttered.

--- a/rivet-core/src/coverage.rs
+++ b/rivet-core/src/coverage.rs
@@ -121,6 +121,46 @@ impl CoverageEntry {
     }
 }
 
+/// V-closure for one source artifact type: the *intersection* of every
+/// traceability rule that applies to it.
+///
+/// Per-rule coverage answers "how many requirements are satisfied?" and,
+/// separately, "how many are verified?" — but a release needs the **both**:
+/// a requirement is closed in the V only when it is satisfied (left side)
+/// *and* verified (right side). This is strictly stronger than per-rule
+/// coverage — a type can be 100% on each rule individually yet have lower
+/// closure when *different* artifacts miss *different* rules.
+///
+/// `closed` follows the same 3-state convention as [`CoverageEntry`]: an
+/// artifact is closed when it is not *strictly missing* on any applicable
+/// rule (covered OR external-boundary on each). `open_ids` is the union of
+/// the applicable rules' `uncovered_ids` — the artifacts missing at least
+/// one side.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ClosureEntry {
+    /// Source artifact type (e.g. `"requirement"`).
+    pub source_type: String,
+    /// Names of the rules intersected (always ≥ 2).
+    pub rule_names: Vec<String>,
+    /// Total source artifacts of this type.
+    pub total: usize,
+    /// Artifacts not strictly missing on any applicable rule.
+    pub closed: usize,
+    /// IDs strictly missing on at least one applicable rule (sorted, unique).
+    pub open_ids: Vec<String>,
+}
+
+impl ClosureEntry {
+    /// Closure percentage (0..100). Returns 100 when total is 0.
+    pub fn percentage(&self) -> f64 {
+        if self.total == 0 {
+            100.0
+        } else {
+            (self.closed as f64 / self.total as f64) * 100.0
+        }
+    }
+}
+
 /// Full coverage report across all traceability rules.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CoverageReport {
@@ -136,6 +176,54 @@ impl CoverageReport {
         }
         let covered: usize = self.entries.iter().map(|e| e.covered).sum();
         (covered as f64 / total as f64) * 100.0
+    }
+
+    /// V-closure across every source type that is governed by more than one
+    /// traceability rule — the intersection of those rules (e.g. the count
+    /// of requirements that are BOTH satisfied AND verified). Source types
+    /// with a single rule are omitted: their closure is just that rule's
+    /// coverage, so there is nothing new to report. Entries preserve the
+    /// first-seen order of source types in `self.entries`.
+    pub fn v_closure(&self) -> Vec<ClosureEntry> {
+        use std::collections::BTreeSet;
+
+        // Group rule-entries by source type, preserving first-seen order.
+        let mut order: Vec<&str> = Vec::new();
+        for e in &self.entries {
+            if !order.contains(&e.source_type.as_str()) {
+                order.push(&e.source_type);
+            }
+        }
+
+        let mut out = Vec::new();
+        for st in order {
+            let group: Vec<&CoverageEntry> = self
+                .entries
+                .iter()
+                .filter(|e| e.source_type == st)
+                .collect();
+            if group.len() < 2 {
+                continue;
+            }
+            // Every rule over the same source type sees the same artifact
+            // population; take the max defensively in case a rule scoped its
+            // total differently.
+            let total = group.iter().map(|e| e.total).max().unwrap_or(0);
+            let open: BTreeSet<&str> = group
+                .iter()
+                .flat_map(|e| e.uncovered_ids.iter().map(String::as_str))
+                .collect();
+            let open_ids: Vec<String> = open.iter().map(|s| s.to_string()).collect();
+            let closed = total.saturating_sub(open_ids.len());
+            out.push(ClosureEntry {
+                source_type: st.to_string(),
+                rule_names: group.iter().map(|e| e.rule_name.clone()).collect(),
+                total,
+                closed,
+                open_ids,
+            });
+        }
+        out
     }
 
     /// Serialize the report to a JSON string.
@@ -797,5 +885,76 @@ mod tests {
         assert_eq!(entry.covered, 1, "SG-A covered via alternate backlink");
         assert_eq!(entry.uncovered_ids, vec!["SG-B"]);
         assert_eq!(entry.total, 2);
+    }
+
+    fn rule_entry(rule: &str, source: &str, total: usize, uncovered: &[&str]) -> CoverageEntry {
+        CoverageEntry {
+            rule_name: rule.into(),
+            description: String::new(),
+            source_type: source.into(),
+            link_type: "x".into(),
+            direction: CoverageDirection::Backward,
+            target_types: vec![],
+            covered: total - uncovered.len(),
+            external_boundary: 0,
+            external_boundary_ids: vec![],
+            total,
+            uncovered_ids: uncovered.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    // rivet: verifies REQ-228
+    #[test]
+    fn v_closure_is_the_intersection_not_the_per_rule_average() {
+        // Two rules over `requirement`: satisfies (left side of the V) and
+        // verifies (right side). REQ-002 misses satisfies; REQ-003 misses
+        // verifies. Each rule alone is 2/3, but only REQ-001 is closed on
+        // BOTH — closure is 1/3, strictly lower than either rule.
+        let report = CoverageReport {
+            entries: vec![
+                rule_entry("req-satisfies", "requirement", 3, &["REQ-002"]),
+                rule_entry("req-verifies", "requirement", 3, &["REQ-003"]),
+            ],
+        };
+
+        let closure = report.v_closure();
+        assert_eq!(closure.len(), 1, "one source type with ≥2 rules");
+        let c = &closure[0];
+        assert_eq!(c.source_type, "requirement");
+        assert_eq!(c.rule_names, vec!["req-satisfies", "req-verifies"]);
+        assert_eq!(c.total, 3);
+        assert_eq!(c.closed, 1, "only REQ-001 satisfies BOTH rules");
+        assert_eq!(c.open_ids, vec!["REQ-002", "REQ-003"]);
+        assert!((c.percentage() - 33.333).abs() < 0.01);
+    }
+
+    #[test]
+    fn v_closure_omits_single_rule_types_and_counts_external_boundary_as_closed() {
+        let mut satisfies = rule_entry("req-satisfies", "requirement", 3, &[]);
+        // REQ-003 is delegated to a supplier on the verifies side: it is an
+        // external-boundary, NOT strictly missing, so it stays closed.
+        let mut verifies = rule_entry("req-verifies", "requirement", 3, &[]);
+        verifies.covered = 2;
+        verifies.external_boundary = 1;
+        verifies.external_boundary_ids = vec!["REQ-003".into()];
+        satisfies.covered = 3;
+
+        let report = CoverageReport {
+            entries: vec![
+                satisfies,
+                verifies,
+                // A single-rule type contributes no closure entry.
+                rule_entry("dd-justifies", "design-decision", 2, &["DD-002"]),
+            ],
+        };
+
+        let closure = report.v_closure();
+        assert_eq!(closure.len(), 1, "design-decision (single rule) omitted");
+        assert_eq!(closure[0].source_type, "requirement");
+        assert_eq!(
+            closure[0].closed, 3,
+            "external-boundary REQ-003 counts as closed (accounted)"
+        );
+        assert!(closure[0].open_ids.is_empty());
     }
 }


### PR DESCRIPTION
Fast-follow from #555 (requirement-verification rule) and #559 (`rivet verify`).

## Why

Per-rule coverage answers "how many requirements are satisfied?" and, separately,
"how many are verified?" — but a release needs the **intersection**: a requirement
is closed in the V only when it's BOTH satisfied (left side) AND verified (right
side). The per-rule numbers hide this — a type can be 100% on each rule yet have
lower closure when *different* artifacts miss *different* rules.

## What

`CoverageReport::v_closure()`: for every source type governed by >1 traceability
rule, the share of artifacts not strictly missing on **any** applicable rule
(covered OR external-boundary on each — the same 3-state "accounted" convention as
per-rule coverage, so a supplier-delegated derivative counts as closed). Single-rule
types are omitted (their closure is just that rule's coverage).

- `rivet coverage` → `V-closure: requirement (all 2 rules)  12.8%  [29/227]`
- `rivet coverage --format json` → `closure[]` with `closed/total/open_ids/percentage/rule_names`

## On this repo

Requirements are **12.8% V-closed** (29/227) vs 25.1% satisfied — the metric
surfaces the verification gap the per-rule numbers hide.

## Verification

- `cargo test -p rivet-core --lib coverage` (45) + cli coverage suite (16) pass
- `rivet validate` PASS; fmt + clippy clean
- REQ-228 dogfood-verified through `rivet verify REQ-228 --scan` (#559's command)

Filed as REQ-228 (traces-to REQ-004). v0.19.0 item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)