### PR TITLE
chore(release): v0.22.0 — Release planning, complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-27
+
+Theme: **Release planning, complete** — turn the v0.21 `release:` field into a
+full, dogfooded workflow. v0.22 is the first rivet release planned, executed,
+and gated entirely with rivet's own tooling: the plan lives in `release:`-tagged
+artifacts, and `rivet release status` is the authority that called it cuttable.
+
+### Added
+- **`rivet list --release <ver>`** (REQ-232, #516) — the release-planning view;
+  keep only artifacts scoped to a release. Sugar for `(= release "<ver>")`,
+  composes with `--type`/`--status`/`--filter`.
+- **`rivet release status <ver>`** (REQ-233, #516) — readiness burn-down:
+  per-status counts of the artifacts in a release, the not-yet-`verified` set
+  that blocks the cut, and a cuttable verdict. **Exits non-zero while not
+  cuttable**, so CI can gate a release on it. `--format json` too.
+- **`rivet release move <id> <ver>`** (REQ-234, #516) — re-target an artifact to
+  a release as a logged scope decision; reports the old → new transition,
+  idempotent, via the safe modify write-path.
+- **`rivet shard <file>`** (REQ-235, #490 / DD-070) — split a single-file
+  artifact source into one `<ID>.yaml` per artifact so existing projects adopt
+  the conflict-free per-id layout (the data-migration half of #490). Reversible
+  and lossless: writes the per-id files, verifies they hold the same id set,
+  backs up the original, reloads the whole project to confirm nothing was lost,
+  and only then removes the backup — restoring + refusing on any mismatch.
+
 ## [0.21.1] - 2026-06-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.21.1"
+version = "0.22.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v0.22.0. Theme: **Release planning, complete** — the v0.21 `release:` field becomes a full, dogfooded workflow.

**The first rivet release planned, executed, and gated entirely with rivet's own tooling** — the plan lived in `release:`-tagged artifacts (REQ-232..235), and `rivet release status v0.22.0` is the authority that called it cuttable.

## Scope (all merged + verified)
- **REQ-232** `rivet list --release <ver>` — release-planning view (#604)
- **REQ-233** `rivet release status <ver>` — readiness burn-down, CI-gateable (#605)
- **REQ-234** `rivet release move <id> <ver>` — logged scope change (#606)
- **REQ-235** `rivet shard <file>` — reversible per-id source migration, #490 slice 2 (#607)

## Version bumps
- `Cargo.toml`/`Cargo.lock` → 0.22.0
- `vscode-rivet/package.json` → 0.22.0
- `CHANGELOG.md` [0.22.0]

`rivet docs check` PASS. `rivet release status v0.22.0` → ✓ Cuttable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)