### PR TITLE
feat(list): --release <ver> release-planning view (REQ-232, #516)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7513,7 +7513,7 @@ artifacts:
   - id: REQ-232
     type: requirement
     title: rivet list --release <ver> filter sugar
-    status: proposed
+    status: verified
     description: "Convenience flag equal to --filter (= release \"<ver>\"). #516 slice 2. v0.22."
     provenance:
       created-by: ai-assisted

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -525,6 +525,12 @@ enum Command {
         /// artifact or a raw YAML parse (#506). No effect on text output.
         #[arg(long)]
         full: bool,
+
+        /// Filter to artifacts scoped to a release (e.g. v0.22.0) — the
+        /// release-planning view. Sugar for `--filter '(= release "<ver>")'`
+        /// (#516, REQ-232). Combines with --type/--status/--filter.
+        #[arg(long, value_name = "VERSION")]
+        release: Option<String>,
     },
 
     /// Show artifact summary statistics
@@ -2285,6 +2291,7 @@ fn run(cli: Cli) -> Result<bool> {
             orphans,
             rank_by_backlinks,
             full,
+            release,
         } => cmd_list(
             &cli,
             r#type.as_deref(),
@@ -2296,6 +2303,7 @@ fn run(cli: Cli) -> Result<bool> {
             *orphans,
             *rank_by_backlinks,
             *full,
+            release.as_deref(),
         ),
         Command::Get { id, format } => cmd_get(&cli, id, format),
         // REQ-167 / #426: `trace` is the discoverable namesake verb for the
@@ -6678,6 +6686,7 @@ fn cmd_list(
     orphans_only: bool,
     rank_by_backlinks: bool,
     full: bool,
+    release_filter: Option<&str>,
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
     let ctx = ProjectContext::load(cli)?;
@@ -6710,6 +6719,13 @@ fn cmd_list(
         results.retain(|a| {
             rivet_core::sexpr_eval::matches_filter_with_store(&expr, a, &graph, &store)
         });
+    }
+
+    // REQ-232 / #516: `--release <ver>` is the release-planning view — keep
+    // only artifacts scoped to that release. Sugar for `(= release "<ver>")`,
+    // composing with the filters above.
+    if let Some(ver) = release_filter {
+        results.retain(|a| a.release.as_deref() == Some(ver));
     }
 
     // REQ-128: `--orphans` keeps only artifacts with no inbound and no

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6254,6 +6254,78 @@ fn release_field_loads_sets_and_filters_without_loss() {
     );
 }
 
+/// REQ-232 (#516): `rivet list --release <ver>` is the release-planning view —
+/// it keeps only artifacts scoped to that release and composes with the other
+/// filters. Sugar for `--filter '(= release "<ver>")'`.
+///
+/// rivet: verifies REQ-232
+#[test]
+fn list_release_flag_filters_by_release_scope() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    assert!(
+        Command::new(rivet_bin())
+            .args(["init", "--preset", "dev", "--dir", dirs])
+            .output()
+            .expect("init")
+            .status
+            .success()
+    );
+    std::fs::write(
+        dir.join("artifacts/reqs.yaml"),
+        "artifacts:\n  \
+         - id: REQ-9\n    type: requirement\n    title: A\n    status: draft\n    release: v1.0.0\n  \
+         - id: REQ-8\n    type: requirement\n    title: B\n    status: draft\n    release: v2.0.0\n  \
+         - id: REQ-7\n    type: requirement\n    title: C\n    status: draft\n",
+    )
+    .unwrap();
+    let run = |args: &[&str]| {
+        let out = Command::new(rivet_bin())
+            .args(["--project", dirs])
+            .args(args)
+            .output()
+            .expect("run rivet");
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    };
+
+    // --release keeps only the matching artifact.
+    let v1 = run(&["list", "--release", "v1.0.0", "--format", "json"]);
+    assert!(
+        v1.contains("REQ-9") && !v1.contains("REQ-8") && !v1.contains("REQ-7"),
+        "--release v1.0.0 must keep only REQ-9; got:\n{v1}"
+    );
+
+    // Unassigned artifacts (no release) are excluded.
+    let v2 = run(&["list", "--release", "v2.0.0", "--format", "json"]);
+    assert!(
+        v2.contains("REQ-8") && !v2.contains("REQ-7"),
+        "--release v2.0.0 must keep only REQ-8; got:\n{v2}"
+    );
+
+    // Composes with --status (REQ-9 is draft → still matches).
+    let combined = run(&[
+        "list",
+        "--release",
+        "v1.0.0",
+        "--status",
+        "draft",
+        "--format",
+        "json",
+    ]);
+    assert!(
+        combined.contains("REQ-9"),
+        "--release must compose with --status; got:\n{combined}"
+    );
+
+    // Unknown release → empty.
+    let none = run(&["list", "--release", "v9.9.9", "--format", "json"]);
+    assert!(
+        !none.contains("REQ-"),
+        "an unknown release must list nothing; got:\n{none}"
+    );
+}
+
 /// #552: `rivet add --type <T>` must create a default file for the type when
 /// none exists yet, instead of erroring "no existing file found … use --file".
 /// You shouldn't need --file just to add the FIRST artifact of a type.


### PR DESCRIPTION
First **v0.22** slice — `rivet list --release <ver>`, the release-planning view promised by the v0.21 `release:` field.

```
$ rivet list --release v0.22.0
REQ-232  rivet list --release <ver>          verified
REQ-233  rivet release status <ver> burn-down  proposed
REQ-234  rivet release move <id> <ver>         proposed
REQ-235  rivet migrate --explode <source>      proposed
```

Sugar for `--filter '(= release "<ver>")'`; composes with `--type`/`--status`/`--filter`. A thin `results.retain(|a| a.release == ver)` in `cmd_list`.

## Verification
- New test `list_release_flag_filters_by_release_scope`: filters by release, excludes unassigned, composes with `--status`, empty for unknown release.
- Verified end-to-end against rivet's own plan (the query above is real output).
- REQ-232 advanced `proposed → implemented → verified` via its test marker.

## Dogfooding finding (filed #603)
Advancing REQ-232 with `rivet verify` needed an explicit `--scan rivet-cli/tests` — the default scan stops at the repo-root `tests/` and doesn't recurse into member crates. This is the **mixed-workspace edge flagged on #574, now hit in practice**. Filed as #603 (refs #574).

Implements REQ-232 (#516 slice 2). Next: REQ-233 (`release status` burn-down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)