### PR TITLE
feat(serve): POST /api/v1/sql — read-only SQL over the live server (REQ-229)

### DIFF
--- a/rivet-cli/src/serve/api.rs
+++ b/rivet-cli/src/serve/api.rs
@@ -760,3 +760,58 @@ fn matches_filters(artifact: &rivet_core::model::Artifact, params: &ArtifactsPar
     }
     true
 }
+
+// ── SQL query endpoint (REQ-229 / DD-068) ───────────────────────────────────
+//
+// `POST /api/v1/sql` runs read-only SQL over the live store — the same
+// `rivet_core::sql` executor the CLI uses, exposed over HTTP so a running
+// server is queryable by any agent that can POST JSON (no MCP required). The
+// endpoint is READ-ONLY by design: a network-facing server must not accept
+// arbitrary artifact mutations; writes go through the local `rivet sql` CLI
+// (filesystem-authenticated) which holds the write lock + reloads.
+
+#[derive(Deserialize)]
+pub(crate) struct SqlRequest {
+    query: String,
+}
+
+#[derive(Serialize)]
+struct SqlResponse {
+    columns: Vec<String>,
+    rows: Vec<Vec<String>>,
+    row_count: usize,
+}
+
+pub(crate) async fn sql(State(state): State<SharedState>, Json(req): Json<SqlRequest>) -> Response {
+    let head = req
+        .query
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    if head != "SELECT" && head != "WITH" {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "the /sql endpoint is read-only (SELECT/WITH only); \
+                          use the `rivet sql` CLI for writes"
+            })),
+        )
+            .into_response();
+    }
+
+    let guard = state.read().await;
+    match rivet_core::sql::query(&guard.store, &req.query) {
+        Ok(r) => Json(SqlResponse {
+            row_count: r.rows.len(),
+            columns: r.columns,
+            rows: r.rows,
+        })
+        .into_response(),
+        Err(e) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}

--- a/rivet-cli/src/serve/api.rs
+++ b/rivet-cli/src/serve/api.rs
@@ -782,7 +782,35 @@ struct SqlResponse {
     row_count: usize,
 }
 
-pub(crate) async fn sql(State(state): State<SharedState>, Json(req): Json<SqlRequest>) -> Response {
+pub(crate) async fn sql(
+    State(state): State<SharedState>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<SqlRequest>,
+) -> Response {
+    // CORS hardening: `/api/v1` carries `CorsLayer::permissive()`, so without
+    // this guard a page on another origin could POST SQL to a localhost server
+    // and read artifact data cross-origin (the SQL endpoint is more capable than
+    // the fixed `/artifacts` read). Browser cross-origin requests always carry an
+    // `Origin` header; local CLI/agent clients (curl, reqwest) do not. The /sql
+    // endpoint is for those programmatic clients — so reject any Origin-bearing
+    // request. (If a browser UI ever needs /sql, relax this to a same-origin
+    // allowlist.)
+    if headers.contains_key(axum::http::header::ORIGIN) {
+        return (
+            axum::http::StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "cross-origin requests are not permitted on /api/v1/sql; \
+                          call it from the local CLI or a same-host client"
+            })),
+        )
+            .into_response();
+    }
+
+    // Read-only is guaranteed at the executor layer, not by this string check:
+    // `sql::query` builds an EPHEMERAL in-memory SQLite from the store, runs one
+    // prepared statement, and discards it — there is no write-back to the YAML
+    // source of truth anywhere in the serve path. The prefix check below is just
+    // an early, friendly rejection.
     let head = req
         .query
         .split_whitespace()

--- a/rivet-cli/src/serve/mod.rs
+++ b/rivet-cli/src/serve/mod.rs
@@ -935,6 +935,7 @@ pub async fn run(app_state: AppState, bind: String, watch: bool) -> Result<()> {
                 .route("/artifacts", get(api::artifacts))
                 .route("/diagnostics", get(api::diagnostics))
                 .route("/coverage", get(api::coverage))
+                .route("/sql", post(api::sql))
                 .layer(CorsLayer::permissive())
                 .with_state(state.clone()),
         )

--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -1429,3 +1429,62 @@ fn embed_unknown_artifact_returns_200_with_not_found_body() {
     child.kill().ok();
     child.wait().ok();
 }
+
+/// Minimal raw-HTTP POST of a JSON body; returns (status, response_body).
+fn post_json(port: u16, path: &str, body: &str) -> (u16, String) {
+    use std::io::{Read, Write};
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect");
+    stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    let req = format!(
+        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\n\
+         Connection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(req.as_bytes()).expect("write request");
+    let mut resp = Vec::new();
+    stream.read_to_end(&mut resp).ok();
+    let resp = String::from_utf8_lossy(&resp).to_string();
+    let status = resp
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(0);
+    let body = resp.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
+    (status, body)
+}
+
+/// `POST /api/v1/sql` runs a read query and refuses writes (REQ-229 / serve slice).
+// rivet: verifies REQ-229
+#[test]
+fn sql_endpoint_runs_read_query_and_refuses_writes() {
+    let (mut child, port) = start_server();
+
+    let (status, body) = post_json(
+        port,
+        "/api/v1/sql",
+        r#"{"query":"SELECT id FROM artifacts LIMIT 1"}"#,
+    );
+    assert_eq!(status, 200, "read query should be 200; body: {body}");
+    assert!(
+        body.contains("columns") && body.contains("rows"),
+        "read response must carry columns+rows: {body}"
+    );
+
+    let (wstatus, wbody) = post_json(
+        port,
+        "/api/v1/sql",
+        r#"{"query":"UPDATE artifacts SET status='x'"}"#,
+    );
+    assert_eq!(
+        wstatus, 400,
+        "write must be rejected with 400; body: {wbody}"
+    );
+    assert!(
+        wbody.contains("read-only"),
+        "write rejection must explain read-only: {wbody}"
+    );
+
+    child.kill().ok();
+}

--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -1432,11 +1432,20 @@ fn embed_unknown_artifact_returns_200_with_not_found_body() {
 
 /// Minimal raw-HTTP POST of a JSON body; returns (status, response_body).
 fn post_json(port: u16, path: &str, body: &str) -> (u16, String) {
+    post_json_with_origin(port, path, body, None)
+}
+
+/// As [`post_json`], but optionally sets an `Origin` header to exercise the
+/// cross-origin guard on `/api/v1/sql`.
+fn post_json_with_origin(port: u16, path: &str, body: &str, origin: Option<&str>) -> (u16, String) {
     use std::io::{Read, Write};
     let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect");
     stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
+    let origin_header = origin
+        .map(|o| format!("Origin: {o}\r\n"))
+        .unwrap_or_default();
     let req = format!(
-        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\
+        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n{origin_header}\
          Content-Type: application/json\r\nContent-Length: {}\r\n\
          Connection: close\r\n\r\n{body}",
         body.len()
@@ -1484,6 +1493,20 @@ fn sql_endpoint_runs_read_query_and_refuses_writes() {
     assert!(
         wbody.contains("read-only"),
         "write rejection must explain read-only: {wbody}"
+    );
+
+    // Cross-origin guard: a browser cross-origin POST (Origin header set) is
+    // rejected 403 even for a read, neutralizing the permissive-CORS
+    // exfiltration vector.
+    let (ostatus, obody) = post_json_with_origin(
+        port,
+        "/api/v1/sql",
+        r#"{"query":"SELECT id FROM artifacts LIMIT 1"}"#,
+        Some("https://evil.example"),
+    );
+    assert_eq!(
+        ostatus, 403,
+        "cross-origin request must be 403; body: {obody}"
     );
 
     child.kill().ok();


### PR DESCRIPTION
The second SQL transport (after the CLI): `POST /api/v1/sql` runs the same
`rivet_core::sql` executor over HTTP, so a running `rivet serve` is queryable by
any agent that can POST JSON — **no MCP required**.

```
curl -s localhost:PORT/api/v1/sql -H 'content-type: application/json' \
  -d '{"query":"SELECT id FROM artifacts WHERE status=\"implemented\""}'
→ {"columns":["id"],"rows":[["REQ-1"],...],"row_count":N}
```

**Read-only by design.** A network-facing endpoint must not accept arbitrary
artifact mutations, so non-`SELECT`/`WITH` statements return **400** pointing to
the local `rivet sql` CLI (filesystem-authenticated, holds the write lock). This
keeps the dangerous surface local while the query surface is shared.

Verified: serve integration test (read → 200 with columns+rows; write → 400
read-only); fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)