### PR TITLE
feat(add): per-id directory source layout for conflict-free parallel adds (#490)

### DIFF
--- a/artifacts/v040-verification.yaml
+++ b/artifacts/v040-verification.yaml
@@ -492,3 +492,17 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-7
       timestamp: 2026-04-19T12:00:00Z
+
+  - id: DD-070
+    type: design-decision
+    title: Directory sources with per-id file layout for conflict-free parallel adds
+    status: accepted
+    fields:
+      rationale: "Every PR filing an artifact appends to one shared per-type file (requirements.yaml), so any two in-flight PRs collide on its tail — a standing tax on the dogfooding loop (#422, #487, and the #595 rebase this session). The read path already globs a directory of per-id files and every artifact records its own source_file, so modify/remove/validate/next-id are already path-agnostic; only rivet add hardcoded one-file-per-type. Add an opt-in SourceConfig layout: per-id so add writes <dir>/<ID>.yaml. Two PRs adding different artifacts touch different files → zero conflict. Default stays single-file for backward compat. Slice 1 (this change) = add write-path + config flag; a migrate --explode command to split existing files is Slice 2 (#490)."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-26T07:57:31Z
+    links:
+      - type: satisfies
+        target: REQ-007

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -15330,30 +15330,70 @@ fn cmd_add(
         }
     }
 
+    // #490: a directory source can declare `layout: per-id`, writing one
+    // `<ID>.yaml` per artifact so two parallel adds never share a file. The read
+    // path globs the directory regardless of layout; only the add target moves.
+    // Default stays single-file (append to `<type>s.yaml`) for backward compat.
+    use rivet_core::model::SourceLayout;
+    let layout_for_dir = |dir: &std::path::Path| -> SourceLayout {
+        ctx.config
+            .sources
+            .iter()
+            .filter(|s| matches!(s.format.as_str(), "generic" | "generic-yaml"))
+            .find(|s| {
+                let sp = cli.project.join(&s.path);
+                dir == sp || dir.starts_with(&sp)
+            })
+            .map(|s| s.layout)
+            .unwrap_or_default()
+    };
+
     // Determine target file
     let target_file = if let Some(f) = file {
-        cli.project.join(f)
+        let p = cli.project.join(f);
+        // An explicit directory target means one file per artifact.
+        if p.is_dir() {
+            p.join(format!("{id}.yaml"))
+        } else {
+            p
+        }
     } else if let Some(existing) = mutate::find_file_for_type(artifact_type, &store) {
-        existing
+        // Artifacts of this type already live somewhere. If the owning source is
+        // per-id, the new artifact gets its own `<ID>.yaml` file instead of
+        // being appended to a sibling's file (#490).
+        let is_per_id = existing
+            .parent()
+            .is_some_and(|d| layout_for_dir(d) == SourceLayout::PerId);
+        if is_per_id {
+            let dir = existing
+                .parent()
+                .unwrap_or(existing.as_path())
+                .to_path_buf();
+            dir.join(format!("{id}.yaml"))
+        } else {
+            existing
+        }
     } else {
         // #552: no file holds this type yet — synthesize a default in the
         // project's first generic-yaml source (e.g. `design-decision` ->
         // `artifacts/design-decisions.yaml`) instead of forcing the user to
         // pass --file just to add the FIRST artifact of a type. Created with an
         // `artifacts:` header below if absent.
-        let src = ctx
+        let src_cfg = ctx
             .config
             .sources
             .iter()
             .find(|s| matches!(s.format.as_str(), "generic" | "generic-yaml"))
-            .map(|s| cli.project.join(&s.path))
             .ok_or_else(|| {
                 anyhow::anyhow!(
                     "no generic-yaml source in rivet.yaml to add a '{artifact_type}' to. \
                      Use --file to specify a target."
                 )
             })?;
-        if src.is_dir() {
+        let src = cli.project.join(&src_cfg.path);
+        if src_cfg.layout == SourceLayout::PerId && src.is_dir() {
+            src.join(format!("{id}.yaml"))
+        } else if src.is_dir() {
             src.join(format!("{artifact_type}s.yaml"))
         } else {
             src

--- a/rivet-cli/src/serve/variant.rs
+++ b/rivet-cli/src/serve/variant.rs
@@ -333,6 +333,7 @@ mod tests {
                 path: "artifacts".into(),
                 format: "generic-yaml".into(),
                 adapter: None,
+                layout: Default::default(),
                 config: Default::default(),
             }],
             docs: vec![],

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6296,6 +6296,75 @@ fn add_creates_default_file_for_a_new_type() {
     );
 }
 
+/// #490: a source with `layout: per-id` makes `rivet add` write one `<ID>.yaml`
+/// file per artifact in the source directory, so two parallel adds never touch
+/// the same file (the structural cure for the requirements.yaml merge-conflict
+/// tax). The directory read path loads them all. Default (single-file) layout
+/// is unchanged — covered by `add_creates_default_file_for_a_new_type`.
+///
+/// rivet: verifies REQ-007
+#[test]
+fn add_with_per_id_layout_writes_one_file_per_artifact() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    std::fs::create_dir_all(dir.join("artifacts/requirements")).unwrap();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: t\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts/requirements\n    format: generic-yaml\n    layout: per-id\n",
+    )
+    .unwrap();
+
+    let add = |title: &str| {
+        Command::new(rivet_bin())
+            .args([
+                "--project",
+                dirs,
+                "add",
+                "--type",
+                "requirement",
+                "--title",
+                title,
+            ])
+            .output()
+            .expect("add")
+    };
+    assert!(add("First").status.success(), "first add must succeed");
+    assert!(add("Second").status.success(), "second add must succeed");
+
+    // Two adds → two distinct files, and NO shared per-type `requirements.yaml`.
+    let entries: Vec<String> = std::fs::read_dir(dir.join("artifacts/requirements"))
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().into_owned()))
+        .collect();
+    assert_eq!(
+        entries.len(),
+        2,
+        "per-id must write one file per artifact; got {entries:?}"
+    );
+    assert!(
+        !entries.iter().any(|n| n == "requirements.yaml"),
+        "per-id must not append to a shared requirements.yaml; got {entries:?}"
+    );
+    assert!(
+        entries.iter().all(|n| n.ends_with(".yaml")),
+        "per-id files should be `<ID>.yaml`; got {entries:?}"
+    );
+
+    // The directory read path loads both artifacts.
+    let list = Command::new(rivet_bin())
+        .args(["--project", dirs, "list", "--format", "json"])
+        .output()
+        .expect("list");
+    let out = String::from_utf8_lossy(&list.stdout);
+    assert_eq!(
+        out.matches("\"id\"").count(),
+        2,
+        "both per-id artifacts must load via the directory source; got:\n{out}"
+    );
+}
+
 /// REQ-158 / #397: `rivet validate` emits a `near-duplicate-intent` INFO for a
 /// pair of same-type artifacts with highly similar titles, and NOT for a
 /// distinct one. `rivet add` emits a non-blocking note for a similar new title.

--- a/rivet-core/src/model.rs
+++ b/rivet-core/src/model.rs
@@ -1053,6 +1053,22 @@ pub struct ProjectMetadata {
     pub schemas: Vec<String>,
 }
 
+/// On-disk layout for how `rivet add` writes new artifacts into a directory
+/// source (#490). The read path globs every `*.yaml` in a directory regardless
+/// of layout; this only governs the write target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SourceLayout {
+    /// All artifacts of a type accumulate in one `<type>s.yaml` file; new
+    /// artifacts are appended at EOF. The historical default — two parallel
+    /// adds collide on the file's tail.
+    #[default]
+    SingleFile,
+    /// One file per artifact id (`<ID>.yaml`) in the source directory, so two
+    /// PRs adding different artifacts touch different files → never conflict.
+    PerId,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceConfig {
     pub path: String,
@@ -1060,6 +1076,9 @@ pub struct SourceConfig {
     /// Path to a WASM adapter component (only used when `format: "wasm"`).
     #[serde(default)]
     pub adapter: Option<String>,
+    /// How `rivet add` writes new artifacts into this source (#490).
+    #[serde(default)]
+    pub layout: SourceLayout,
     #[serde(default)]
     pub config: BTreeMap<String, String>,
 }


### PR DESCRIPTION
## Problem

Every PR that files an artifact appends to one shared per-type file (`artifacts/requirements.yaml`), so any two in-flight PRs collide on its tail. A standing merge-conflict tax on the dogfooding loop — documented in #422/#487 and hit again **this session** rebasing #595.

## Key finding (de-risks the whole thing)

The feared "structural migration" is mostly already built: `import_generic_directory` recursively loads every `*.yaml` in a directory source today, and each artifact records its own `source_file` — so `modify`/`remove`/`validate`/`next-id` are **already** path-agnostic. The *only* code assuming one-file-per-type was `rivet add`.

## This change (Slice 1)

- **`SourceConfig.layout`** (`model.rs`) — new opt-in enum: `single-file` (default, today's append behavior) or `per-id`.
- **`rivet add`** — when the owning source is `per-id` (or `--file` points at a directory), write `<dir>/<ID>.yaml` instead of appending to `<type>s.yaml`. Reuses the existing "ensure `artifacts:` header + append" machinery — the new file is just named by the (unique) id.

Two PRs adding different artifacts then touch **different files → zero conflict, ever.**

`rivet.yaml`:
```yaml
sources:
  - path: artifacts/requirements
    format: generic-yaml
    layout: per-id          # ← opt-in; omit for today's single-file behavior
```

## Verification
- New test `add_with_per_id_layout_writes_one_file_per_artifact`: two adds → two distinct `<ID>.yaml` files (no shared `requirements.yaml`), both load via the directory read path.
- Backward compat: `add_creates_default_file_for_a_new_type` (single-file append) still green.
- End-to-end confirmed: per-id adds load + `validate` PASS; default unchanged. fmt + clippy `--all-targets` clean.

## Design + follow-up
Design decision **DD-070** (filed in this PR, `satisfies` REQ-007). **Slice 2** = a `rivet migrate --explode <source>` command to split an existing single-file source into per-id files (opt-in, for existing projects).

Refs #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)