### PR TITLE
feat(schema): declare cited-source on verification types (REQ-236 pt1, #556)

### DIFF
--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6578,6 +6578,62 @@ fn shard_splits_source_into_per_id_files_reversibly() {
     );
 }
 
+/// REQ-236 (#556): `cited-source` is declared on the verification types in the
+/// aspice preset, so a hash-stamped pointer to the test source file is accepted
+/// (not rejected as an undeclared field) and `rivet check sources` drift-tracks
+/// it — the requirement→test evidence can no longer silently rot.
+///
+/// rivet: verifies REQ-236
+#[test]
+fn cited_source_accepted_on_sw_verification() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    std::fs::create_dir_all(dir.join("tests")).unwrap();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: t\n  version: \"0.1.0\"\n  schemas: [common, aspice]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join("tests/hal.rs"), "fn t() {}\n").unwrap();
+    std::fs::write(
+        dir.join("artifacts/v.yaml"),
+        "artifacts:\n  \
+         - id: SWR-1\n    type: sw-req\n    title: HAL requirement\n    status: approved\n  \
+         - id: FV-1\n    type: sw-verification\n    title: HAL verification\n    status: draft\n    fields:\n      method: automated-test\n      cited-source:\n        uri: tests/hal.rs\n        kind: file\n    links:\n      - type: verifies\n        target: SWR-1\n",
+    )
+    .unwrap();
+
+    // The cited-source field must NOT be rejected as undeclared on the
+    // verification type (the #556 symptom).
+    let val = Command::new(rivet_bin())
+        .args(["--project", dirs, "validate"])
+        .output()
+        .expect("validate");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&val.stdout),
+        String::from_utf8_lossy(&val.stderr)
+    );
+    assert!(
+        !combined.contains("'cited-source' is not defined"),
+        "cited-source must be declared on sw-verification; got:\n{combined}"
+    );
+
+    // `check sources` must recognize and drift-track the cited test file.
+    let cs = Command::new(rivet_bin())
+        .args(["--project", dirs, "check", "sources"])
+        .output()
+        .expect("check sources");
+    let cs_out = String::from_utf8_lossy(&cs.stdout);
+    assert!(
+        cs_out.contains("FV-1") && cs_out.contains("tests/hal.rs"),
+        "check sources must track the verification's cited test file; got:\n{cs_out}"
+    );
+}
+
 /// #552: `rivet add --type <T>` must create a default file for the type when
 /// none exists yet, instead of erroring "no existing file found … use --file".
 /// You shouldn't need --file just to add the FIRST artifact of a type.

--- a/schemas/aspice.yaml
+++ b/schemas/aspice.yaml
@@ -201,6 +201,14 @@ artifact-types:
       - name: steps
         type: structured
         required: false
+      - name: cited-source
+        type: cited-source
+        required: false
+        description: >
+          Sha256-stamped reference to the test source file(s) that perform this
+          verification. `rivet validate` / `rivet check sources` flag drift the
+          moment the cited file changes without a re-stamp, so the
+          requirement→test evidence cannot silently rot (REQ-236, #556).
     link-fields:
       - name: verifies
         link-type: verifies
@@ -232,6 +240,14 @@ artifact-types:
       - name: steps
         type: structured
         required: false
+      - name: cited-source
+        type: cited-source
+        required: false
+        description: >
+          Sha256-stamped reference to the test source file(s) that perform this
+          verification. `rivet validate` / `rivet check sources` flag drift the
+          moment the cited file changes without a re-stamp, so the
+          requirement→test evidence cannot silently rot (REQ-236, #556).
     link-fields:
       - name: verifies
         link-type: verifies
@@ -266,6 +282,14 @@ artifact-types:
       - name: steps
         type: structured
         required: false
+      - name: cited-source
+        type: cited-source
+        required: false
+        description: >
+          Sha256-stamped reference to the test source file(s) that perform this
+          verification. `rivet validate` / `rivet check sources` flag drift the
+          moment the cited file changes without a re-stamp, so the
+          requirement→test evidence cannot silently rot (REQ-236, #556).
     link-fields:
       - name: verifies
         link-type: verifies
@@ -297,6 +321,14 @@ artifact-types:
       - name: steps
         type: structured
         required: false
+      - name: cited-source
+        type: cited-source
+        required: false
+        description: >
+          Sha256-stamped reference to the test source file(s) that perform this
+          verification. `rivet validate` / `rivet check sources` flag drift the
+          moment the cited file changes without a re-stamp, so the
+          requirement→test evidence cannot silently rot (REQ-236, #556).
     link-fields:
       - name: verifies
         link-type: verifies
@@ -328,6 +360,14 @@ artifact-types:
       - name: steps
         type: structured
         required: false
+      - name: cited-source
+        type: cited-source
+        required: false
+        description: >
+          Sha256-stamped reference to the test source file(s) that perform this
+          verification. `rivet validate` / `rivet check sources` flag drift the
+          moment the cited file changes without a re-stamp, so the
+          requirement→test evidence cannot silently rot (REQ-236, #556).
     link-fields:
       - name: verifies
         link-type: verifies


### PR DESCRIPTION
First v0.23 slice (theme: **Traceability evidence**) and part 1 of #556.

## What
A verification artifact is exactly where a hash-stamped pointer to the **test source** belongs — "this requirement is verified by the tests in `crates/X/src/lib.rs`, sha256 `f5f98a…`" — so `rivet validate` flags drift the moment that file changes without a re-stamp. But `cited-source` was only declared on requirement-ish types; on a `sw-verification` it was **rejected as an undeclared field** (#556 symptom).

This declares `cited-source` under `fields:` for all five aspice verification types: `unit-verification`, `sw-integration-verification`, `sw-verification`, `sys-integration-verification`, `sys-verification`. The field already round-trips and `rivet check sources` already hashes it — it just wasn't *declared* there.

## Verified
```
# a sw-verification with cited-source: {uri: tests/hal.rs, kind: file}
$ rivet validate          # → no "'cited-source' is not defined" (was rejected)
$ rivet check sources
FV-1   MISSING-HASH   STALE-MISSING   file   tests/hal.rs   # ← now drift-tracked
```
Test `cited_source_accepted_on_sw_verification`. 78 schema tests green; rivet's own `validate` still PASS; fmt + clippy clean. Schema-version-bump check is warn-only.

## Remaining (REQ-236 part 2)
The native **`named-test-exists` check** — assert a named-test step's filter actually matches a test (a `cargo test typo` exits 0 / "0 passed", silently keeping a requirement 'verified'). Language-specific test-name extraction is the hard part; tracked as the second half of #556, so REQ-236 stays open until it lands.

Implements REQ-236 (part 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)