### PR TITLE
chore(release): v0.22.1 — fix --set-release folded-scalar corruption (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-06-27
+
+### Fixed
+- **`rivet modify --set-release` no longer corrupts an artifact with a folded
+  (`>`) or literal (`|`) `description:` scalar (data loss).** A follow-up to the
+  v0.21.1 fix: the insert-position logic consumed a field's block extent but
+  **broke on the first blank line** — and a block scalar can contain internal
+  blank lines (a folded `description:` with a blank between paragraphs is very
+  common). So `--set-release` spliced the new `release:` key *inside* the scalar,
+  truncating the description and producing an invalid/misattributed value
+  (silent — `modify` reported success). The inserter now peeks past blank runs:
+  a blank belongs to the scalar only when a deeper-indented line follows.
+  Reported on real v0.22.0 use (#613). (REQ-004)
+
 ## [0.22.0] - 2026-06-27
 
 Theme: **Release planning, complete** — turn the v0.21 `release:` field into a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.22.1"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch release. Fixes a **data-corruption P0** in v0.22.0 reported by @avrabe (#613).

## The fix (#614, on main)
`rivet modify --set-release` spliced the new `release:` key **inside** a folded (`>`) / literal (`|`) `description:` scalar that contains an internal blank line, truncating it and producing an invalid/misattributed value — silent (`modify` reported success). Folded descriptions are ubiquitous, so most artifacts were affected. The insert-position logic now peeks past blank runs (a blank belongs to the scalar only when a deeper-indented line follows).

## Version bumps
- `Cargo.toml`/`Cargo.lock` → 0.22.1
- `vscode-rivet/package.json` → 0.22.1
- `CHANGELOG.md` [0.22.1]

Regression test `set_field_inserts_after_folded_scalar_with_blank_line` guards it. `docs check` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)