### PR TITLE
chore(release): v0.24.0 — serve traceability UX (REQ-238, REQ-243, REQ-244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-02
+
+### Added
+- **Graphical req → test-result trace on the dashboard** (REQ-238, #547) — the
+  artifact detail view renders a "Test Result Trace" panel: it walks forward to
+  the verifications/tests that trace back to the artifact, rolls their recorded
+  results into a verdict badge (passing / failing / no test evidence), and lists
+  each reached node with its hop distance, link type, and latest result. The
+  dashboard counterpart of `rivet trace-results` (which shipped in 0.23.0).
+- **Per-artifact lifecycle-gap badge in the serve overview** (REQ-244, #622) —
+  the artifacts overview flags what each artifact is still missing to complete
+  its downstream trace (⚠ N gap(s)), matching the per-artifact validation view.
+  The artifacts API exposes the same per-artifact `missing` field for bulk
+  queries.
+
 ### Changed / Fixed
+- **Artifact-view source link opens the built-in `/source` viewer at the
+  artifact's definition line** (REQ-243, #623) — previously a dead `href="#"`
+  that did nothing in a plain browser and only worked via the VSIX editor shim.
+  The dashboard now deep-links into the source viewer (scrolling to the line)
+  while keeping the `data-source-*` attributes so the VSIX webview still opens
+  the file in the editor.
 - **`rivet check bidirectional` no longer demands non-authorable inverses**
   (#648). When a schema declares `link-types.X.inverse: Y` but does *not*
   declare `Y` as its own `link-types:` entry, authoring a `Y` link would

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7651,7 +7651,7 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-01T00:00:00Z
-    release: v0.24.0
+    release: v0.25.0
 
   - id: REQ-246
     type: requirement
@@ -7662,7 +7662,7 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-01T00:00:00Z
-    release: v0.24.0
+    release: v0.25.0
 
   - id: REQ-247
     type: requirement
@@ -7673,7 +7673,7 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-01T00:00:00Z
-    release: v0.24.0
+    release: v0.25.0
 
   - id: REQ-248
     type: requirement
@@ -7684,7 +7684,7 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-01T00:00:00Z
-    release: v0.24.0
+    release: v0.25.0
 
   - id: REQ-249
     type: requirement

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.24.0 — serve traceability UX

Cuts v0.24.0 on **3 verified requirements** shipped this cycle. `rivet release status v0.24.0` = **cuttable (3/3 verified)**.

### Shipped
- **REQ-238** (#547) — graphical req→test-result **Test Result Trace panel** on the dashboard (verdict badge + reached-node table).
- **REQ-243** (#623) — artifact-view **source link opens the `/source` viewer** at the artifact's definition line (browser deep-link + preserved VSIX editor shim).
- **REQ-244** (#622) — per-artifact **lifecycle-gap badge** in the serve overview + `missing` field on the artifacts API.
- Also includes the **#648** bidirectional-oracle fix (`Schema::is_authorable_link_type`) merged this cycle.

### Deliberately descoped → v0.25.0 (not ready)
- REQ-245 — backend-down indicator (frontend)
- REQ-246 — human-friendly editing UI (design-first / scope TBD)
- REQ-247 — AADL inline SVG in static export (wasm-blocked; honest-note shipped)
- REQ-248 — test-result external links (needs a results data-model decision)

### Release-prep contents
- Workspace + `vscode-rivet` bumped to **0.24.0**; `Cargo.lock` updated.
- CHANGELOG `[Unreleased]` → `[0.24.0]`.
- The 4 descoped requirements retagged `release: v0.25.0`.

Verified: `rivet validate` PASS, `rivet docs check` PASS, full `serve_integration` suite 48/48 across the three feature PRs (#651, #653, #654).

Refs: FEAT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)