### PR TITLE
feat(sql): `rivet sql` — read-only SQL over the store, no MCP/server (REQ-229)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1031,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1371,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1377,6 +1404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1962,6 +1998,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2832,6 +2879,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rowan 0.16.2",
+ "rusqlite",
  "salsa",
  "serde",
  "serde_json",
@@ -2915,6 +2963,20 @@ dependencies = [
  "hashbrown 0.15.5",
  "rustc-hash 2.1.2",
  "text-size",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3038,7 +3100,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "intrusive-collections",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,10 @@ rowan = { git = "https://github.com/pulseengine/rowan.git", branch = "fix/miri-s
 # Markdown rendering
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 
+# SQL facade over the artifact store (REQ-229 / DD-068). `bundled` compiles
+# SQLite from source so there is no system libsqlite3 dependency.
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # Benchmarking
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1240,6 +1240,27 @@ enum Command {
         variant: Option<String>,
     },
 
+    /// Run a SQL query over the artifact store (REQ-229 / DD-068)
+    ///
+    /// Projects the artifacts as virtual tables and runs read-only SQL — no
+    /// server and no MCP required. Tables: `artifacts(id, type, title,
+    /// description, status, fields_json)`, `links(source, link_type, target,
+    /// external)`, `fields(artifact_id, key, value)`, `provenance(...)`. SQL
+    /// gives JOINs/aggregations the s-expression filter can't express, e.g. the
+    /// V-closure set:
+    ///   rivet sql "SELECT id FROM artifacts WHERE status='implemented'
+    ///     AND id NOT IN (SELECT target FROM links WHERE link_type='verifies')"
+    Sql {
+        /// The SQL query (must start with SELECT or WITH; writes are a planned
+        /// follow-up slice).
+        #[arg(value_name = "QUERY")]
+        query: String,
+
+        /// Output format: "table" (default), "json", or "csv".
+        #[arg(short, long, default_value = "table")]
+        format: String,
+    },
+
     /// Stamp artifact(s) with AI provenance metadata
     Stamp {
         /// Artifact ID to stamp, "all" for every artifact, or a glob/prefix
@@ -2730,6 +2751,7 @@ fn run(cli: Cli) -> Result<bool> {
                 ),
             }
         }
+        Command::Sql { query, format } => cmd_sql(&cli, query, format),
         Command::Stamp {
             id,
             created_by,
@@ -16184,6 +16206,107 @@ fn cmd_mcp(cli: &Cli, list_tools: bool, probe: bool, format: &str) -> Result<boo
 /// Three output formats: `text` (one line per match, id + title + status),
 /// `json` (MCP-shape: `{filter, count, total, truncated, artifacts[]}`),
 /// or `ids` (newline-separated IDs — handy for shell pipelines).
+/// `rivet sql` — read-only SQL over the artifact store (REQ-229 / DD-068).
+///
+/// Loads the project, projects it into an in-memory SQLite (tables backed by
+/// the live store, rebuilt per invocation so results are never stale), runs the
+/// query, and prints `table` / `json` / `csv`. No server and no MCP required.
+fn cmd_sql(cli: &Cli, query: &str, format: &str) -> Result<bool> {
+    validate_format(format, &["table", "json", "csv"])?;
+
+    let project = rivet_core::load_project_full(&cli.project)
+        .with_context(|| format!("loading project from {}", cli.project.display()))?;
+
+    let result =
+        rivet_core::sql::query(&project.store, query).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    match format {
+        "json" => {
+            // One JSON object per row, keyed by column name — the shape an LLM
+            // expects back from a SELECT.
+            let objs: Vec<serde_json::Value> = result
+                .rows
+                .iter()
+                .map(|row| {
+                    let map: serde_json::Map<String, serde_json::Value> = result
+                        .columns
+                        .iter()
+                        .zip(row)
+                        .map(|(c, v)| (c.clone(), serde_json::Value::String(v.clone())))
+                        .collect();
+                    serde_json::Value::Object(map)
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&objs)?);
+        }
+        "csv" => {
+            println!(
+                "{}",
+                result
+                    .columns
+                    .iter()
+                    .map(|c| csv_escape(c))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+            for row in &result.rows {
+                println!(
+                    "{}",
+                    row.iter()
+                        .map(|c| csv_escape(c))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                );
+            }
+        }
+        _ => {
+            // Aligned text table.
+            let mut widths: Vec<usize> = result.columns.iter().map(|c| c.chars().count()).collect();
+            for row in &result.rows {
+                for (i, cell) in row.iter().enumerate() {
+                    if let Some(w) = widths.get_mut(i) {
+                        *w = (*w).max(cell.chars().count());
+                    }
+                }
+            }
+            let render = |cells: &[String]| {
+                cells
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| {
+                        format!("{:<width$}", c, width = widths.get(i).copied().unwrap_or(0))
+                    })
+                    .collect::<Vec<_>>()
+                    .join("  ")
+            };
+            println!("{}", render(&result.columns));
+            println!(
+                "{}",
+                widths
+                    .iter()
+                    .map(|w| "-".repeat(*w))
+                    .collect::<Vec<_>>()
+                    .join("  ")
+            );
+            for row in &result.rows {
+                println!("{}", render(row));
+            }
+            eprintln!("\n{} row(s)", result.rows.len());
+        }
+    }
+    Ok(true)
+}
+
+/// Minimal RFC-4180 CSV escaping: quote a field containing comma, quote, CR or
+/// LF and double any embedded quotes.
+fn csv_escape(s: &str) -> String {
+    if s.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
 fn cmd_query(
     cli: &Cli,
     sexpr: &str,

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1320,6 +1320,64 @@ fn list_json() {
     );
 }
 
+/// `rivet sql` runs read-only SQL over the store with no server/MCP (REQ-229).
+/// Covers the schema projection and a JOIN (the V-closure query).
+// rivet: verifies REQ-229
+#[test]
+fn sql_join_and_json_over_the_store() {
+    // JOIN: requirements with no incoming `verifies` link — the V-closure set.
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "sql",
+            "SELECT id FROM artifacts WHERE type='requirement' \
+             AND id NOT IN (SELECT target FROM links WHERE link_type='verifies') \
+             ORDER BY id",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute rivet sql");
+
+    assert!(
+        output.status.success(),
+        "rivet sql must exit 0. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("sql JSON must be valid");
+    let rows = parsed
+        .as_array()
+        .expect("sql --format json is an array of rows");
+    assert!(
+        rows.iter()
+            .all(|r| r.get("id").and_then(|v| v.as_str()).is_some()),
+        "each row must carry the projected `id` column"
+    );
+}
+
+/// `rivet sql` refuses writes in the read-only MVP (REQ-229).
+// rivet: verifies REQ-229
+#[test]
+fn sql_refuses_writes() {
+    let output = Command::new(rivet_bin())
+        .args([
+            "--project",
+            project_root().to_str().unwrap(),
+            "sql",
+            "UPDATE artifacts SET status='x'",
+        ])
+        .output()
+        .expect("failed to execute rivet sql");
+
+    assert!(!output.status.success(), "a write must be rejected");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("read-only"),
+        "error must explain reads-only"
+    );
+}
+
 /// `rivet list --format json` artifacts have expected fields.
 #[test]
 fn list_json_artifact_fields() {

--- a/rivet-core/Cargo.toml
+++ b/rivet-core/Cargo.toml
@@ -9,11 +9,15 @@ rust-version.workspace = true
 
 
 [features]
-default = ["aadl", "rowan-yaml"]
+default = ["aadl", "rowan-yaml", "sql"]
 rowan-yaml = []
 oslc = ["dep:reqwest", "dep:urlencoding"]
 wasm = ["dep:wasmtime", "dep:wasmtime-wasi"]
 aadl = ["dep:spar-hir", "dep:spar-analysis"]
+# REQ-229 / DD-068: SQL query facade over the artifact store. Kept in `default`
+# so `rivet sql` ships, but gated so the minimal `--no-default-features` build
+# (REQ-202) excludes the bundled SQLite C compile.
+sql = ["dep:rusqlite"]
 
 [dependencies]
 serde = { workspace = true }
@@ -30,6 +34,9 @@ quick-xml = { workspace = true }
 rowan = { workspace = true }
 pulldown-cmark = { workspace = true }
 etch = { path = "../etch" }
+
+# SQL facade (optional, behind "sql" feature) — REQ-229 / DD-068
+rusqlite = { workspace = true, optional = true }
 
 # OSLC client (optional, behind "oslc" feature)
 reqwest = { workspace = true, optional = true }

--- a/rivet-core/src/lib.rs
+++ b/rivet-core/src/lib.rs
@@ -82,6 +82,8 @@ pub mod sexpr;
 pub mod sexpr_eval;
 pub mod similarity;
 pub mod snapshot;
+#[cfg(feature = "sql")]
+pub mod sql;
 pub mod store;
 pub mod templates;
 pub mod test_scanner;

--- a/rivet-core/src/sql.rs
+++ b/rivet-core/src/sql.rs
@@ -1,0 +1,254 @@
+//! SQL query facade over the artifact store (REQ-229 / DD-068).
+//!
+//! Read-only MVP. Each call builds an **ephemeral in-memory SQLite** from the
+//! live store and runs the query against it. Because the CLI reloads the project
+//! on every invocation, results are never stale — this gives DD-068's "no stale
+//! snapshot" guarantee without a full `vtab` module. The `vtab` upgrade is only
+//! needed for the *write* path (`xUpdate`), which is a separate slice; reads at
+//! rivet's scale (hundreds of artifacts) don't need it.
+//!
+//! Tables projected from the [`Store`]:
+//! - `artifacts(id, type, title, description, status, fields_json)`
+//! - `links(source, link_type, target, external)`
+//! - `fields(artifact_id, key, value)`   — EAV; one row per field, for JOINs
+//! - `provenance(artifact_id, created_by, model, session_id, timestamp, reviewed_by)`
+//!
+//! Only read statements (`SELECT` / `WITH`) are accepted; writes are refused
+//! with a pointer to the planned write slice.
+
+#![cfg(feature = "sql")]
+
+use crate::store::Store;
+use rusqlite::Connection;
+
+/// Tabular result of a SQL query: column names plus stringified rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SqlResult {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+/// Run a read-only SQL query against the artifact store.
+///
+/// Returns an error string for write statements (anything not starting with
+/// `SELECT` or `WITH`) or on SQL errors.
+pub fn query(store: &Store, sql: &str) -> Result<SqlResult, String> {
+    let head = sql
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    if head != "SELECT" && head != "WITH" {
+        return Err(format!(
+            "only read-only queries are supported (must start with SELECT or WITH; got `{head}`). \
+             SQL writes (INSERT/UPDATE/DELETE -> mutate) are a planned follow-up slice of REQ-229."
+        ));
+    }
+
+    let conn = Connection::open_in_memory().map_err(|e| e.to_string())?;
+    build_schema(&conn).map_err(|e| e.to_string())?;
+    populate(&conn, store).map_err(|e| e.to_string())?;
+    run_query(&conn, sql)
+}
+
+fn build_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE artifacts (
+            id          TEXT PRIMARY KEY,
+            type        TEXT NOT NULL,
+            title       TEXT,
+            description TEXT,
+            status      TEXT,
+            fields_json TEXT
+         );
+         CREATE TABLE links (
+            source    TEXT NOT NULL,
+            link_type TEXT NOT NULL,
+            target    TEXT NOT NULL,
+            external  TEXT
+         );
+         CREATE TABLE fields (
+            artifact_id TEXT NOT NULL,
+            key         TEXT NOT NULL,
+            value       TEXT
+         );
+         CREATE TABLE provenance (
+            artifact_id TEXT NOT NULL,
+            created_by  TEXT,
+            model       TEXT,
+            session_id  TEXT,
+            timestamp   TEXT,
+            reviewed_by TEXT
+         );",
+    )
+}
+
+fn populate(conn: &Connection, store: &Store) -> rusqlite::Result<()> {
+    for a in store.iter_sorted() {
+        let fields_json = serde_json::to_string(&a.fields).ok();
+        conn.execute(
+            "INSERT INTO artifacts (id, type, title, description, status, fields_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                a.id,
+                a.artifact_type,
+                a.title,
+                a.description,
+                a.status,
+                fields_json,
+            ],
+        )?;
+
+        for l in &a.links {
+            // `external` is non-null only for `*-external` link types; serialize
+            // the structured payload to JSON so it stays queryable.
+            let external = l
+                .external
+                .as_ref()
+                .and_then(|e| serde_json::to_string(e).ok());
+            conn.execute(
+                "INSERT INTO links (source, link_type, target, external) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![a.id, l.link_type, l.target, external],
+            )?;
+        }
+
+        for (key, value) in &a.fields {
+            conn.execute(
+                "INSERT INTO fields (artifact_id, key, value) VALUES (?1, ?2, ?3)",
+                rusqlite::params![a.id, key, yaml_value_to_sql(value)],
+            )?;
+        }
+
+        if let Some(p) = &a.provenance {
+            conn.execute(
+                "INSERT INTO provenance
+                   (artifact_id, created_by, model, session_id, timestamp, reviewed_by)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                rusqlite::params![
+                    a.id,
+                    p.created_by,
+                    p.model,
+                    p.session_id,
+                    p.timestamp,
+                    p.reviewed_by,
+                ],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Flatten a YAML field value to a SQL-friendly string: scalars become their
+/// natural text, complex values (sequences/maps) become compact JSON so they
+/// remain queryable with SQLite's `json_*` functions.
+fn yaml_value_to_sql(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::Null => None,
+        serde_yaml::Value::Bool(b) => Some(b.to_string()),
+        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        serde_yaml::Value::String(s) => Some(s.clone()),
+        other => serde_json::to_string(other).ok(),
+    }
+}
+
+fn run_query(conn: &Connection, sql: &str) -> Result<SqlResult, String> {
+    let mut stmt = conn.prepare(sql).map_err(|e| e.to_string())?;
+    let columns: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+    let col_count = columns.len();
+
+    let mut out_rows = Vec::new();
+    let mut rows = stmt.query([]).map_err(|e| e.to_string())?;
+    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+        let mut cells = Vec::with_capacity(col_count);
+        for i in 0..col_count {
+            let cell = row.get_ref(i).map_err(|e| e.to_string())?;
+            cells.push(value_ref_to_string(cell));
+        }
+        out_rows.push(cells);
+    }
+
+    Ok(SqlResult {
+        columns,
+        rows: out_rows,
+    })
+}
+
+fn value_ref_to_string(v: rusqlite::types::ValueRef<'_>) -> String {
+    use rusqlite::types::ValueRef;
+    match v {
+        ValueRef::Null => String::new(),
+        ValueRef::Integer(i) => i.to_string(),
+        ValueRef::Real(f) => f.to_string(),
+        ValueRef::Text(t) => String::from_utf8_lossy(t).into_owned(),
+        ValueRef::Blob(b) => format!("<blob {} bytes>", b.len()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{artifact_with_links, minimal_artifact};
+
+    fn store_with_v_model() -> Store {
+        let mut store = Store::new();
+        // REQ-1: implemented + verified (closed). REQ-2: implemented, no verify.
+        store
+            .insert(minimal_artifact("REQ-1", "requirement"))
+            .unwrap();
+        store
+            .insert(minimal_artifact("REQ-2", "requirement"))
+            .unwrap();
+        store
+            .insert(artifact_with_links(
+                "TEST-1",
+                "test",
+                &[("verifies", "REQ-1")],
+            ))
+            .unwrap();
+        store
+    }
+
+    // rivet: verifies REQ-229
+    #[test]
+    fn select_projects_artifacts_table() {
+        let store = store_with_v_model();
+        let r = query(
+            &store,
+            "SELECT id FROM artifacts WHERE type='requirement' ORDER BY id",
+        )
+        .unwrap();
+        assert_eq!(r.columns, vec!["id"]);
+        assert_eq!(
+            r.rows,
+            vec![vec!["REQ-1".to_string()], vec!["REQ-2".to_string()]]
+        );
+    }
+
+    // rivet: verifies REQ-229
+    #[test]
+    fn join_reproduces_v_closure_set() {
+        // The V-closure query: implemented requirements with no incoming verify.
+        // (minimal_artifact has no status, so emulate via the links join only.)
+        let store = store_with_v_model();
+        let r = query(
+            &store,
+            "SELECT id FROM artifacts
+             WHERE type='requirement'
+               AND id NOT IN (SELECT target FROM links WHERE link_type='verifies')
+             ORDER BY id",
+        )
+        .unwrap();
+        assert_eq!(
+            r.rows,
+            vec![vec!["REQ-2".to_string()]],
+            "only REQ-2 lacks a verify"
+        );
+    }
+
+    #[test]
+    fn writes_are_refused() {
+        let store = Store::new();
+        let err = query(&store, "UPDATE artifacts SET status='x'").unwrap_err();
+        assert!(err.contains("read-only"), "got: {err}");
+    }
+}


### PR DESCRIPTION
Implements the read-only MVP of REQ-229 / DD-068.

## What
`rivet sql "<query>"` runs read-only SQL over the artifact graph — **no server,
no MCP** (the hard constraint: some environments forbid adding MCP servers).
`rivet_core::sql::query` projects the live store into an ephemeral in-memory
SQLite, rebuilt per call so results are never stale (DD-068's "no stale snapshot"
without a `vtab` module — `vtab` lands with the write slice).

Tables: `artifacts(id, type, title, description, status, fields_json)`,
`links(source, link_type, target, external)`, `fields(artifact_id, key, value)`,
`provenance(...)`. Output: `table` / `json` / `csv`. Writes are refused with a
pointer to the planned write slice. Feature-gated `sql` (in `default`; bundled
SQLite so no system libsqlite3). The shared core executor is ready for serve
`POST /sql` + an MCP `rivet_sql` tool as additive transports.

## Why it matters
SQL expresses JOINs/aggregations the s-expr filter can't. The V-closure metric
(bespoke Rust in REQ-228) is now one query:
```
rivet sql "SELECT id FROM artifacts WHERE status='implemented'
  AND id NOT IN (SELECT target FROM links WHERE link_type='verifies')"
```
→ 102 open requirements on this repo.

## Verification
- core sql tests 3/3 (projection, V-closure JOIN, write-guard)
- cli suite **137/137** incl. 2 new `sql_*` integration tests
- live `rivet sql` (table/json/csv) on this repo
- `fmt` + `clippy --all-targets -D warnings` clean

Next slice (separate REQ): writable `xUpdate -> mutate -> validate -> YAML`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)