### PR TITLE
chore(release): v0.23.0 — Traceability evidence (REQ-236..242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-01
+
+Theme: **Traceability evidence** — make the requirement → verification → test
+chain mechanically drift-proof, and make the validator's own signals
+trustworthy and consistent. Six requirements, each shipped with a regression
+test proven to fail without the fix. Planned, executed, and gated entirely with
+rivet's own `release:` tooling.
+
+### Added
+- **`rivet check verification-evidence`** (REQ-236, #556) — a named-test-exists
+  oracle. A verification step commonly ties a requirement to a test via
+  `fields.steps[].run: "cargo test -p X some_test"`, but `cargo test typo`
+  exits 0 with "0 passed", silently keeping the requirement `verified`. This
+  asserts every named cargo-test filter matches a real test in the scanned Rust
+  sources; a missing test fails the check.
+- **`rivet trace-results <id>`** (REQ-238, #547) — the forward req → test-result
+  trace: from a requirement, walk backlinks (through the ASPICE V) to the tests
+  that cover it and their latest pass/fail, with a roll-up verdict. Text or
+  JSON; exits non-zero on a failing covering test. The graphical dashboard view
+  built on this JSON is scoped to v0.24.
+- **`release:` readiness is configurable** (REQ-240, #612) — `rivet.yaml`'s
+  `release.ready-when: [<status>…]` extends the release-ready status set, and
+  `release.require: coverage` derives readiness from validate V-closure so a
+  V-model/ASPICE project (which verifies via links, not a status flip) can green
+  `rivet release status`. Purely additive; defaults unchanged.
+
+### Changed / Fixed
+- **`rivet validate` and `rivet validate --direct` now produce identical
+  output** (REQ-241, #620). The substantive divergence (self-satisfying links
+  counted as coverage) was the v0.22.2 fix; the last residual difference (an
+  `--explain` hint naming a different example artifact by iteration order) is now
+  deterministic.
+- **The default marker scan reaches member crates in a cargo workspace**
+  (REQ-242, #603) — a workspace whose root also has its own `tests/` (rivet
+  itself) previously hid member-crate `verifies` markers from `rivet verify` /
+  `coverage --tests`. Shared workspace-aware defaults; the two never disagree.
+- **The validator and the commit-trailer parser agree on artifact-id shape**
+  (REQ-239, #577) — a digit-bearing prefix like `MAD1-101` is now a valid commit
+  ref (was rejected, forcing a rename loop), and `rivet validate` warns early
+  (`commit-ref-shape`) when an id can't be used as a trailer reference.
+- **A lifecycle-completeness gap for a sw-req now names the ASPICE chain**
+  (REQ-237, #350) — instead of a bare `missing: unit-verification, …`, it points
+  at the required intermediate (add a `sw-detail-design` that this artifact
+  traces to, verified by a `unit-verification`), so authoring a direct link
+  isn't the first, rejected, guess.
+
+### Deferred
+- **REQ-238's graphical dashboard trace view** → v0.24 (needs the serve/frontend
+  work + the Playwright E2E gate). The trace *mechanism* above ships now.
+
 ## [0.22.2] - 2026-06-30
 
 Theme: **Dogfooding hardening** — a focused patch from an internal bug-hunt of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.22.2"
+version = "0.23.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7569,12 +7569,12 @@ artifacts:
     type: requirement
     title: graphical req->test-result trace view
     status: implemented
-    description: "A graphical/visual way to trace a requirement to its test results. #547. v0.23."
+    description: "A graphical/visual way to trace a requirement to its test results. #547. The forward-trace MECHANISM shipped (rivet-core result_trace + `rivet trace-results`, the JSON the view consumes); the graphical dashboard rendering is the remaining half and needs the serve/frontend work + Playwright E2E gate, so it is scoped to v0.24. Moved from v0.23 so v0.23 cuts on its 6 verified evidence REQs."
     provenance:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-06-27T06:51:07Z
-    release: v0.23.0
+    release: v0.24.0
 
   - id: REQ-239
     type: requirement

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.23.0 — Traceability evidence

Six verified requirements, each with a regression test proven to fail without the fix. `rivet release status v0.23.0` → **cuttable (6/6 verified)**.

| REQ | Issue | What |
|---|---|---|
| 236 | #556 | `rivet check verification-evidence` — named-test-exists oracle |
| 237 | #350 | lifecycle gap names the ASPICE verification chain |
| 239 | #577 | validator ⇄ commit-trailer parser id-shape parity |
| 240 | #612 | configurable release readiness (ready-when + coverage) |
| 241 | #620 | `validate` ⇄ `--direct` identical output |
| 242 | #603 | default marker scan reaches workspace member crates |

Plus the **REQ-238 forward-trace mechanism** (`rivet trace-results`); the graphical dashboard view is **deferred to v0.24** (retagged here, needs Playwright).

Version bumped (Cargo.toml/lock + vscode). `rivet validate` PASS, `rivet docs check` 0 violations, clippy `--all-targets` clean, full suites green — verified locally (org runners busy, draining the queue; the GitHub-hosted release build runs on tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)