### PR TITLE
plan(v0.23): REQ-240 — coverage-based release cuttability (#612)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7586,3 +7586,14 @@ artifacts:
       model: claude-opus-4-8
       timestamp: 2026-06-27T06:51:08Z
     release: v0.23.0
+
+  - id: REQ-240
+    type: requirement
+    title: release status cuttability derives from coverage/links, not just status string
+    status: proposed
+    description: "rivet release status cuttability is status-only (verified/accepted); V-model/ASPICE projects verify via links (validate coverage rules), so the gate never greens for them. Derive release-ready from validate coverage passing, with a release.ready-when escape hatch. #612, follow-up to REQ-233."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-06-27T09:52:30Z
+    release: v0.23.0


### PR DESCRIPTION
Adds **REQ-240** to the v0.23 plan (`release: v0.23.0`), filed from @avrabe's #612.

`rivet release status` cuttability is status-only (`verified`/`accepted`), but V-model / ASPICE projects — like gale (967 artifacts, ASIL-D) — express verification through **links** (a requirement sits at terminal `approved`, verified by a link to a passing verification, exactly what `validate` coverage rules already check). So the headline CI-gate can never go green for them.

REQ-240: derive release-ready from **`validate` coverage passing** (the V is closed), with a `release.ready-when` escape hatch in rivet.yaml for explicit control. Follow-up to REQ-233; fits the v0.23 "traceability evidence" theme.

Updates the live v0.23 burn-down (`rivet release status v0.23.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)