### PR TITLE
feat(serve): overview flags per-artifact lifecycle gaps with a badge (REQ-244 pt2, #622)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7634,7 +7634,7 @@ artifacts:
   - id: REQ-244
     type: requirement
     title: rivet serve overview surfaces per-artifact missing coverage
-    status: implemented
+    status: verified
     description: "The `rivet serve` validation detail view shows what an artifact is missing, but the overview does not surface it. Expose the missing-coverage signal in the overview so gaps are visible without drilling into each artifact. #622."
     provenance:
       created-by: ai-assisted

--- a/rivet-cli/src/render/artifacts.rs
+++ b/rivet-cli/src/render/artifacts.rs
@@ -260,14 +260,35 @@ pub(crate) fn render_artifacts_list(ctx: &RenderContext, params: &ViewParams) ->
     html.push_str("<th>Links</th><th data-col=\"tags\">Tags</th>");
     html.push_str("</tr></thead><tbody>");
 
+    // #622 (REQ-244): per-artifact lifecycle gaps, so the overview flags what's
+    // missing to complete each artifact's trace — not only the per-artifact
+    // validation view. Computed once over the store (same pass the artifacts API
+    // uses); only the page's artifacts are looked up below.
+    let gap_artifacts: Vec<rivet_core::model::Artifact> = store.iter().cloned().collect();
+    let gaps: std::collections::HashMap<String, Vec<String>> =
+        rivet_core::lifecycle::check_lifecycle_completeness(&gap_artifacts, ctx.schema, ctx.graph)
+            .into_iter()
+            .map(|g| (g.artifact_id, g.missing))
+            .collect();
+
     for a in page_artifacts {
         let status = a.status.as_deref().unwrap_or("-");
-        let status_badge = match status {
+        let mut status_cell = match status {
             "approved" => format!("<span class=\"badge badge-ok\">{status}</span>"),
             "draft" => format!("<span class=\"badge badge-warn\">{status}</span>"),
             "obsolete" => format!("<span class=\"badge badge-error\">{status}</span>"),
             _ => format!("<span class=\"badge badge-info\">{status}</span>"),
         };
+        // Gap indicator: warn badge listing the missing downstream types,
+        // appended to the status cell so it reads at a glance.
+        if let Some(missing) = gaps.get(&a.id).filter(|m| !m.is_empty()) {
+            status_cell.push_str(&format!(
+                " <span class=\"badge badge-warn\" title=\"missing: {}\">\u{26a0} {} gap{}</span>",
+                html_escape(&missing.join(", ")),
+                missing.len(),
+                if missing.len() == 1 { "" } else { "s" },
+            ));
+        }
         let tags_csv = a.tags.join(",");
         let tags_display = if a.tags.is_empty() {
             String::from("-")
@@ -293,7 +314,7 @@ pub(crate) fn render_artifacts_list(ctx: &RenderContext, params: &ViewParams) ->
              <td data-tags=\"{}\">{}</td></tr>",
             badge_for_type(&a.artifact_type),
             html_escape(&a.title),
-            status_badge,
+            status_cell,
             a.links.len(),
             html_escape(&tags_csv),
             tags_display,

--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -603,6 +603,35 @@ fn api_artifacts_expose_missing_gaps() {
     child.wait().ok();
 }
 
+/// #622 (REQ-244 pt2): the artifacts OVERVIEW page renders a lifecycle-gap
+/// badge (server-rendered HTML — no client JS), so gaps are visible at a
+/// glance, matching the per-artifact validation view. rivet's own corpus has
+/// requirements without a full downstream trace, so the requirement listing
+/// must contain the badge.
+///
+/// The badge is per-row, so it only appears on the page that actually holds a
+/// gapped artifact. rivet's gaps sit on `requirement` artifacts, which sort
+/// after the ~500-row page cap on the unfiltered list — so we filter to
+/// `types=requirement` to land them on page 1 (matching how a user would
+/// narrow the view to inspect requirement completeness).
+///
+/// rivet: verifies REQ-244
+#[test]
+fn overview_renders_lifecycle_gap_badge() {
+    let (mut child, port) = start_server();
+
+    let (status, body, _headers) = fetch(port, "/artifacts?types=requirement&per_page=500", false);
+    assert_eq!(status, 200);
+    assert!(
+        body.contains("gap</span>") || body.contains("gaps</span>"),
+        "the artifacts overview must render a lifecycle-gap badge; \
+         none found in the server-rendered HTML"
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
 #[test]
 fn api_artifacts_filter_by_type() {
     let (mut child, port) = start_server();


### PR DESCRIPTION
## Summary
Completes **REQ-244** (`#622`): the `rivet serve` artifacts overview now renders a per-row **lifecycle-gap badge** (⚠ N gap(s), server-rendered HTML, no client JS) listing the missing downstream types, so completeness gaps are visible at a glance — not only in the per-artifact validation view. This lands alongside the `missing` API field shipped in **pt1 (#647)**.

## Why the test filters by type
The badge is per-row, so it appears on whatever page holds a gapped artifact. `items_per_page()` clamps the list to 500 rows, and rivet's own gaps all sit on `requirement` artifacts, which sort *past* position 500 on the id-ascending unfiltered list. The integration test therefore queries `/artifacts?types=requirement&per_page=500` to land gapped requirements on page 1 — matching how a user narrows the view to inspect requirement completeness.

## Verification
- `overview_renders_lifecycle_gap_badge` (new) — asserts the badge is in the server-rendered HTML.
- `api_artifacts_expose_missing_gaps` (pt1) — asserts the JSON `missing` field.
- Full `serve_integration` suite: **46/46 green**.
- `cargo clippy --all-targets -- -D warnings` exit 0; `cargo fmt --check` clean.

Empirically confirmed against rivet's own corpus: 121 gapped requirements, 121 badges rendered.

## Traceability
- Implements / Verifies: **REQ-244** (status → `verified`)
- Refs: **FEAT-001**

🤖 Generated with [Claude Code](https://claude.com/claude-code)