### PR TITLE
chore(release): v0.22.2 — dogfooding data-loss/correctness fixes + wasmtime security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-06-30
+
+Theme: **Dogfooding hardening** — a focused patch from an internal bug-hunt of
+rivet's own write/validate paths, plus a security-advisory bump. One P0
+data-loss fix, three correctness fixes (each with a regression test proven to
+fail without the fix), and a wasmtime security update.
+
+### Fixed
+- **`rivet modify --add-tag` / `--remove-tag` no longer corrupts a block-style
+  `tags:` list (data loss).** The new tag set renders as a flow list
+  (`tags: [a, b, c]`) and replaces the existing `tags:` field; the field-replace
+  path used a scalar-only extent helper that recognised only `|`/`>` block
+  scalars, so a block-style list —
+  ```yaml
+  tags:
+    - core
+    - safety
+  ```
+  had only its `tags:` key line rewritten, orphaning the `- item` children under
+  the new value. The file then failed to parse and **every** artifact in it
+  silently vanished from the loaded store (`rivet list` → 0 artifacts), though
+  `modify` reported success. The replace path now uses the same `field_block_end`
+  extent helper as the insert path (consuming block scalars, nested mappings, and
+  block lists); the scalar-only helper was deleted so it cannot be reintroduced.
+  Same class as #573 / #613. Found by dogfooding (#625). (REQ-034)
+- **`rivet validate` no longer counts a self-satisfying link (`REQ-X → REQ-X`)
+  as closing a traceability rule (false PASS).** An author could pass
+  `validate --direct` (and the MCP `rivet_validate` tool, which shares the same
+  library path) by linking an artifact to itself, with zero real upstream trace.
+  `rivet coverage` already excluded self-links, so the two could give opposite
+  verdicts on the same project. `validate` now applies the same guards
+  (`l.target != id`, `bl.source != id`). (#627, REQ-004)
+- **`rivet release status` no longer reports an empty release scope as
+  cuttable.** A scope with zero artifacts (a version nobody has assigned work to,
+  or — most commonly — a mistyped version) was vacuously cuttable: exit 0,
+  `"cuttable": true`. A `rivet release status vX.Y.Z || fail` CI gate therefore
+  greened on "ship a release containing nothing". An empty scope is now not
+  cuttable (exit non-zero). (#628, REQ-007)
+- **`rivet add` routes new artifacts deterministically when a type spans more
+  than one source file.** Routing used `store.iter()` (HashMap order, seeded
+  per-process), so the destination file flipped run-to-run on identical input.
+  It now iterates in id-sorted order — the lowest-id artifact of the type decides
+  the file, every call. (#629, REQ-007)
+
+### Security
+- **Bumped `wasmtime` / `wasmtime-wasi` 44.0.3 → 45.0.3 for RUSTSEC-2026-0188**
+  (WASI hard links and renames bypass `wasmtime-wasi`'s `FilePerms` on the
+  destination path). rivet's only wasmtime user is the compose-witness component
+  runner (`rivet-core/src/wasm_runtime.rs`, `wasm` feature). The bump is
+  source-compatible — the WASI host code compiles unchanged and all
+  `wasm_runtime` tests pass. (#632, REQ-086)
+
 ## [0.22.1] - 2026-06-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.22.1"
+version = "0.22.2"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.22.2 — Dogfooding hardening patch

Five fixes from an internal bug-hunt of rivet's own write/validate paths, all merged to main and each shipped with a regression test proven to fail without the fix:

| # | Severity | Fix |
|---|----------|-----|
| #625 | **P0 data loss** | `modify --add-tag`/`--remove-tag` corrupted a block-style `tags:` list → whole file unparseable → `rivet list` loads 0 artifacts (REQ-034) |
| #627 | High | `validate --direct`/MCP counted self-links as closing a rule → false PASS (REQ-004) |
| #628 | Med-High | `release status` greened an empty/typo'd release scope (REQ-007) |
| #629 | Medium | `rivet add` routed non-deterministically across files (REQ-007) |
| #632 | Security | wasmtime 44.0.3 → 45.0.3 for RUSTSEC-2026-0188 (REQ-086) |

Version bumped in Cargo.toml/lock + vscode-rivet/package.json; CHANGELOG `[0.22.2]` added. `rivet validate`, `rivet docs check` (0 violations), `clippy --all-targets`, and the full rivet-core/rivet-cli test suites pass locally.

> Note: the self-hosted CI runner pool is currently offline (#509), so the per-PR `ci.yml` gates (Test/Clippy on self-hosted) are queued. The release was verified locally instead; the release build/publish workflows run on GitHub-hosted runners and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)