### PR TITLE
chore(release): v0.21.1 — fix --set-release artifact corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-06-26
+
+### Fixed
+- **`rivet modify --set-release` (and any new-base-field insert) no longer
+  corrupts artifacts with a trailing block mapping (data loss).** `--set-release`
+  — shipped in v0.21.0 — spliced the new `release:` key *between* a trailing
+  `provenance:` block and its children, producing invalid YAML so the artifact
+  (and its file-mates) vanished on reload. Since every AI-stamped artifact has a
+  `provenance:` block, this hit most artifacts the command touched. The inserter
+  now skips a field's full extent, including nested block-mapping children, and
+  places the new field after the whole block. Found by dogfooding the v0.21.0
+  release field. (REQ-004)
+
 ## [0.21.0] - 2026-06-26
 
 Theme: **Authoring & release ergonomics** — fix the dogfooding friction that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch release. Fixes a **data-corruption P0** in v0.21.0.

## The fix (#600, already on main)
`rivet modify --set-release` inserted the new `release:` key *inside* a trailing `provenance:` block, producing invalid YAML → the artifact vanished on reload. Every AI-stamped artifact has a `provenance:` block, so the command corrupted most artifacts it touched. The inserter now skips a field's full extent (including nested block-mapping children).

Found by dogfooding the v0.21.0 release field while planning v0.22 — a real `--set-release` on rivet's own `requirements.yaml` corrupted it.

## Version bumps
- `Cargo.toml`/`Cargo.lock` → 0.21.1
- `vscode-rivet/package.json` → 0.21.1
- `CHANGELOG.md` [0.21.1]

Regression test `set_field_inserts_after_trailing_provenance_block` guards it. `docs check` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)