### PR TITLE
fix(yaml): parse plain multi-line scalars as sequence items (#570)

### DIFF
--- a/rivet-core/src/yaml_cst.rs
+++ b/rivet-core/src/yaml_cst.rs
@@ -795,6 +795,31 @@ impl<'src> Parser<'src> {
                         if self.at(SyntaxKind::Comment) {
                             self.bump();
                         }
+                        // Multi-line plain scalars as sequence items: consume
+                        // continuation lines indented deeper than the `-`, that
+                        // don't start a new sequence item or mapping entry. This
+                        // mirrors the mapping-value path in `parse_mapping_entry`
+                        // — a plain scalar that folds across lines is valid YAML
+                        // (e.g. a wrapped `causal-factors:` list item). Without
+                        // it the continuation line was misread as a new mapping
+                        // key ("expected ':' after mapping key"). The `indent`
+                        // here is the dash column, so the shared helper's
+                        // strictly-deeper test correctly excludes sibling items.
+                        while self.at(SyntaxKind::Newline) {
+                            if !self.is_plain_scalar_continuation(indent) {
+                                break;
+                            }
+                            self.bump(); // newline
+                            while !self.at_eof()
+                                && !self.at(SyntaxKind::Newline)
+                                && !self.at(SyntaxKind::Comment)
+                            {
+                                self.bump();
+                            }
+                            if self.at(SyntaxKind::Comment) {
+                                self.bump();
+                            }
+                        }
                     }
                 }
                 Some(SyntaxKind::Newline | SyntaxKind::Comment) => {
@@ -1233,6 +1258,29 @@ artifacts:
     fn multiline_plain_scalar_nested() {
         parse_and_check(
             "items:\n  - id: X\n    fields:\n      alt: Rejected because it\n        requires separate deploy.\n\n  - id: Y\n    title: Next\n",
+        );
+    }
+
+    /// Regression (#570): a plain (unquoted) multi-line scalar used as a
+    /// *sequence item* that wraps onto an indented continuation line. The
+    /// continuation was misread as a new mapping key
+    /// ("expected ':' after mapping key" / "expected mapping key, found
+    /// Some(Dash)"). This is the dominant shape in STPA `causal-factors:` /
+    /// wrapped `scenario` lists. Valid YAML — PyYAML/serde_yaml accept it.
+    #[test]
+    fn multiline_plain_scalar_sequence_item() {
+        parse_and_check(
+            "causal-factors:\n  - Base offset calculation uses defined_function_count instead of\n    total_function_count (imports plus defined)\n",
+        );
+    }
+
+    /// The continuation absorb must not swallow a following sibling item or a
+    /// deeper nested mapping: a wrapped item, then a single-line sibling, then
+    /// a `- id:`-style mapping item must all parse cleanly.
+    #[test]
+    fn multiline_plain_scalar_sequence_item_then_siblings() {
+        parse_and_check(
+            "items:\n  - first item that wraps onto\n    a second line\n  - second single-line item\n  - id: X\n    title: a mapping item\n",
         );
     }
 


### PR DESCRIPTION
Fixes #570.

## The bug

`parse_block_sequence` consumed only the **first line** of a plain (unquoted) scalar used as a sequence item. A continuation line indented past the `-` was then re-entered as a new mapping entry → `expected ':' after mapping key` / `expected mapping key, found Some(Dash)`.

`parse_mapping_entry` already handles this for mapping **values** via `is_plain_scalar_continuation` (yaml_cst.rs:686-700). This PR applies the identical continuation loop to sequence-item values, passing the **dash column** as the indent boundary so the helper's strictly-deeper test still excludes sibling `-` items and nested `key:` mappings. ~20 lines, reusing proven logic.

## Why it matters beyond the parse error (the important part)

On recovery, the mis-parse didn't just emit a diagnostic — it **dropped the `links:` block that followed the scalar within the same artifact**. Those links became invisible to validation.

Measured on a real project (pulseengine/meld, 19 docs / 208 artifacts):

| | unpatched (origin/main) | patched |
|---|---|---|
| `rivet validate` | **PASS — exit 0** | **FAIL — exit 1** |
| errors | 0 | 77 |
| warnings | 405 | 154 |

The unpatched binary returns a **false green**: requirements' `derives-from`/`tracked-by` edges and `verifies`/`satisfies` backlinks inside scalar-bearing artifacts were silently omitted, so dangling-target and coverage rules never fired. With the fix the same project parses fully and validation is honest — the 405 vague "missing backlink" warnings collapse (links now register) and the genuinely-dangling links surface as errors (e.g. `derives-from targets '#130'`, unmodeled `issued-by` controllers).

A verifier that drops the trace edges it can't parse is worse than one that errors loudly. This is a soundness fix, not cosmetics.

## Tests

- `multiline_plain_scalar_sequence_item` — the #570 repro.
- `multiline_plain_scalar_sequence_item_then_siblings` — boundary guard: a wrapped item followed by a single-line sibling and a `- id:` mapping item must all parse.
- Full `rivet-core` lib suite green (1142 passed); fmt + clippy clean.

Found dogfooding rivet on meld's safety traceability (meld#303 / the v0.36 enforced-traceability work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)