### PR TITLE
plan(v0.22): release-planning slices as requirements (release: v0.22.0)

### DIFF
--- a/artifacts/cross-git-investigation.yaml
+++ b/artifacts/cross-git-investigation.yaml
@@ -1154,3 +1154,14 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-7
       timestamp: 2026-05-20T09:00:00Z
+
+  - id: REQ-233
+    type: requirement
+    title: rivet release status <ver> readiness burn-down
+    status: proposed
+    description: "Per-status counts + the not-yet-verified set for a release; cuttable when zero. Reads the release: field. #516 slice 3. v0.22 centerpiece."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-26T18:44:22Z
+    release: v0.22.0

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7509,3 +7509,36 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-25T09:00:00Z
+
+  - id: REQ-232
+    type: requirement
+    title: rivet list --release <ver> filter sugar
+    status: proposed
+    description: "Convenience flag equal to --filter (= release \"<ver>\"). #516 slice 2. v0.22."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-26T18:44:21Z
+    release: v0.22.0
+
+  - id: REQ-234
+    type: requirement
+    title: rivet release move <id> <ver> logged scope change
+    status: proposed
+    description: "Re-target an artifact to a release as a logged scope decision (uses --set-release). #516 slice 3. v0.22."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-26T18:44:22Z
+    release: v0.22.0
+
+  - id: REQ-235
+    type: requirement
+    title: rivet migrate --explode <source> to per-id files
+    status: proposed
+    description: "Split an existing single-file source into per-id <ID>.yaml files so existing projects adopt the conflict-free layout (DD-070). #490 slice 2. v0.22."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-26T18:44:23Z
+    release: v0.22.0


### PR DESCRIPTION
Makes the **v0.22 plan live in the trace** (not a spreadsheet) by filing the four scoped slices as `proposed` requirements, each tagged `release: v0.22.0`. Queryable today:

```
$ rivet list --filter '(= release "v0.22.0")'
REQ-232  rivet list --release <ver> filter sugar           (#516 §2)
REQ-233  rivet release status <ver> readiness burn-down    (#516 §3, centerpiece)
REQ-234  rivet release move <id> <ver> logged scope change (#516 §3)
REQ-235  rivet migrate --explode <source> to per-id files  (#490 §2, DD-070)
```

**v0.22 theme:** complete release-planning — finish what v0.21 started (the `release:` field is half-useful without a burn-down query). Each slice is small; the field + loader already exist.

**Dogfood notes** (both are wins of the methodology):
- Filing these with `--set-release` exercised and confirmed the **v0.21.1** corruption fix — all four carry `provenance:` blocks and validate cleanly.
- Found a minor routing quirk: `rivet add --type requirement` appended REQ-233 to `cross-git-investigation.yaml` (another file holding a requirement-type artifact) rather than `requirements.yaml` — `find_file_for_type` is order-dependent. Functionally fine (the trace is file-agnostic), but worth a follow-up; #490's per-id layout sidesteps it entirely.

Once merged, v0.22 implementation starts at REQ-232 (`list --release`). `validate` PASS; `docs check` PASS.

Refs REQ-007, DD-070.

🤖 Generated with [Claude Code](https://claude.com/claude-code)