### PR TITLE
feat(release): rivet release status <ver> readiness burn-down (REQ-233, #516)

### DIFF
--- a/artifacts/cross-git-investigation.yaml
+++ b/artifacts/cross-git-investigation.yaml
@@ -1158,7 +1158,7 @@ artifacts:
   - id: REQ-233
     type: requirement
     title: rivet release status <ver> readiness burn-down
-    status: proposed
+    status: verified
     description: "Per-status counts + the not-yet-verified set for a release; cuttable when zero. Reads the release: field. #516 slice 3. v0.22 centerpiece."
     provenance:
       created-by: ai-assisted

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -917,6 +917,13 @@ enum Command {
         action: BaselineAction,
     },
 
+    /// Release planning: scope artifacts to a release and query readiness
+    /// (#516). Pairs with the `release:` field and `list --release`.
+    Release {
+        #[command(subcommand)]
+        action: ReleaseAction,
+    },
+
     /// Capture or compare project snapshots for delta tracking
     #[cfg(feature = "serve")]
     Snapshot {
@@ -1485,6 +1492,21 @@ enum BaselineAction {
     },
     /// List baselines found across externals
     List,
+}
+
+#[derive(Debug, Subcommand)]
+enum ReleaseAction {
+    /// Readiness burn-down for a release (REQ-233, #516): per-status counts of
+    /// the artifacts scoped to `release: <version>`, plus the set that is not
+    /// yet `verified`/`accepted`. The release is cuttable when that set is
+    /// empty. Exits non-zero when not cuttable (so CI can gate on it).
+    Status {
+        /// Release version, e.g. v0.22.0
+        version: String,
+        /// Output format: "text" (default) or "json"
+        #[arg(short, long, default_value = "text")]
+        format: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -2460,6 +2482,9 @@ fn run(cli: Cli) -> Result<bool> {
         Command::Baseline { action } => match action {
             BaselineAction::Verify { name, strict } => cmd_baseline_verify(&cli, name, *strict),
             BaselineAction::List => cmd_baseline_list(&cli),
+        },
+        Command::Release { action } => match action {
+            ReleaseAction::Status { version, format } => cmd_release_status(&cli, version, format),
         },
         #[cfg(feature = "serve")]
         Command::Snapshot { action } => match action {
@@ -6671,6 +6696,82 @@ fn cmd_bundle(cli: &Cli, id: &str, depth: usize, format: &str, incoming: bool) -
             Ok(false)
         }
     }
+}
+
+/// REQ-233 / #516: readiness burn-down for a release — per-status counts of the
+/// artifacts scoped to `release: <version>`, plus the not-yet-`verified` set.
+/// The release is cuttable when that set is empty; returns `Ok(false)` (process
+/// exits non-zero) when it is not, so CI can gate a release on it.
+fn cmd_release_status(cli: &Cli, version: &str, format: &str) -> Result<bool> {
+    validate_format(format, &["text", "json"])?;
+    let ctx = ProjectContext::load(cli)?;
+    ctx.warn_parse_error_skips(cli);
+
+    let mut scoped: Vec<&rivet_core::model::Artifact> = ctx
+        .store
+        .iter()
+        .filter(|a| a.release.as_deref() == Some(version))
+        .collect();
+    scoped.sort_by(|a, b| a.id.cmp(&b.id));
+
+    // `verified` and `accepted` are the done states; anything else still blocks.
+    let is_done = |s: Option<&str>| matches!(s, Some("verified") | Some("accepted"));
+    let mut by_status: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    for a in &scoped {
+        *by_status
+            .entry(a.status.as_deref().unwrap_or("(none)").to_string())
+            .or_default() += 1;
+    }
+    let not_done: Vec<&&rivet_core::model::Artifact> = scoped
+        .iter()
+        .filter(|a| !is_done(a.status.as_deref()))
+        .collect();
+    let cuttable = not_done.is_empty();
+
+    if format == "json" {
+        let obj = serde_json::json!({
+            "release": version,
+            "total": scoped.len(),
+            "by_status": by_status,
+            "not_verified": not_done.iter().map(|a| serde_json::json!({
+                "id": a.id,
+                "status": a.status.as_deref().unwrap_or("(none)"),
+                "title": a.title,
+            })).collect::<Vec<_>>(),
+            "cuttable": cuttable,
+        });
+        println!("{}", serde_json::to_string_pretty(&obj)?);
+    } else if scoped.is_empty() {
+        println!(
+            "Release {version}: no artifacts scoped — assign with \
+             `rivet modify <ID> --set-release {version}`."
+        );
+    } else {
+        println!("Release {version} — {} artifact(s)", scoped.len());
+        for (status, count) in &by_status {
+            println!("  {status:<12} {count}");
+        }
+        if cuttable {
+            println!("\n\u{2713} Cuttable — every artifact is verified/accepted.");
+        } else {
+            println!("\nNot yet verified ({}):", not_done.len());
+            for a in &not_done {
+                println!(
+                    "  {:<10} {:<12} {}",
+                    a.id,
+                    a.status.as_deref().unwrap_or("(none)"),
+                    a.title
+                );
+            }
+            println!(
+                "\n\u{2717} NOT cuttable — {} artifact(s) not yet verified.",
+                not_done.len()
+            );
+        }
+    }
+
+    Ok(cuttable)
 }
 
 /// List artifacts.

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6326,6 +6326,71 @@ fn list_release_flag_filters_by_release_scope() {
     );
 }
 
+/// REQ-233 (#516): `rivet release status <ver>` reports the readiness burn-down
+/// — the not-yet-verified set — and exits non-zero while the release is not
+/// cuttable, zero once every scoped artifact is verified/accepted.
+///
+/// rivet: verifies REQ-233
+#[test]
+fn release_status_reports_burn_down_and_exit_code() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    assert!(
+        Command::new(rivet_bin())
+            .args(["init", "--preset", "dev", "--dir", dirs])
+            .output()
+            .expect("init")
+            .status
+            .success()
+    );
+    let reqs = dir.join("artifacts/reqs.yaml");
+    // Two in v1.0.0: one verified, one still proposed → not cuttable.
+    std::fs::write(
+        &reqs,
+        "artifacts:\n  \
+         - id: REQ-9\n    type: requirement\n    title: A\n    status: verified\n    release: v1.0.0\n  \
+         - id: REQ-8\n    type: requirement\n    title: B\n    status: proposed\n    release: v1.0.0\n",
+    )
+    .unwrap();
+
+    let status = Command::new(rivet_bin())
+        .args(["--project", dirs, "release", "status", "v1.0.0"])
+        .output()
+        .expect("release status");
+    let out = String::from_utf8_lossy(&status.stdout);
+    assert!(
+        out.contains("REQ-8") && out.contains("NOT cuttable"),
+        "must list the not-yet-verified artifact and flag not-cuttable; got:\n{out}"
+    );
+    assert!(
+        !status.status.success(),
+        "must exit non-zero while the release is not cuttable (so CI can gate)"
+    );
+
+    // Verify REQ-8 → now everything is done → cuttable, exit zero.
+    std::fs::write(
+        &reqs,
+        "artifacts:\n  \
+         - id: REQ-9\n    type: requirement\n    title: A\n    status: verified\n    release: v1.0.0\n  \
+         - id: REQ-8\n    type: requirement\n    title: B\n    status: verified\n    release: v1.0.0\n",
+    )
+    .unwrap();
+    let status2 = Command::new(rivet_bin())
+        .args(["--project", dirs, "release", "status", "v1.0.0"])
+        .output()
+        .expect("release status");
+    assert!(
+        status2.status.success(),
+        "must exit zero once every scoped artifact is verified; stdout:\n{}",
+        String::from_utf8_lossy(&status2.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&status2.stdout).contains("Cuttable"),
+        "must report the release as cuttable"
+    );
+}
+
 /// #552: `rivet add --type <T>` must create a default file for the type when
 /// none exists yet, instead of erroring "no existing file found … use --file".
 /// You shouldn't need --file just to add the FIRST artifact of a type.


### PR DESCRIPTION
The **release-planning centerpiece** (#516 slice 3) — turns the `release:` field into an actionable burn-down.

```
$ rivet release status v0.22.0
Release v0.22.0 — 4 artifact(s)
  proposed     2
  verified     2

Not yet verified (2):
  REQ-234    proposed     rivet release move <id> <ver> logged scope change
  REQ-235    proposed     rivet migrate --explode <source> to per-id files

✗ NOT cuttable — 2 artifact(s) not yet verified.
$ echo $?
1
```

- Per-status counts of artifacts scoped to `release: <version>`, the **not-yet-verified set** that blocks the cut, and a cuttable verdict (`verified`/`accepted` are done).
- **Exits non-zero while not cuttable** → CI can gate a release on `rivet release status vX.Y`.
- `--format json` (`total`, `by_status`, `not_verified[]`, `cuttable`).
- Adds a `release` command group; `release move` (REQ-234) lands next.

## Verification
- Test `release_status_reports_burn_down_and_exit_code`: not-cuttable lists the blocker + exits non-zero; all-verified → cuttable + exits zero.
- Real output above is rivet's **own v0.22 plan** — the burn-down tracks its own slices completing (REQ-232/233 verified as they land).
- REQ-233 advanced to `verified`. clippy/fmt clean.

Implements REQ-233 (#516 slice 3). Next: REQ-234 (`release move`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)