### PR TITLE
feat(release): rivet release move <id> <ver> logged scope change (REQ-234, #516)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7524,7 +7524,7 @@ artifacts:
   - id: REQ-234
     type: requirement
     title: rivet release move <id> <ver> logged scope change
-    status: proposed
+    status: verified
     description: "Re-target an artifact to a release as a logged scope decision (uses --set-release). #516 slice 3. v0.22."
     provenance:
       created-by: ai-assisted

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1507,6 +1507,15 @@ enum ReleaseAction {
         #[arg(short, long, default_value = "text")]
         format: String,
     },
+    /// Re-target an artifact to a different release (REQ-234, #516) — a logged
+    /// scope decision. Reports the old → new release transition; the artifact
+    /// edit is the durable record.
+    Move {
+        /// Artifact ID to move (e.g. REQ-042)
+        id: String,
+        /// Destination release version (e.g. v0.23.0)
+        version: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -2485,6 +2494,7 @@ fn run(cli: Cli) -> Result<bool> {
         },
         Command::Release { action } => match action {
             ReleaseAction::Status { version, format } => cmd_release_status(&cli, version, format),
+            ReleaseAction::Move { id, version } => cmd_release_move(&cli, id, version),
         },
         #[cfg(feature = "serve")]
         Command::Snapshot { action } => match action {
@@ -6696,6 +6706,44 @@ fn cmd_bundle(cli: &Cli, id: &str, depth: usize, format: &str, incoming: bool) -
             Ok(false)
         }
     }
+}
+
+/// REQ-234 / #516: re-target an artifact to a different release — a logged scope
+/// decision. The artifact edit (via the shared safe modify write-path) is the
+/// durable record; this surfaces the old → new transition.
+fn cmd_release_move(cli: &Cli, id: &str, version: &str) -> Result<bool> {
+    // Capture the current release for the scope-change log. Scope the borrow so
+    // `cmd_modify` can reload the project below.
+    let old = {
+        let ctx = ProjectContext::load(cli)?;
+        ctx.store
+            .get(id)
+            .ok_or_else(|| anyhow::anyhow!("artifact '{id}' not found"))?
+            .release
+            .clone()
+    };
+    if old.as_deref() == Some(version) {
+        println!("{id} is already scoped to {version} — nothing to do.");
+        return Ok(true);
+    }
+    let ok = cmd_modify(
+        cli,
+        Some(id),
+        None,
+        false,
+        None,
+        Some(version),
+        None,
+        None,
+        &[],
+        &[],
+        &[],
+    )?;
+    if ok {
+        let from = old.as_deref().unwrap_or("(unassigned)");
+        println!("scope change: {id} moved {from} \u{2192} {version}");
+    }
+    Ok(ok)
 }
 
 /// REQ-233 / #516: readiness burn-down for a release — per-status counts of the

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6391,6 +6391,79 @@ fn release_status_reports_burn_down_and_exit_code() {
     );
 }
 
+/// REQ-234 (#516): `rivet release move <id> <ver>` re-targets an artifact to a
+/// release, logging the old → new transition; idempotent when already scoped.
+///
+/// rivet: verifies REQ-234
+#[test]
+fn release_move_retargets_and_logs_scope_change() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    assert!(
+        Command::new(rivet_bin())
+            .args(["init", "--preset", "dev", "--dir", dirs])
+            .output()
+            .expect("init")
+            .status
+            .success()
+    );
+    std::fs::write(
+        dir.join("artifacts/reqs.yaml"),
+        "artifacts:\n  \
+         - id: REQ-9\n    type: requirement\n    title: A\n    status: draft\n    release: v1.0.0\n  \
+         - id: REQ-8\n    type: requirement\n    title: B\n    status: draft\n",
+    )
+    .unwrap();
+    let run = |args: &[&str]| {
+        let out = Command::new(rivet_bin())
+            .args(["--project", dirs])
+            .args(args)
+            .output()
+            .expect("run rivet");
+        (
+            out.status.success(),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+        )
+    };
+
+    // Move an assigned artifact: logs the transition, re-targets the scope.
+    let (ok, out) = run(&["release", "move", "REQ-9", "v2.0.0"]);
+    assert!(ok, "move must succeed; got:\n{out}");
+    assert!(
+        out.contains("v1.0.0") && out.contains("v2.0.0"),
+        "must log the old → new release transition; got:\n{out}"
+    );
+    let (_, v2) = run(&["list", "--release", "v2.0.0", "--format", "json"]);
+    assert!(
+        v2.contains("REQ-9"),
+        "REQ-9 must now be in v2.0.0; got:\n{v2}"
+    );
+    let (_, v1) = run(&["list", "--release", "v1.0.0", "--format", "json"]);
+    assert!(
+        !v1.contains("REQ-9"),
+        "REQ-9 must no longer be in v1.0.0; got:\n{v1}"
+    );
+
+    // Move an unassigned artifact: transition from "(unassigned)".
+    let (ok2, out2) = run(&["release", "move", "REQ-8", "v2.0.0"]);
+    assert!(
+        ok2,
+        "moving an unassigned artifact must succeed; got:\n{out2}"
+    );
+    assert!(
+        out2.contains("unassigned") && out2.contains("v2.0.0"),
+        "must log the move from unassigned; got:\n{out2}"
+    );
+
+    // Idempotent: moving to the same release is a no-op.
+    let (ok3, out3) = run(&["release", "move", "REQ-9", "v2.0.0"]);
+    assert!(
+        ok3 && out3.contains("nothing to do"),
+        "must be idempotent; got:\n{out3}"
+    );
+}
+
 /// #552: `rivet add --type <T>` must create a default file for the type when
 /// none exists yet, instead of erroring "no existing file found … use --file".
 /// You shouldn't need --file just to add the FIRST artifact of a type.


### PR DESCRIPTION
Completes the `release` command group (#516 slice 3): `rivet release move <id> <ver>` re-targets an artifact to a different release as a **logged scope decision**.

```
$ rivet release move REQ-42 v0.23.0
modified REQ-42
scope change: REQ-42 moved v0.22.0 → v0.23.0
```

- Reports the old → new transition; the artifact edit (shared safe modify write-path) is the durable record.
- Idempotent (`already scoped … nothing to do`); moves unassigned artifacts from `(unassigned)`.

## Verification
- Test `release_move_retargets_and_logs_scope_change`: logs the transition + re-targets (leaves the old release, joins the new); unassigned case; idempotent no-op.
- REQ-234 advanced to `verified`. With it, `rivet release status v0.22.0` → **3 verified, 1 proposed** (only REQ-235 left). fmt/clippy clean.

Implements REQ-234. Last slice: REQ-235 (`rivet migrate --explode`, the #490 data migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)