### PR TITLE
plan(v0.23): traceability-evidence slices (release: v0.23.0)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7542,3 +7542,47 @@ artifacts:
       model: claude-opus-4-8
       timestamp: 2026-06-26T18:44:23Z
     release: v0.22.0
+
+  - id: REQ-236
+    type: requirement
+    title: cited-source on verification types + native named-test-exists check
+    status: proposed
+    description: "Declare cited-source on sw/unit/sys-verification types and add a native named-test-exists check so requirement->test evidence is drift-checked, not just asserted. #556. v0.23 centerpiece."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-27T06:51:06Z
+    release: v0.23.0
+
+  - id: REQ-237
+    type: requirement
+    title: direct test->sw-req link (skip full ASPICE design chain)
+    status: proposed
+    description: "Allow a test to link directly to a sw-req for verified status without the full ASPICE design chain; guide the completeness error toward it. #350. v0.23."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-27T06:51:07Z
+    release: v0.23.0
+
+  - id: REQ-238
+    type: requirement
+    title: graphical req->test-result trace view
+    status: proposed
+    description: "A graphical/visual way to trace a requirement to its test results. #547. v0.23."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-27T06:51:07Z
+    release: v0.23.0
+
+  - id: REQ-239
+    type: requirement
+    title: validate <-> commit-name parsing parity
+    status: proposed
+    description: "Sync the validate naming checks with commit-name parsing so naming issues are caught early and consistently. #577. v0.23."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-27T06:51:08Z
+    release: v0.23.0


### PR DESCRIPTION
**v0.23 theme: Traceability evidence** — make requirement→test evidence *drift-checked*, not just asserted (the V-model core). Files the scoped slices as `release: v0.23.0` requirements so the roadmap is live and queryable via the v0.22 tooling:

```
$ rivet release status v0.23.0
Release v0.23.0 — 4 artifact(s)
  proposed     4
✗ NOT cuttable — 4 artifact(s) not yet verified.
```

| REQ | Slice | Issue |
|---|---|---|
| REQ-236 | cited-source on verification types + native `named-test-exists` check (centerpiece) | #556 |
| REQ-237 | direct test→sw-req link (skip the full ASPICE design chain) | #350 |
| REQ-238 | graphical req→test-result trace view | #547 |
| REQ-239 | `validate` ↔ commit-name parsing parity | #577 |

Planned with rivet's own commands (`add --file` + `modify --set-release`). `validate` PASS.

Once merged, v0.23 execution starts at REQ-236 (the drift-check centerpiece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)