### PR TITLE
fix(test): cfg-gate import-alias reqif test to match the alias (#293)

### DIFF
--- a/rivet-cli/tests/export_reqif_roundtrip.rs
+++ b/rivet-cli/tests/export_reqif_roundtrip.rs
@@ -178,6 +178,14 @@ fn export_reqif_to_directory_gives_actionable_error() {
 
 /// `rivet import` is a visible alias for `import-results` (the natural inverse
 /// of `export`) in the default build. #453 / REQ-184.
+///
+/// Gated to mirror the alias itself: `ImportResults` declares
+/// `#[cfg_attr(not(feature = "wasm"), command(visible_alias = "import"))]`, so
+/// the `import` alias only exists with `wasm` OFF. With `wasm` ON (e.g. a
+/// `--all-features` build), `import` resolves to the distinct custom-WASM-adapter
+/// command, which has no `--format` — so this assertion must not run there
+/// (it was a perpetual red in the `--all-features` test-evidence job; #293).
+#[cfg(not(feature = "wasm"))]
 #[test]
 fn import_alias_works_for_reqif() {
     let proj = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## What

Gates `rivet-cli/tests/export_reqif_roundtrip.rs::import_alias_works_for_reqif` with `#[cfg(not(feature = "wasm"))]` so it only runs in the configuration where the alias it tests actually exists.

## Why

The `import` visible alias for `ImportResults` is declared:
```rust
// rivet-cli/src/main.rs:1000
#[cfg_attr(not(feature = "wasm"), command(visible_alias = "import"))]
ImportResults { ... }   // --format lives here
```
The alias exists **only when `wasm` is OFF** — with `wasm` ON, `import` is the distinct custom-WASM-adapter command (no `--format`). The test was unconditional, so under `--all-features` it panicked:
```
`rivet import` alias must work. stderr: error: unexpected argument '--format' found
```

This made the nightly `--all-features` `build-test-evidence` job a **perpetual red** — failing identically since at least v0.19.0 (release run 28076317317) and again on v0.20.0 (28184915874). The job is non-blocking (`continue-on-error`), so it went unnoticed across releases. Root-caused in #293.

## Verification

- **Default features** (wasm off): crate compiles, test present.
- **`--all-features`** (wasm on): crate compiles, `cargo test … -- --list` shows **0** occurrences of `import_alias_works_for_reqif` (gated out); the other reqif tests remain.

Refs #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)