### PR TITLE
feat(sql): `rivet sql` write slice — UPDATE via validate + safe YAML edit (REQ-230)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7419,3 +7419,54 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-24T09:00:00Z
+
+  - id: REQ-230
+    type: requirement
+    title: "`rivet sql` supports writes (UPDATE) routed through validate + the safe YAML edit path"
+    status: proposed
+    description: |
+      Write slice of the SQL facade (REQ-229 / DD-068). Lets an agent CHANGE
+      artifacts through the same SQL surface it queries — the unification the
+      design promised — without a second language. As with reads, NO MCP and NO
+      server are required: `rivet sql "UPDATE artifacts SET status='verified'
+      WHERE id='REQ-1'"` works as a plain CLI command.
+
+      Mechanism (no parallel writer — reuses the existing validated path): the
+      write runs against the ephemeral in-memory SQLite (staging), then the
+      `artifacts` table is diffed against the live store. Each changed row is
+      translated to a `ModifyParams` and applied via `validate_modify` +
+      `yaml_edit::modify_artifact_in_file` — the indentation-safe editor that
+      does NOT go through the `render_artifact_yaml` allowlist, so unrelated
+      fields are preserved (the allowlist-drop trap DD-068 flagged). Validation
+      runs BEFORE any file is written: an `UPDATE ... SET status='bogus'` is
+      rejected, not silently persisted, and the whole statement is all-or-nothing.
+
+      Scope of THIS slice: `UPDATE artifacts SET {status|title|description}`.
+      Out of scope (clear errors, follow-up slices): writes to `fields`/`links`
+      (mapped to set-fields / link edits), `INSERT` (artifact creation via
+      `add`), `DELETE` (removal), and multi-statement transactions. A write that
+      changes the `fields`/`links` staging tables is REFUSED rather than silently
+      dropped.
+
+      Acceptance:
+        - `rivet sql "UPDATE artifacts SET status='verified' WHERE id='<X>'"`
+          updates the artifact's YAML (status changed, all other fields intact)
+          with no server/MCP.
+        - An invalid value (off-enum status) is rejected; the file is unchanged.
+        - A write touching unsupported tables (`fields`/`links`) or `INSERT`/
+          `DELETE` errors clearly, no partial write.
+        - Round-trip fidelity test: a sibling field on the same artifact survives
+          the SQL UPDATE (guards the allowlist-drop trap).
+        - `cargo test -p rivet-core` + cli suite pass; fmt + clippy clean.
+    tags: [sql, write, mutate, agent-interface, v-model]
+    fields:
+      priority: should
+      category: functional
+      baseline: v0.20.0-track
+    links:
+      - type: traces-to
+        target: REQ-007
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-24T10:00:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -16217,6 +16217,17 @@ fn cmd_sql(cli: &Cli, query: &str, format: &str) -> Result<bool> {
     let project = rivet_core::load_project_full(&cli.project)
         .with_context(|| format!("loading project from {}", cli.project.display()))?;
 
+    // Write verbs route through the validated mutate path (REQ-230); everything
+    // else is a read.
+    let head = query
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    if !matches!(head.as_str(), "SELECT" | "WITH") {
+        return cmd_sql_write(&project, query);
+    }
+
     let result =
         rivet_core::sql::query(&project.store, query).map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -16305,6 +16316,42 @@ fn csv_escape(s: &str) -> String {
     } else {
         s.to_string()
     }
+}
+
+/// `rivet sql` write path (REQ-230): translate a write statement into validated
+/// `ModifyParams` and apply them through the indentation-safe
+/// `modify_artifact_in_file` editor. All changes are validated BEFORE any file
+/// is written — an invalid value aborts the whole statement, nothing partial.
+fn cmd_sql_write(project: &rivet_core::LoadedProject, query: &str) -> Result<bool> {
+    let planned =
+        rivet_core::sql::plan_write(&project.store, query).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if planned.is_empty() {
+        eprintln!("0 artifacts changed");
+        return Ok(true);
+    }
+
+    // Validate every change first (schema enums, reserved keys, …) so a bad
+    // value can't leave a half-applied statement on disk.
+    for pw in &planned {
+        rivet_core::mutate::validate_modify(&pw.id, &pw.params, &project.store, &project.schema)
+            .map_err(|e| anyhow::anyhow!("rejected `{}`: {e}", pw.id))?;
+    }
+
+    // Apply through the safe YAML editor (preserves sibling fields).
+    for pw in &planned {
+        let src = project
+            .store
+            .get(&pw.id)
+            .and_then(|a| a.source_file.clone())
+            .ok_or_else(|| anyhow::anyhow!("no source file recorded for `{}`", pw.id))?;
+        rivet_core::mutate::modify_artifact_in_file(&pw.id, &pw.params, &src, &project.store)
+            .map_err(|e| anyhow::anyhow!("writing `{}`: {e}", pw.id))?;
+    }
+
+    let ids: Vec<&str> = planned.iter().map(|p| p.id.as_str()).collect();
+    eprintln!("{} artifact(s) updated: {}", planned.len(), ids.join(", "));
+    Ok(true)
 }
 
 fn cmd_query(

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1357,24 +1357,79 @@ fn sql_join_and_json_over_the_store() {
     );
 }
 
-/// `rivet sql` refuses writes in the read-only MVP (REQ-229).
-// rivet: verifies REQ-229
+/// A throwaway dev project with one implemented requirement carrying sibling
+/// fields, for SQL write tests (REQ-230).
+fn sql_write_project() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+    let init = Command::new(rivet_bin())
+        .args(["init", "--preset", "dev", "--dir", dir.to_str().unwrap()])
+        .output()
+        .expect("init");
+    assert!(
+        init.status.success(),
+        "init must succeed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    std::fs::write(
+        dir.join("artifacts").join("requirements.yaml"),
+        "artifacts:\n  - id: REQ-001\n    type: requirement\n    \
+         title: A requirement\n    status: implemented\n    \
+         fields:\n      priority: must\n      category: functional\n",
+    )
+    .expect("write fixture");
+    tmp
+}
+
+/// `rivet sql` UPDATE changes status and preserves sibling fields (REQ-230) —
+/// the round-trip-fidelity guard against the `render_artifact_yaml` allowlist.
+// rivet: verifies REQ-230
 #[test]
-fn sql_refuses_writes() {
-    let output = Command::new(rivet_bin())
+fn sql_write_updates_status_and_preserves_siblings() {
+    let tmp = sql_write_project();
+    let dir = tmp.path();
+    let out = Command::new(rivet_bin())
         .args([
             "--project",
-            project_root().to_str().unwrap(),
+            dir.to_str().unwrap(),
             "sql",
-            "UPDATE artifacts SET status='x'",
+            "UPDATE artifacts SET status='verified' WHERE id='REQ-001'",
         ])
         .output()
-        .expect("failed to execute rivet sql");
-
-    assert!(!output.status.success(), "a write must be rejected");
+        .expect("sql write");
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("read-only"),
-        "error must explain reads-only"
+        out.status.success(),
+        "write must succeed. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let content = std::fs::read_to_string(dir.join("artifacts").join("requirements.yaml")).unwrap();
+    assert!(content.contains("status: verified"), "status updated");
+    assert!(
+        content.contains("priority: must") && content.contains("category: functional"),
+        "sibling fields must survive the SQL UPDATE (allowlist-drop guard):\n{content}"
+    );
+}
+
+/// `rivet sql` rejects an invalid status and leaves the file unchanged (REQ-230).
+// rivet: verifies REQ-230
+#[test]
+fn sql_write_rejects_invalid_value_atomically() {
+    let tmp = sql_write_project();
+    let dir = tmp.path();
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "sql",
+            "UPDATE artifacts SET status='not-a-status' WHERE id='REQ-001'",
+        ])
+        .output()
+        .expect("sql write");
+    assert!(!out.status.success(), "an off-enum status must be rejected");
+    let content = std::fs::read_to_string(dir.join("artifacts").join("requirements.yaml")).unwrap();
+    assert!(
+        content.contains("status: implemented"),
+        "file must be unchanged on rejection:\n{content}"
     );
 }
 

--- a/rivet-core/src/sql.rs
+++ b/rivet-core/src/sql.rs
@@ -1,11 +1,9 @@
-//! SQL query facade over the artifact store (REQ-229 / DD-068).
+//! SQL query + write facade over the artifact store (REQ-229 / DD-068).
 //!
-//! Read-only MVP. Each call builds an **ephemeral in-memory SQLite** from the
-//! live store and runs the query against it. Because the CLI reloads the project
-//! on every invocation, results are never stale — this gives DD-068's "no stale
-//! snapshot" guarantee without a full `vtab` module. The `vtab` upgrade is only
-//! needed for the *write* path (`xUpdate`), which is a separate slice; reads at
-//! rivet's scale (hundreds of artifacts) don't need it.
+//! Each call builds an **ephemeral in-memory SQLite** from the live store and
+//! runs against it. Because the CLI reloads the project on every invocation,
+//! results are never stale — DD-068's "no stale snapshot" guarantee without a
+//! full `vtab` module (which rivet's scale doesn't need).
 //!
 //! Tables projected from the [`Store`]:
 //! - `artifacts(id, type, title, description, status, fields_json)`
@@ -13,11 +11,15 @@
 //! - `fields(artifact_id, key, value)`   — EAV; one row per field, for JOINs
 //! - `provenance(artifact_id, created_by, model, session_id, timestamp, reviewed_by)`
 //!
-//! Only read statements (`SELECT` / `WITH`) are accepted; writes are refused
-//! with a pointer to the planned write slice.
+//! [`query`] runs read-only `SELECT`/`WITH`. [`plan_write`] (REQ-230) handles
+//! `UPDATE artifacts SET {status|title|description}`: it diffs the staging table
+//! against the store and returns `ModifyParams` for the caller to validate and
+//! apply via the indentation-safe `modify_artifact_in_file` editor (no allowlist
+//! drop). Writes to `fields`/`links` and `INSERT`/`DELETE` are refused.
 
 #![cfg(feature = "sql")]
 
+use crate::mutate::ModifyParams;
 use crate::store::Store;
 use rusqlite::Connection;
 
@@ -184,6 +186,153 @@ fn value_ref_to_string(v: rusqlite::types::ValueRef<'_>) -> String {
     }
 }
 
+/// A modification planned by a write query: the artifact id and the
+/// `ModifyParams` to apply. Pure data — the caller validates and applies each
+/// via `validate_modify` + `modify_artifact_in_file` (the indentation-safe
+/// path that does NOT drop sibling fields, REQ-230 / DD-068).
+#[derive(Debug)]
+pub struct PlannedWrite {
+    pub id: String,
+    pub params: ModifyParams,
+}
+
+/// Plan the artifact modifications implied by a write SQL statement WITHOUT
+/// touching any file.
+///
+/// The statement runs against the ephemeral staging SQLite; the `artifacts`
+/// table is then diffed against the live store. Only `UPDATE artifacts SET
+/// {status|title|description}` is supported in this slice — writes that change
+/// the `fields`/`links` staging tables, or that `INSERT`/`DELETE` rows, are
+/// refused (clear error, never a silent partial write).
+pub fn plan_write(store: &Store, sql: &str) -> Result<Vec<PlannedWrite>, String> {
+    let head = sql
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    if head == "SELECT" || head == "WITH" {
+        return Err(
+            "not a write statement — use `rivet sql` without a write verb for reads".into(),
+        );
+    }
+
+    let conn = Connection::open_in_memory().map_err(|e| e.to_string())?;
+    build_schema(&conn).map_err(|e| e.to_string())?;
+    populate(&conn, store).map_err(|e| e.to_string())?;
+
+    // Snapshot the tables this slice does NOT support, so a write that changes
+    // them is refused rather than silently dropped.
+    let fields_before = snapshot(
+        &conn,
+        "SELECT artifact_id, key, value FROM fields ORDER BY 1, 2",
+    )?;
+    let links_before = snapshot(
+        &conn,
+        "SELECT source, link_type, target FROM links ORDER BY 1, 2, 3",
+    )?;
+
+    conn.execute(sql, [])
+        .map_err(|e| format!("SQL write failed: {e}"))?;
+
+    if snapshot(
+        &conn,
+        "SELECT artifact_id, key, value FROM fields ORDER BY 1, 2",
+    )? != fields_before
+    {
+        return Err("writes to `fields` are not supported in this slice (UPDATE artifacts SET status/title/description only); mapping SQL field writes to set-field is a follow-up".into());
+    }
+    if snapshot(
+        &conn,
+        "SELECT source, link_type, target FROM links ORDER BY 1, 2, 3",
+    )? != links_before
+    {
+        return Err("writes to `links` are not supported in this slice".into());
+    }
+
+    // Diff the artifacts table against the store.
+    let mut planned = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut stmt = conn
+        .prepare("SELECT id, title, description, status FROM artifacts")
+        .map_err(|e| e.to_string())?;
+    let mut rows = stmt.query([]).map_err(|e| e.to_string())?;
+    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+        let id: String = row.get(0).map_err(|e| e.to_string())?;
+        let title: String = row.get(1).map_err(|e| e.to_string())?;
+        let description: Option<String> = row.get(2).map_err(|e| e.to_string())?;
+        let status: Option<String> = row.get(3).map_err(|e| e.to_string())?;
+        seen.insert(id.clone());
+
+        let orig = store.get(&id).ok_or_else(|| {
+            format!("INSERT is not supported in this slice (new id `{id}`); create artifacts with `rivet add`")
+        })?;
+
+        let mut params = ModifyParams {
+            set_status: None,
+            set_title: None,
+            set_description: None,
+            add_tags: Vec::new(),
+            remove_tags: Vec::new(),
+            set_fields: Vec::new(),
+        };
+        let mut changed = false;
+
+        if status != orig.status {
+            match &status {
+                Some(s) => {
+                    params.set_status = Some(s.clone());
+                    changed = true;
+                }
+                None => {
+                    return Err(format!(
+                        "clearing `status` via SQL (SET status=NULL) is not supported for `{id}`"
+                    ));
+                }
+            }
+        }
+        if title != orig.title {
+            params.set_title = Some(title.clone());
+            changed = true;
+        }
+        if description != orig.description {
+            match &description {
+                Some(d) => {
+                    params.set_description = Some(d.clone());
+                    changed = true;
+                }
+                None => {
+                    return Err(format!(
+                        "clearing `description` via SQL is not supported for `{id}`"
+                    ));
+                }
+            }
+        }
+
+        if changed {
+            planned.push(PlannedWrite { id, params });
+        }
+    }
+
+    // A row present in the store but gone from staging means a DELETE.
+    if let Some(missing) = store.iter().map(|a| &a.id).find(|id| !seen.contains(*id)) {
+        return Err(format!(
+            "DELETE is not supported in this slice (row `{missing}` removed); use `rivet modify`/remove"
+        ));
+    }
+
+    Ok(planned)
+}
+
+/// Snapshot a query's rows as a single comparable string (for change detection).
+fn snapshot(conn: &Connection, sql: &str) -> Result<String, String> {
+    let r = run_query(conn, sql)?;
+    Ok(r.rows
+        .iter()
+        .map(|row| row.join("\u{1f}"))
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,5 +399,81 @@ mod tests {
         let store = Store::new();
         let err = query(&store, "UPDATE artifacts SET status='x'").unwrap_err();
         assert!(err.contains("read-only"), "got: {err}");
+    }
+
+    // rivet: verifies REQ-230
+    #[test]
+    fn plan_write_status_update_targets_one_artifact() {
+        use crate::test_helpers::artifact_with_status;
+        let mut store = Store::new();
+        store
+            .insert(artifact_with_status("REQ-1", "requirement", "implemented"))
+            .unwrap();
+        store
+            .insert(artifact_with_status("REQ-2", "requirement", "implemented"))
+            .unwrap();
+
+        let planned = plan_write(
+            &store,
+            "UPDATE artifacts SET status='verified' WHERE id='REQ-1'",
+        )
+        .unwrap();
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].id, "REQ-1");
+        assert_eq!(planned[0].params.set_status.as_deref(), Some("verified"));
+        // Untouched fields stay None — the apply path edits only what changed.
+        assert!(planned[0].params.set_title.is_none());
+    }
+
+    // rivet: verifies REQ-230
+    #[test]
+    fn plan_write_refuses_insert_and_delete() {
+        use crate::test_helpers::artifact_with_status;
+        let mut store = Store::new();
+        store
+            .insert(artifact_with_status("REQ-1", "requirement", "implemented"))
+            .unwrap();
+
+        let ins = plan_write(
+            &store,
+            "INSERT INTO artifacts (id, type, title) VALUES ('REQ-9', 'requirement', 't')",
+        )
+        .unwrap_err();
+        assert!(ins.contains("INSERT is not supported"), "got: {ins}");
+
+        let del = plan_write(&store, "DELETE FROM artifacts WHERE id='REQ-1'").unwrap_err();
+        assert!(del.contains("DELETE is not supported"), "got: {del}");
+    }
+
+    // rivet: verifies REQ-230
+    #[test]
+    fn plan_write_refuses_field_writes() {
+        use crate::test_helpers::artifact_with_status;
+        let mut store = Store::new();
+        store
+            .insert(artifact_with_status("REQ-1", "requirement", "implemented"))
+            .unwrap();
+        let err = plan_write(
+            &store,
+            "INSERT INTO fields (artifact_id, key, value) VALUES ('REQ-1', 'priority', 'high')",
+        )
+        .unwrap_err();
+        assert!(err.contains("`fields`"), "got: {err}");
+    }
+
+    // rivet: verifies REQ-230
+    #[test]
+    fn plan_write_noop_when_value_unchanged() {
+        use crate::test_helpers::artifact_with_status;
+        let mut store = Store::new();
+        store
+            .insert(artifact_with_status("REQ-1", "requirement", "implemented"))
+            .unwrap();
+        let planned = plan_write(
+            &store,
+            "UPDATE artifacts SET status='implemented' WHERE id='REQ-1'",
+        )
+        .unwrap();
+        assert!(planned.is_empty(), "no-op write plans nothing");
     }
 }


### PR DESCRIPTION
The write slice of the SQL facade (REQ-230 / DD-068) — agents now **change**
artifacts through the same SQL surface they query, no MCP/server.

## How (reuses the validated mutate path — no parallel writer)
`sql::plan_write` runs the statement against the staging in-memory SQLite, diffs
the `artifacts` table against the live store, and returns `ModifyParams` per
changed artifact (pure, no I/O). The CLI then:
1. **validates every change** (`validate_modify`) *before* writing any file, and
2. applies each via **`yaml_edit::modify_artifact_in_file`** — the
   indentation-safe editor that preserves sibling fields (avoids the
   `render_artifact_yaml` allowlist-drop trap DD-068 flagged).

```
rivet sql "UPDATE artifacts SET status='verified' WHERE id='REQ-1'"
```

## Safety
- **All-or-nothing**: an off-enum value (`status='bogus'`) is rejected; the file
  is unchanged (validated before any write).
- **No silent drops**: writes touching `fields`/`links`, or `INSERT`/`DELETE`,
  are refused with a clear message (the staging diff catches them).
- **Round-trip fidelity** is asserted by tests: a sibling field survives the SQL
  UPDATE.

## Scope
`UPDATE artifacts SET {status|title|description}`. Follow-ups (separate REQs):
field/link writes (→ set-field / link edits), `INSERT` (→ add), `DELETE`,
multi-statement transactions, and the additive serve `POST /sql` + MCP transports.

## Verification
- core sql tests **7/7** (4 new write tests)
- cli sql tests **3/3** incl. round-trip fidelity + atomic rejection
- live UPDATE on a temp project; `fmt` + `clippy -D warnings` clean; `rivet validate` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)