### PR TITLE
fix: three correctness bugs from a dogfooding bug-hunt (validate self-link, empty release, add routing)

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -6916,7 +6916,11 @@ fn cmd_release_status(cli: &Cli, version: &str, format: &str) -> Result<bool> {
         .iter()
         .filter(|a| !is_done(a.status.as_deref()))
         .collect();
-    let cuttable = not_done.is_empty();
+    // An EMPTY scope is not cuttable: a release nobody has assigned artifacts
+    // to — or, more commonly, a mistyped version — must not green a
+    // `rivet release status vX.Y.Z || fail` CI gate. "Ship a release
+    // containing nothing" is the most common operator typo, not success (#628).
+    let cuttable = !scoped.is_empty() && not_done.is_empty();
 
     if format == "json" {
         let obj = serde_json::json!({

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -6391,6 +6391,66 @@ fn release_status_reports_burn_down_and_exit_code() {
     );
 }
 
+/// #628: an EMPTY release scope (a version nobody has assigned artifacts to,
+/// or — most commonly — a mistyped version) must NOT report as cuttable. A
+/// `rivet release status vX.Y.Z || fail` CI gate must not green on "ship a
+/// release containing nothing".
+///
+/// rivet: verifies REQ-234
+#[test]
+fn release_status_empty_scope_is_not_cuttable() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    assert!(
+        Command::new(rivet_bin())
+            .args(["init", "--preset", "dev", "--dir", dirs])
+            .output()
+            .expect("init")
+            .status
+            .success()
+    );
+    // One artifact, scoped to v1.0.0 — NOT to the version we query below.
+    let reqs = dir.join("artifacts/reqs.yaml");
+    std::fs::write(
+        &reqs,
+        "artifacts:\n  \
+         - id: REQ-9\n    type: requirement\n    title: A\n    status: verified\n    release: v1.0.0\n",
+    )
+    .unwrap();
+
+    // A version nobody scoped: empty scope must be non-zero (text + json).
+    let status = Command::new(rivet_bin())
+        .args(["--project", dirs, "release", "status", "v2.0.0"])
+        .output()
+        .expect("release status");
+    assert!(
+        !status.status.success(),
+        "empty scope must exit non-zero so a CI gate can't green a typo'd/empty release; stdout:\n{}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+
+    let json = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "release",
+            "status",
+            "v2.0.0",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("release status json");
+    let v: serde_json::Value =
+        serde_json::from_slice(&json.stdout).expect("json output must parse");
+    assert_eq!(v["total"], 0, "no artifacts should be scoped to v2.0.0");
+    assert_eq!(
+        v["cuttable"], false,
+        "an empty release scope must not be cuttable"
+    );
+}
+
 /// REQ-234 (#516): `rivet release move <id> <ver>` re-targets an artifact to a
 /// release, logging the old → new transition; idempotent when already scoped.
 ///

--- a/rivet-core/src/mutate.rs
+++ b/rivet-core/src/mutate.rs
@@ -483,8 +483,15 @@ pub fn find_source_file(id: &str, store: &Store) -> Option<PathBuf> {
 
 /// Find the appropriate file for a new artifact of a given type by looking
 /// at where existing artifacts of that type are stored.
+///
+/// Iterates in **id-sorted** order (not `store.iter()`'s HashMap order) so a
+/// type spanning more than one source file always routes a new artifact to
+/// the same destination — the file of the lowest-id existing artifact of that
+/// type. With raw `store.iter()` the destination flipped between runs on
+/// identical input (HashMap uses a per-process random seed), so `rivet add`
+/// could non-deterministically fragment a type across files (#629).
 pub fn find_file_for_type(artifact_type: &str, store: &Store) -> Option<PathBuf> {
-    for artifact in store.iter() {
+    for artifact in store.iter_sorted() {
         if artifact.artifact_type == artifact_type {
             if let Some(ref path) = artifact.source_file {
                 return Some(path.clone());
@@ -743,6 +750,37 @@ mod tests {
         assert_eq!(next_id(&store, "REQ"), "REQ-003");
         assert_eq!(next_id(&store, "FEAT"), "FEAT-002");
         assert_eq!(next_id(&store, "DD"), "DD-001");
+    }
+
+    // #629: when a type spans more than one source file, `rivet add` must
+    // route a new artifact deterministically — to the file of the LOWEST-id
+    // existing artifact of that type — not to whichever file `store.iter()`'s
+    // HashMap order happens to surface first.
+    // rivet: verifies REQ-031
+    #[test]
+    fn find_file_for_type_is_deterministic_when_type_spans_files() {
+        // A `requirement` type split across two files: the lowest id lives in
+        // requirements.yaml; a higher id lives in extra.yaml.
+        let mut store = Store::new();
+        let mut hi = minimal_artifact("REQ-900", "requirement");
+        hi.source_file = Some(PathBuf::from("artifacts/extra.yaml"));
+        store.insert(hi).unwrap();
+        let mut lo = minimal_artifact("REQ-001", "requirement");
+        lo.source_file = Some(PathBuf::from("artifacts/requirements.yaml"));
+        store.insert(lo).unwrap();
+        let mut mid = minimal_artifact("REQ-500", "requirement");
+        mid.source_file = Some(PathBuf::from("artifacts/extra.yaml"));
+        store.insert(mid).unwrap();
+
+        // The lowest-id artifact (REQ-001) decides the destination, every call.
+        let expected = Some(PathBuf::from("artifacts/requirements.yaml"));
+        for _ in 0..16 {
+            assert_eq!(
+                find_file_for_type("requirement", &store),
+                expected,
+                "routing must be stable across calls (lowest-id file wins)"
+            );
+        }
     }
 
     // #479: burned IDs (claimed in git history but absent from the working

--- a/rivet-core/src/validate.rs
+++ b/rivet-core/src/validate.rs
@@ -953,7 +953,14 @@ pub fn validate_structural_with_externals_and_variant(
             // violation while coverage would count the link as satisfying.
             if let Some(required_link) = &rule.required_link {
                 let has_link = artifact.links.iter().any(|l| {
+                    // Self-satisfying links (REQ-X → REQ-X) must not count: an
+                    // author could otherwise close the loop on their own
+                    // artifact and pass validation with zero upstream trace.
+                    // `coverage::compute_coverage` excludes them identically;
+                    // without this guard `validate --direct` and `coverage`
+                    // disagree on the same rule + data (false PASS). #627.
                     l.link_type == *required_link
+                        && l.target != *id
                         && (rule.target_types.is_empty()
                             || store
                                 .get(&l.target)
@@ -990,7 +997,12 @@ pub fn validate_structural_with_externals_and_variant(
                 let backlinks = graph.backlinks_to(id);
                 let matches = |link_name: &str, from_types: &[String]| {
                     backlinks.iter().any(|bl| {
-                        (bl.link_type == link_name || bl.inverse_type.as_deref() == Some(link_name))
+                        // A backlink from the artifact to itself cannot count
+                        // as "satisfied by a different artifact" — same guard
+                        // coverage applies, else validate false-PASSes. #627.
+                        bl.source != *id
+                            && (bl.link_type == link_name
+                                || bl.inverse_type.as_deref() == Some(link_name))
                             && (from_types.is_empty()
                                 || store
                                     .get(&bl.source)
@@ -2632,6 +2644,78 @@ then:
             validate_says_covered, coverage_says_covered,
             "validate and coverage must agree (validate_covered={}, coverage={}/{})",
             validate_says_covered, entry.covered, entry.total
+        );
+    }
+
+    /// #627: a self-satisfying link (REQ-X → REQ-X) must NOT close a
+    /// traceability rule. `coverage` already excludes self-links; `validate`
+    /// did not, so an author could pass `validate --direct` (and the MCP
+    /// `rivet_validate` tool, which shares this path) by linking an artifact
+    /// to itself — a false PASS with zero real upstream trace. validate and
+    /// coverage must agree that the artifact is uncovered.
+    ///
+    /// rivet: verifies REQ-004
+    #[test]
+    fn validate_rejects_self_satisfying_backlink() {
+        let mut file = minimal_schema("test");
+        file.artifact_types = vec![ArtifactTypeDef {
+            name: "requirement".to_string(),
+            description: "REQ".to_string(),
+            fields: vec![],
+            link_fields: vec![],
+            aspice_process: None,
+            common_mistakes: vec![],
+            example: None,
+            yaml_section: None,
+            yaml_sections: vec![],
+            yaml_section_suffix: None,
+            shorthand_links: std::collections::BTreeMap::new(),
+        }];
+        file.traceability_rules = vec![TraceabilityRule {
+            name: "req-backlinked-by-any".into(),
+            description: "Every req must be satisfied by something".into(),
+            source_type: "requirement".into(),
+            required_link: None,
+            required_backlink: Some("satisfies".into()),
+            target_types: vec![],
+            from_types: vec![],
+            severity: Severity::Error,
+            alternate_backlinks: vec![],
+        }];
+        let schema = Schema::merge(&[file]);
+
+        // REQ-001 links `satisfies → itself`: the only backlink to REQ-001 is
+        // from REQ-001. This must NOT count as satisfying the rule.
+        let mut store = Store::new();
+        let mut req = minimal_artifact("REQ-001", "requirement");
+        req.status = Some("approved".to_string());
+        req.links = vec![Link {
+            link_type: "satisfies".to_string(),
+            target: "REQ-001".to_string(),
+            external: None,
+        }];
+        store.insert(req).unwrap();
+
+        let graph = LinkGraph::build(&store, &schema);
+        let diags = validate(&store, &schema, &graph);
+        let rule_fired = diags.iter().any(|d| {
+            d.rule == "req-backlinked-by-any" && d.artifact_id.as_deref() == Some("REQ-001")
+        });
+        assert!(
+            rule_fired,
+            "validate must reject a self-satisfying backlink (false PASS otherwise); diags: {diags:?}"
+        );
+
+        // And coverage must agree the artifact is uncovered.
+        let coverage = crate::coverage::compute_coverage(&store, &schema, &graph);
+        let entry = coverage
+            .entries
+            .iter()
+            .find(|e| e.rule_name == "req-backlinked-by-any")
+            .expect("rule should produce a coverage entry");
+        assert_eq!(
+            entry.covered, 0,
+            "coverage must also treat the self-link as uncovered (validate/coverage parity)"
         );
     }
 


### PR DESCRIPTION
## What

Three independent correctness fixes surfaced by an internal dogfooding
bug-hunt. Each is a focused commit with its own issue, repro, and regression
test.

### 1. `validate` counted self-satisfying links as closing a rule — false PASS (#627)
`validate --direct` (and the MCP `rivet_validate` tool, same library path)
let an artifact satisfy a required-link/backlink rule by linking to **itself**
— a false PASS with zero real upstream trace. `coverage` already excluded
self-links, so the two could give **opposite verdicts on the same project**.
Mirror coverage's guards (`l.target != id`, `bl.source != id`). High severity.

### 2. `release status` greened an empty/typo'd release scope (#628)
`cuttable = not_done.is_empty()` was vacuously true for an empty scope, so
`rivet release status vX.Y.Z || fail` passed on a mistyped version or a
release nobody had scoped — "ship a release containing nothing". Now
`!scoped.is_empty() && not_done.is_empty()`.

### 3. `rivet add` routed non-deterministically across files (#629)
`find_file_for_type` returned the first match in `store.iter()` (HashMap
order, per-process seed), so a type spanning >1 file routed a new artifact to
a different file run-to-run (observed 6/14 vs 8/14). Now iterates
`iter_sorted()` — the lowest-id artifact's file wins deterministically.

## Tests

- `validate_rejects_self_satisfying_backlink` — proven to fail without the
  guard; asserts validate/coverage parity.
- `release_status_empty_scope_is_not_cuttable` — text exit-code + json
  `cuttable:false`.
- `find_file_for_type_is_deterministic_when_type_spans_files` — stable
  destination across 16 calls.

All of `rivet-core` validate/coverage/mutate + `rivet-cli` release tests pass;
`cargo fmt --check` and `clippy --all-targets -D warnings` clean.

Closes #627, #628, #629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
