### PR TITLE
design: adopt gluesql-core as the SQL engine, drop bundled SQLite (DD-069, REQ-231)

### DIFF
--- a/artifacts/decisions.yaml
+++ b/artifacts/decisions.yaml
@@ -1338,3 +1338,45 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-24T09:00:00Z
+
+  - id: DD-069
+    type: design-decision
+    title: Swap the SQL facade engine from rusqlite (bundled SQLite C) to gluesql-core (pure Rust)
+    status: proposed
+    description: >
+      The `rivet sql` facade (REQ-229/REQ-230) uses rusqlite `bundled`, which
+      compiles the SQLite C amalgamation on every build — measurably lengthening
+      CI per-job and compounding self-hosted runner contention (#567; PR #582 sat
+      ~40 min mostly queued). Decision: migrate the engine to `gluesql-core`
+      (pure Rust, no C), verified viable by a prototype.
+    tags: [sql, engine, gluesql, architecture, ci-weight, dogfooding]
+    links:
+      - type: satisfies
+        target: REQ-231
+    fields:
+      baseline: v0.20.0-track
+      source-ref: "rivet-core/src/sql.rs (engine), rivet-core/Cargo.toml (deps)"
+      rationale: |
+        Prototype (proto/gluesql-verify, throwaway):
+          - DIALECT works: the V-closure JOIN with `NOT IN (subquery)` AND
+            `UPDATE artifacts SET ... WHERE ...` both execute in gluesql's dialect.
+          - WEIGHT (decisive): use `gluesql-core` + a custom Store, NOT the
+            umbrella `gluesql` crate. The umbrella pulls EVERY storage backend
+            (csv/parquet/sled/redb/mongo/redis/git) and compiles `cc` (55s).
+            `gluesql-core` + `gluesql_memory_storage` compiles only sqlparser +
+            gluesql-core (pure Rust, no `cc`) in ~19s. The genuine "less heavy" win.
+          - ASYNC: gluesql `execute` is async; bridge into sync `sql::query`/
+            `plan_write` with a small `block_on`.
+        ARCHITECTURE bonus: gluesql-core's Store/StoreMut traits let rivet's store
+        BE the database (DD-068's virtual-tables vision) — reads + writes native,
+        deleting the read-path copy and the write-path staging-diff.
+      alternatives: >
+        (1) Keep rusqlite bundled — rejected: the SQLite-C compile is the CI
+        weight being removed. (2) rusqlite + system libsqlite3 — rejected:
+        portability hit. (3) umbrella `gluesql` — rejected: pulls all storages +
+        `cc`. (4) Turso/Limbo — rejected: beta. (5) DataFusion — rejected: heavy,
+        write-weak. Chosen: gluesql-core + custom Store.
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-25T09:00:00Z

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7470,3 +7470,42 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-24T10:00:00Z
+
+  - id: REQ-231
+    type: requirement
+    title: "Migrate the `rivet sql` engine to gluesql-core (pure Rust) — drop bundled SQLite from the build"
+    status: proposed
+    description: |
+      Replace rusqlite (bundled SQLite C) with `gluesql-core` behind the existing
+      `rivet_core::sql` API (DD-069), so the SQL facade stops compiling the SQLite
+      C amalgamation — relieving CI build weight + the #567 runner contention.
+
+      The public surface (`sql::query`, `sql::plan_write`, the `rivet sql` CLI,
+      the serve `POST /api/v1/sql` endpoint) MUST be unchanged for callers — same
+      SELECT/JOIN reads, same `UPDATE artifacts SET ...` writes, same output.
+      Internally, implement a gluesql-core `Store` (and later `StoreMut`) over
+      rivet's `Store`/`LinkGraph` so the engine queries the live data directly
+      (DD-068 virtual-tables), bridging gluesql's async API via a minimal block_on.
+
+      Acceptance:
+        - rusqlite + libsqlite3-sys removed; a clean build compiles no `cc`/
+          SQLite-C for the SQL feature.
+        - All existing sql tests pass unchanged: core read+write, cli `sql_*`,
+          serve `sql_endpoint_*`.
+        - `rivet sql` V-closure SELECT and `UPDATE artifacts SET status=...`
+          behave identically (incl. round-trip fidelity + validation rejection).
+        - fmt + clippy clean; `rivet validate` PASS.
+      Follow-on: write extensions (INSERT/DELETE/fields/links) become a native
+      StoreMut impl instead of the staging-diff.
+    tags: [sql, engine, gluesql, ci-weight, refactor]
+    fields:
+      priority: should
+      category: non-functional
+      baseline: v0.20.0-track
+    links:
+      - type: traces-to
+        target: REQ-229
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-25T09:00:00Z


### PR DESCRIPTION
Records the verified outcome of the SQL-engine research + prototype (you chose "swap, verify-first").

## Verdict: GO — migrate to `gluesql-core`
Prototype (`proto/gluesql-verify`, throwaway) confirmed:
- **Dialect ✓** — the V-closure JOIN with `NOT IN (subquery)` *and* `UPDATE artifacts SET … WHERE …` both execute in gluesql's dialect (the core risk, retired).
- **Weight ✓ — but only via `gluesql-core`.** The umbrella `gluesql` crate pulls **every** storage backend (csv/parquet/sled/redb/mongo/redis/git) and compiles **`cc`** (~55s). `gluesql-core` + memory-storage compiles only sqlparser + core (pure Rust, no `cc`, ~19s). rusqlite `bundled` compiles the SQLite-C amalgamation per job — the CI weight that made #582 sit ~40 min queued (#567).
- **Async** — `Glue::execute` is async; bridge into the sync `sql::query`/`plan_write` via a small `block_on`.
- **Architecture bonus** — gluesql-core's `Store`/`StoreMut` traits let rivet's store *be* the DB (DD-068's virtual-tables vision): reads + writes go native, deleting the read-path copy and the write-path staging-diff.

## What this PR is
Design artifacts only (DD-069 + REQ-231). The migration itself (REQ-231) is the focused follow-up: swap the engine behind the unchanged `sql::query`/`plan_write` API, remove rusqlite + libsqlite3-sys, keep all read/write/serve tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)