### PR TITLE
feat(release): release.ready-when extends release-ready statuses (REQ-240, #612)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7591,7 +7591,7 @@ artifacts:
     type: requirement
     title: release status cuttability derives from coverage/links, not just status string
     status: proposed
-    description: "rivet release status cuttability is status-only (verified/accepted); V-model/ASPICE projects verify via links (validate coverage rules), so the gate never greens for them. Derive release-ready from validate coverage passing, with a release.ready-when escape hatch. #612, follow-up to REQ-233."
+    description: "rivet release status cuttability is status-only (verified/accepted); V-model/ASPICE projects verify via links (validate coverage rules), so the gate never greens for them. Derive release-ready from validate coverage passing, with a release.ready-when escape hatch. #612, follow-up to REQ-233. Partial: the release.ready-when escape hatch is delivered (ProjectConfig.release.ready-when extends the release-ready status set); deriving cuttability from validate coverage is still open before this can be verified."
     provenance:
       created-by: ai-assisted
       model: claude-opus-4-8

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -6903,8 +6903,20 @@ fn cmd_release_status(cli: &Cli, version: &str, format: &str) -> Result<bool> {
         .collect();
     scoped.sort_by(|a, b| a.id.cmp(&b.id));
 
-    // `verified` and `accepted` are the done states; anything else still blocks.
-    let is_done = |s: Option<&str>| matches!(s, Some("verified") | Some("accepted"));
+    // Release-ready statuses: the built-in `verified`/`accepted` plus any the
+    // project declares via `release.ready-when` (#612 — V-model / ASPICE
+    // projects verify through links and sit at a terminal status like
+    // `approved`, so the status-only default never greens for them).
+    let extra_ready: std::collections::BTreeSet<String> = ctx
+        .config
+        .release
+        .as_ref()
+        .map(|r| r.ready_when.iter().cloned().collect())
+        .unwrap_or_default();
+    let is_done = |s: Option<&str>| {
+        matches!(s, Some("verified") | Some("accepted"))
+            || s.is_some_and(|x| extra_ready.contains(x))
+    };
     let mut by_status: std::collections::BTreeMap<String, usize> =
         std::collections::BTreeMap::new();
     for a in &scoped {
@@ -6942,7 +6954,7 @@ fn cmd_release_status(cli: &Cli, version: &str, format: &str) -> Result<bool> {
             println!("  {status:<12} {count}");
         }
         if cuttable {
-            println!("\n\u{2713} Cuttable — every artifact is verified/accepted.");
+            println!("\n\u{2713} Cuttable — every artifact is release-ready.");
         } else {
             println!("\nNot yet verified ({}):", not_done.len());
             for a in &not_done {

--- a/rivet-cli/src/serve/variant.rs
+++ b/rivet-cli/src/serve/variant.rs
@@ -339,6 +339,7 @@ mod tests {
             docs: vec![],
             results: None,
             commits: None,
+            release: None,
             externals: None,
             baselines: None,
             docs_check: None,

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6634,6 +6634,64 @@ fn cited_source_accepted_on_sw_verification() {
     );
 }
 
+/// REQ-240 (#612): `release.ready-when` in rivet.yaml lets a V-model/ASPICE
+/// project add its own terminal statuses (e.g. `approved`) to the release-ready
+/// set, so `rivet release status` can green for link-verified projects whose
+/// artifacts never carry `status: verified`. Default stays verified/accepted.
+///
+/// rivet: verifies REQ-240
+#[test]
+fn release_status_honors_ready_when_config() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    std::fs::write(
+        dir.join("artifacts/r.yaml"),
+        "artifacts:\n  \
+         - id: REQ-1\n    type: requirement\n    title: a\n    status: approved\n    release: v0.1.0\n  \
+         - id: REQ-2\n    type: requirement\n    title: b\n    status: approved\n    release: v0.1.0\n",
+    )
+    .unwrap();
+    let write_cfg = |ready_when: &str| {
+        std::fs::write(
+            dir.join("rivet.yaml"),
+            format!(
+                "project:\n  name: t\n  version: \"0.1.0\"\n  schemas: [common, dev]\n{ready_when}\
+                 sources:\n  - path: artifacts\n    format: generic-yaml\n"
+            ),
+        )
+        .unwrap();
+    };
+
+    // Default (no ready-when): `approved` is not release-ready → exit non-zero.
+    write_cfg("");
+    let default = Command::new(rivet_bin())
+        .args(["--project", dirs, "release", "status", "v0.1.0"])
+        .output()
+        .expect("release status");
+    assert!(
+        !default.status.success(),
+        "without ready-when, an all-`approved` release must NOT be cuttable"
+    );
+
+    // With `release.ready-when: [approved]` → cuttable, exit zero.
+    write_cfg("release:\n  ready-when: [approved]\n");
+    let configured = Command::new(rivet_bin())
+        .args(["--project", dirs, "release", "status", "v0.1.0"])
+        .output()
+        .expect("release status");
+    assert!(
+        configured.status.success(),
+        "with ready-when: [approved], an all-approved release must be cuttable; stdout:\n{}",
+        String::from_utf8_lossy(&configured.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&configured.stdout).contains("Cuttable"),
+        "must report the release as cuttable"
+    );
+}
+
 /// #552: `rivet add --type <T>` must create a default file for the type when
 /// none exists yet, instead of erroring "no existing file found … use --file".
 /// You shouldn't need --file just to add the FIRST artifact of a type.

--- a/rivet-core/src/model.rs
+++ b/rivet-core/src/model.rs
@@ -978,6 +978,26 @@ impl From<&str> for DocsEntry {
     }
 }
 
+/// Release-readiness configuration for `rivet release status` (#612).
+///
+/// By default an artifact is release-ready only at status `verified`/`accepted`.
+/// V-model / ASPICE projects verify through *links* (a requirement sits at a
+/// terminal status like `approved` and is verified by a link to a passing
+/// verification — what `validate` coverage rules check), so the default gate
+/// never greens. `ready-when` lets a project add its own terminal statuses:
+///
+/// ```yaml
+/// release:
+///   ready-when: [approved]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ReleaseConfig {
+    /// Extra statuses (beyond the built-in `verified`/`accepted`) that count an
+    /// artifact as release-ready for cuttability.
+    #[serde(default, rename = "ready-when")]
+    pub ready_when: Vec<String>,
+}
+
 /// Project configuration loaded from `rivet.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectConfig {
@@ -996,6 +1016,9 @@ pub struct ProjectConfig {
     /// Commit traceability configuration.
     #[serde(default)]
     pub commits: Option<CommitsConfig>,
+    /// Release-readiness configuration for `rivet release status` (#612).
+    #[serde(default)]
+    pub release: Option<ReleaseConfig>,
     /// External project dependencies for cross-repo linking.
     #[serde(default)]
     pub externals: Option<BTreeMap<String, ExternalProject>>,


### PR DESCRIPTION
## What

Delivers the `release.ready-when` escape hatch named in REQ-240: an optional list in `rivet.yaml` that extends which artifact statuses `rivet release status` treats as release-ready.

```yaml
release:
  ready-when: [approved]
```

## Scope note (REQ-240 stays `proposed`)

REQ-240 on main is broader — *"release status cuttability derives from coverage/links, not just the status string, with a release.ready-when escape hatch."* This PR implements **only the escape-hatch half**. The other half (deriving cuttability from validate coverage rather than the status string) is **not** done, so REQ-240 remains `proposed` and this is tagged `Implements: REQ-240` (partial), not `Verifies`.

## How

- `ReleaseConfig { ready-when: Vec<String> }` on `ProjectConfig` (defaults empty).
- `cmd_release_status` folds the configured statuses into `is_done` alongside `verified`/`accepted`. Defaults unchanged.

## Verification

`release_status_honors_ready_when_config`: default config leaves an all-`approved` release not-cuttable (exit 1); `ready-when: [approved]` makes it cuttable (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)