### PR TITLE
design: SQL virtual-table facade over the live store — CLI-first, no MCP required (REQ-229, DD-068)

### DIFF
--- a/artifacts/decisions.yaml
+++ b/artifacts/decisions.yaml
@@ -1274,3 +1274,67 @@ artifacts:
       model: claude-opus-4-7
       session-id: mythos-slop-hunt-needs-json-whole-block
       timestamp: 2026-04-25T00:00:00Z
+
+  - id: DD-068
+    type: design-decision
+    title: SQL virtual-table facade over the live artifact store (CLI-first, transport-agnostic)
+    status: proposed
+    description: >
+      Expose the artifact graph as a SQL interface so agents can use the query
+      language LLMs know best, including JOINs/aggregations the s-expression
+      filter cannot express. Decision: project the live in-memory store as
+      SQLite VIRTUAL tables (rusqlite vtab module) — the tables are backed by
+      `Store`/`LinkGraph` via xFilter, NOT materialized rows, so YAML stays the
+      single source of truth and reads are never stale. The SQL executor lives in
+      a shared core module; transports are thin wrappers over it.
+    tags: [sql, virtual-tables, agent-interface, architecture, serve, mcp, cli]
+    links:
+      - type: satisfies
+        target: REQ-229
+    fields:
+      baseline: v0.20.0-track
+      source-ref: "new: rivet-core/src/sql/ (executor + vtab module); rivet-cli/src/main.rs (cmd_sql); rivet-cli/src/serve.rs (POST /sql); rivet-cli/src/mcp.rs (rivet_sql tool)"
+      rationale: |
+        Why SQL: it is the highest-training-data query language for LLMs and the
+        only one of rivet's surfaces that expresses relational questions
+        (satisfied-AND-verified, per-release readiness) as one-liners instead of
+        bespoke Rust (cf. the V-closure metric, REQ-228, hand-written).
+
+        Why VIRTUAL tables (rusqlite vtab), not a materialized export: a SQLite
+        `.db` export goes stale the instant an artifact changes and needs a
+        re-export step. A vtab module projects the live store on xFilter and
+        routes writes via xUpdate — SQLite stores nothing, so there is no second
+        database to keep in sync and a write CANNOT bypass schema validation or
+        provenance (xUpdate calls the same `mutate` path `rivet_add`/`rivet_modify`
+        already use).
+
+        Why CLI-first / transport-agnostic (HARD constraint, REQ-229): some
+        deployment environments forbid adding MCP servers. The executor therefore
+        lives in the core, and the BASELINE transport is `rivet sql "<query>"` —
+        no server, no MCP, works in CI/sandboxes/shell-only agents. `rivet serve`
+        adds `POST /sql` and the MCP server adds a `rivet_sql` tool, both as thin
+        wrappers over the same executor. MCP is one transport, never the only one.
+
+        Phasing: READ-ONLY first (REQ-229) — all query value, zero YAML-corruption
+        risk. WRITE path (xUpdate → mutate → validate → YAML → reload) is a
+        deliberate SECOND slice behind its own REQ, because: (a) xUpdate is
+        per-row but `mutate` is per-artifact-file (transaction-boundary decision);
+        (b) writes must validate-before-commit so `UPDATE ... SET status='bogus'`
+        is rejected, not silently written; (c) `mutate::render_artifact_yaml` is a
+        hand-rolled allowlist serializer that silently DROPS any field it does not
+        emit, so the write path needs round-trip fidelity tests or fields vanish.
+      alternatives: >
+        (1) `rivet export --format sqlite` (materialized snapshot) — rejected as
+        the primary mechanism: stale-on-write, needs re-export, read-only; kept as
+        a possible offline/compliance-bundle convenience, not the query surface.
+        (2) DataFusion TableProvider — strong reads but weak/awkward INSERT/UPDATE;
+        rusqlite vtab's xUpdate is the cleaner writable-virtual contract.
+        (3) Extend the s-expression `rivet query` with joins — rejected: reinvents
+        SQL with near-zero LLM training data. (4) MCP-only `rivet_sql` tool —
+        rejected: violates the no-MCP constraint; MCP must be one transport among
+        CLI + HTTP. (5) Let SQL writes edit YAML directly — rejected: bypasses
+        schema validation and provenance; all writes go through `mutate`.
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-24T09:00:00Z

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7366,3 +7366,56 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-23T18:30:00Z
+
+  - id: REQ-229
+    type: requirement
+    title: "rivet exposes a SQL query interface over the artifact store, usable WITHOUT MCP or a running server"
+    status: proposed
+    description: |
+      Agents query rivet today via a bespoke s-expression filter (`rivet query
+      "(= (field \"x\") \"y\")"`) for reads and `rivet add`/`modify` for writes —
+      two languages, neither of which LLMs have meaningful training data on, and
+      neither of which expresses JOINs/aggregations (the V-closure query is
+      bespoke Rust). SQL is the most LLM-legible query language and expresses the
+      relational questions (satisfied-AND-verified, coverage rollups) directly.
+
+      Provide a SQL read interface over the artifact graph projected as virtual
+      tables — `artifacts(id,type,title,description,status)`,
+      `links(source,link_type,target,external)`, `fields(artifact_id,key,value)`
+      + `fields_json`, `provenance(...)` — backed by the live in-memory store
+      (the YAML files remain the single source of truth; SQLite stores no rows).
+
+      CONSTRAINT (hard): the interface MUST be usable with **no MCP server and no
+      running `rivet serve`** — many environments forbid adding MCP servers. The
+      baseline transport is a plain CLI command `rivet sql "<query>"` that loads
+      the project, runs the query, and prints results. The same shared executor
+      is ALSO reachable via `rivet serve` (`POST /sql`) and an MCP `rivet_sql`
+      tool, but those are additive — the CLI path is the lowest common
+      denominator (CI, scripts, sandboxes, agents that can only shell out).
+
+      This requirement is the READ-ONLY MVP. The read/write `xUpdate` path
+      (SQL INSERT/UPDATE/DELETE routed through `mutate` + `validate`) is a
+      deliberate second slice (separate REQ) so the YAML-corrupting write path is
+      gated behind its own review. Design recorded in DD-068.
+
+      Acceptance:
+        - `rivet sql "SELECT id FROM artifacts WHERE status='implemented'"`
+          returns matching ids with NO server and NO MCP running.
+        - A JOIN query reproduces the V-closure set, e.g.
+          `SELECT id FROM artifacts WHERE status='implemented' AND id NOT IN
+          (SELECT target FROM links WHERE link_type='verifies')`.
+        - `--format json` emits structured rows; `--format csv` emits a table.
+        - Results reflect the current on-disk artifacts (no stale snapshot).
+        - `cargo test -p rivet-cli` covers the schema projection + a JOIN.
+    tags: [sql, query, agent-interface, cli, virtual-tables]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.20.0-track
+    links:
+      - type: traces-to
+        target: REQ-007
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-24T09:00:00Z


### PR DESCRIPTION
Design artifacts only (no code yet) — captures the architecture for a SQL query
interface over rivet's artifact graph, per discussion.

## Decision (DD-068)
Project the **live in-memory store** as SQLite **virtual tables** (rusqlite vtab):
tables backed by `Store`/`LinkGraph` via `xFilter`, **not** materialized rows — so
YAML stays the single source of truth and reads never go stale. SQL gives agents
the query language LLMs know best, plus JOINs/aggregations the s-expr filter can't
express (the V-closure query becomes a one-liner instead of bespoke Rust).

## Hard constraint (REQ-229): no MCP, no server required
The shared executor lives in core; the **baseline transport is `rivet sql "<query>"`**
— a plain CLI command, no server, no MCP (works in CI, sandboxes, shell-only agents,
and environments that forbid adding MCP servers). `rivet serve` (`POST /sql`) and an
MCP `rivet_sql` tool are **additive** wrappers over the same executor.

## Phasing
- **REQ-229 (this MVP): read-only** — all query value, zero YAML-corruption risk.
- **Write path (future REQ): `xUpdate` → `mutate` → `validate` → YAML → reload** —
  gated behind its own review, because xUpdate (per-row) vs mutate (per-file) is a
  transaction-boundary decision, writes must validate-before-commit, and
  `render_artifact_yaml` silently drops un-emitted fields (round-trip tests required).

`rivet validate` PASS. This is the design-leads-implementation first step; the
read-only `cmd_sql` build follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)