### PR TITLE
chore(release): v0.19.0 — measure the V

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-06-24
+
+Theme: **measure the V** — a combined closure metric plus build/parse fixes.
+
+### Added
+
+- **REQ-228 / #571 — combined V-closure metric in `rivet coverage`.** For every
+  source type governed by more than one traceability rule, `rivet coverage` now
+  reports the *intersection* — the share of artifacts satisfying **every**
+  applicable rule (e.g. requirements that are BOTH satisfied AND verified). This
+  is strictly stronger than the per-rule numbers, which hide the gap when
+  different artifacts miss different rules: on this repo requirements are 12.8%
+  V-closed vs 25.1% satisfied. `--format json` gains a `closure` array
+  (`closed`/`total`/`open_ids`/`percentage`/`rule_names`). External-boundary
+  (supplier-delegated) artifacts count as closed, matching the 3-state
+  `accounted` convention.
+
+### Fixed
+
+- **REQ-227 / #543 — `rivet-core --features wasm` test build compiles.** The
+  host `model::Link` gained an `external` field (prefix:ID externals); an
+  "add it everywhere" pass had leaked it into the WIT-generated `types::Link`
+  constructors, which carry only `link-type` + `target`, breaking
+  `cargo test -p rivet-core --features wasm` (E0560). The host→WIT conversion
+  now omits the host-only field; the `.wit` is unchanged.
+- **#572 / #570 — YAML plain multi-line scalars parse as sequence items.** The
+  rowan-yaml CST no longer mis-folds a plain multi-line scalar that continues
+  onto an indented next line.
+
 ## [0.18.0] - 2026-06-23
 
 Theme: **close the right side of the V** — make requirement→test→evidence a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release-prep for **v0.19.0**. Bumps `Cargo.toml [workspace.package]`,
`vscode-rivet/package.json`, `Cargo.lock` to 0.19.0; CHANGELOG `[Unreleased]` → `[0.19.0]`.

## Scope (all merged to `main`)

| Item | REQ | PR |
|------|-----|----|
| Combined **V-closure** metric in `rivet coverage` (satisfied AND verified) | REQ-228 | #571 |
| `rivet-core --features wasm` test build compiles (drop host-only `Link.external`) | REQ-227 | #543 / #569 |
| YAML plain multi-line scalars parse as sequence items | — | #570 / #572 |

Schemas unchanged (common@0.3.0, dev@0.2.0).

## Local verification
- `rivet validate` → PASS
- `rivet docs check` → PASS (0 violations)

After merge: signed tag `v0.19.0` → release + npm; verify `npm view @pulseengine/rivet version` == 0.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)