### PR TITLE
fix(modify): set-release no longer corrupts a folded scalar with a blank line (#613)

### DIFF
--- a/rivet-core/src/yaml_edit.rs
+++ b/rivet-core/src/yaml_edit.rs
@@ -253,6 +253,26 @@ impl YamlEditor {
         while end < block_end {
             let line = &self.lines[end];
             if line.trim().is_empty() {
+                // A blank line belongs to a block scalar (`>`/`|`) only when a
+                // deeper-indented line follows it. Peek past the run of blanks:
+                // if the next non-blank line is still inside the block, the
+                // blanks are part of the scalar; otherwise the block has ended.
+                // Without this, a folded/literal scalar with an internal blank
+                // line is truncated and the new field gets spliced *inside* it,
+                // corrupting the YAML (#613 — `--set-release` on an artifact
+                // with a folded `description:`).
+                let mut peek = end + 1;
+                while peek < block_end && self.lines[peek].trim().is_empty() {
+                    peek += 1;
+                }
+                if peek < block_end {
+                    let next = &self.lines[peek];
+                    let next_indent = next.len() - next.trim_start().len();
+                    if next_indent > field_indent {
+                        end = peek + 1;
+                        continue;
+                    }
+                }
                 break;
             }
             let indent = line.len() - line.trim_start().len();
@@ -1747,6 +1767,57 @@ artifacts:
         assert_eq!(
             parsed["artifacts"][0]["provenance"]["model"].as_str(),
             Some("claude-opus-4-8")
+        );
+    }
+
+    // rivet: verifies REQ-004
+    /// Regression (#613): inserting a new base field (`--set-release`) on an
+    /// artifact with a folded/literal `description:` scalar that contains an
+    /// INTERNAL BLANK LINE used to splice the new key inside the block — the
+    /// blank prematurely ended the scalar, truncating the description and
+    /// producing a misattributed/invalid value. The new field must land after
+    /// the entire scalar.
+    #[test]
+    fn set_field_inserts_after_folded_scalar_with_blank_line() {
+        let content = "\
+artifacts:
+  - id: REQ-001
+    type: requirement
+    title: t
+    status: implemented
+    description: >
+      Line one of a folded block.
+
+      Line two after a blank.
+    tags:
+      - x";
+        let params = crate::mutate::ModifyParams {
+            set_release: Some("v1.0.0".to_string()),
+            ..Default::default()
+        };
+        let store = crate::store::Store::new();
+        let out =
+            modify_artifact_yaml(content, "REQ-001", &params, &store).expect("modify must succeed");
+
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(&out).expect("output must parse as YAML");
+        assert_eq!(
+            parsed["artifacts"][0]["release"].as_str(),
+            Some("v1.0.0"),
+            "release must be set as a sibling field"
+        );
+        // The folded description must remain whole — both lines, not truncated.
+        let desc = parsed["artifacts"][0]["description"]
+            .as_str()
+            .expect("description must still be a scalar");
+        assert!(
+            desc.contains("Line one") && desc.contains("Line two"),
+            "the folded description must not be split/truncated; got: {desc:?}"
+        );
+        assert_eq!(
+            parsed["artifacts"][0]["tags"][0].as_str(),
+            Some("x"),
+            "sibling fields after the scalar must survive"
         );
     }
 }


### PR DESCRIPTION
## P0 — data corruption in v0.22.0 (and v0.21.x)

Follow-up to the v0.21.1 fix. `rivet modify --set-release` inserted the new `release:` key **inside** a folded (`>`) / literal (`|`) `description:` scalar that contains an internal blank line:

```yaml
    description: >
      Line one of a folded block.
    release: v1.0.0          # ← spliced INSIDE the block

      Line two after a blank.
```

This truncated the description and produced an invalid/misattributed value — silent (`modify` reports success), surfacing later at `rivet release status` / `validate`. Folded descriptions are very common, so most artifacts were affected. Reported in #613 by @avrabe.

## Root cause
v0.21.1 added `field_block_end` to skip a field's block extent, but it **broke on the first blank line** — and a block scalar can contain blank lines. So it stopped mid-block.

## Fix
When `field_block_end` hits a blank line, peek past the run of blanks: the blanks belong to the scalar only if a deeper-indented line follows; otherwise the block has ended. The new field now lands after the whole scalar.

```yaml
    description: >
      Line one of a folded block.

      Line two after a blank.
    release: v1.0.0          # ← now a sibling, after the full block
    links: ...
```

## Verification
- New regression test `set_field_inserts_after_folded_scalar_with_blank_line` — output parses, description intact (both lines), `release` is a sibling.
- Reporter's exact repro fixed: `release:` after the full description, artifact loads, `list --release` scopes it.
- All 34 `yaml_edit` tests pass; fmt + clippy clean.

Fixes #613. **Recommend a v0.22.1 patch** — `--set-release` on any folded-description artifact corrupts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)