### PR TITLE
docs(status): advance SQL REQs via dogfooding (229/230 verified, 231 implemented)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7370,7 +7370,7 @@ artifacts:
   - id: REQ-229
     type: requirement
     title: "rivet exposes a SQL query interface over the artifact store, usable WITHOUT MCP or a running server"
-    status: proposed
+    status: verified
     description: |
       Agents query rivet today via a bespoke s-expression filter (`rivet query
       "(= (field \"x\") \"y\")"`) for reads and `rivet add`/`modify` for writes —
@@ -7423,7 +7423,7 @@ artifacts:
   - id: REQ-230
     type: requirement
     title: "`rivet sql` supports writes (UPDATE) routed through validate + the safe YAML edit path"
-    status: proposed
+    status: verified
     description: |
       Write slice of the SQL facade (REQ-229 / DD-068). Lets an agent CHANGE
       artifacts through the same SQL surface it queries — the unification the
@@ -7474,7 +7474,7 @@ artifacts:
   - id: REQ-231
     type: requirement
     title: "Migrate the `rivet sql` engine to gluesql-core (pure Rust) — drop bundled SQLite from the build"
-    status: proposed
+    status: implemented
     description: |
       Replace rusqlite (bundled SQLite C) with `gluesql-core` behind the existing
       `rivet_core::sql` API (DD-069), so the SQL facade stops compiling the SQLite


### PR DESCRIPTION
Closes the V on the SQL-interface requirements — using the shipped features on rivet's own artifacts:

1. **`rivet sql "UPDATE artifacts SET status='implemented' WHERE id IN ('REQ-229','REQ-230','REQ-231')"`** — one multi-row write through the REQ-230 write path on the new gluesql engine ("3 artifact(s) updated").
2. **`rivet verify REQ-229` + `rivet verify REQ-230`** (REQ-226) — advanced to `verified` on their `// rivet: verifies` source markers.

REQ-231 stays `implemented` (no dedicated verifies-marker — its verification is "all sql tests pass on gluesql"). `rivet validate` PASS — round-trip fidelity confirmed on real artifacts.

A small but real demonstration that the SQL write + `rivet verify` features work end-to-end on the project that built them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)