### PR TITLE
fix(aspice): make swe1-has-verification satisfiers reachable (#652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Embedded aspice schema is self-consistent** (#652). The
+  `swe1-has-verification` coverage rule lists `unit-verification` and
+  `sw-integration-verification` as `verifies` satisfiers for `sw-req`, but
+  those types' `verifies` link-fields only allowed
+  `sw-detail-design` / `sw-arch-component` targets — the satisfiers were
+  unreachable and `rivet validate` warned against its own embedded schema
+  (facets 1 & 2 of #648; facet 3 was fixed in #650). `sw-req` is now an
+  allowed `verifies` target for both types, so the coverage rule is
+  reachable and an `implemented` sw-req with a real unit / integration
+  verification linked no longer carries a permanent, unfixable
+  lifecycle-coverage gap. Regression test in
+  `rivet-core/tests/schema_validation_rules.rs` asserts the embedded
+  common+aspice schema surfaces zero `coverage-rule-consistency`
+  diagnostics.
+
 ## [0.24.0] - 2026-07-02
 
 ### Added

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -679,11 +679,14 @@ fn validate_surfaces_parse_error_on_malformed_artifact_file() {
     );
 }
 
-/// #350 (REQ-237): the lifecycle completeness gap for an implemented sw-req
-/// must NAME the ASPICE chain — a `unit-verification` verifies a
-/// `sw-detail-design`, not the `sw-req` directly, so authoring a direct link is
-/// rejected and the bare "missing" list points at the wrong fix. The hint tells
-/// the author to add the intermediate.
+/// #350 / #652 (REQ-237): the lifecycle completeness gap for an implemented
+/// sw-req must NAME the verification types the author can attach. REQ-237's
+/// goal (#350, "direct test -> sw-req link without full ASPICE chain") is
+/// completed by #652, which made `unit-verification` /
+/// `sw-integration-verification` reach `sw-req` via `verifies`. So the gap now
+/// names all three directly-linkable verification types and no longer routes
+/// through the `sw-detail-design` chain — the chain hint was the stopgap for
+/// the pre-#652 schema where direct linking was impossible.
 ///
 /// rivet: verifies REQ-237
 #[test]
@@ -715,11 +718,14 @@ fn lifecycle_gap_names_the_aspice_verification_chain() {
         .expect("validate");
     // The gap hints are emitted on stderr alongside the gap list.
     let err = String::from_utf8_lossy(&out.stderr);
+    // Post-#652 the hint names every directly-linkable verification type for the
+    // sw-req, instead of routing through the design chain.
     assert!(
-        err.contains("not `sw-req` directly")
-            && err.contains("sw-detail-design")
-            && err.contains("unit-verification"),
-        "the lifecycle gap must name the ASPICE chain for the sw-req; stderr:\n{err}"
+        err.contains("unit-verification")
+            && err.contains("sw-integration-verification")
+            && err.contains("sw-verification"),
+        "the lifecycle gap must name the directly-linkable verification types for \
+         the sw-req; stderr:\n{err}"
     );
 }
 
@@ -2982,9 +2988,11 @@ fn schema_sources_reports_resolution() {
 }
 
 /// `validate --explain` on an aspice `sw-req` with a verification coverage gap
-/// surfaces the verification type that can attach directly (`sw-verification`)
-/// and annotates the ones that can't — instead of listing all three terminal
-/// types as if any could link straight to the req. #350 / REQ-178.
+/// surfaces the verification types that can attach directly. After #652 made
+/// the `swe1-has-verification` satisfiers reachable (unit-verification and
+/// sw-integration-verification gained `verifies -> sw-req`), all three
+/// verification types link directly — so explain lists all three and no longer
+/// annotates any as attaching only via the design chain. #350 / #652 / REQ-178.
 // rivet: verifies REQ-178
 #[test]
 fn explain_names_directly_linkable_verification_type() {
@@ -3013,13 +3021,14 @@ fn explain_names_directly_linkable_verification_type() {
         .output()
         .expect("run validate --explain");
     let text = String::from_utf8_lossy(&out.stdout);
+    // Explain surfaces the set of directly-linkable verification types. Post-#652
+    // that set is all three (not just sw-verification).
     assert!(
-        text.contains("from one of [\"sw-verification\"]"),
-        "explain should surface the directly-linkable verification type. got:\n{text}"
-    );
-    assert!(
-        text.contains("not 'sw-req' directly"),
-        "explain should note the indirect types attach via the design chain. got:\n{text}"
+        text.contains("from one of")
+            && text.contains("sw-verification")
+            && text.contains("unit-verification")
+            && text.contains("sw-integration-verification"),
+        "explain should list every directly-linkable verification type. got:\n{text}"
     );
 }
 

--- a/rivet-core/src/schema.rs
+++ b/rivet-core/src/schema.rs
@@ -1388,9 +1388,14 @@ mod tests {
 
         // sw-verification CAN `verifies` a sw-req (its link-field allows it)…
         assert!(schema.from_type_can_link("sw-verification", "verifies", "sw-req"));
-        // …but unit-verification CANNOT — its `verifies` only targets sw-detail-design.
-        assert!(!schema.from_type_can_link("unit-verification", "verifies", "sw-req"));
+        // …and after #652, unit-verification CAN too — its `verifies` now targets
+        // sw-req alongside sw-detail-design so the `swe1-has-verification`
+        // coverage-rule satisfier is reachable.
+        assert!(schema.from_type_can_link("unit-verification", "verifies", "sw-req"));
         assert!(schema.from_type_can_link("unit-verification", "verifies", "sw-detail-design"));
+        // …but the check still respects the target list: sw-arch-component is not
+        // among unit-verification's `verifies` targets, so this stays false.
+        assert!(!schema.from_type_can_link("unit-verification", "verifies", "sw-arch-component"));
         // Unknown types / undeclared links are treated as permitted (no over-assert).
         assert!(schema.from_type_can_link("made-up-type", "verifies", "sw-req"));
     }

--- a/rivet-core/tests/schema_validation_rules.rs
+++ b/rivet-core/tests/schema_validation_rules.rs
@@ -486,3 +486,26 @@ fn common_status_accepts_accepted_and_still_rejects_typos() {
          allowed-values guard exactly once; got {dd_typo_status_diags:#?}"
     );
 }
+
+/// The embedded aspice schema's `swe1-has-verification` coverage rule
+/// lists `unit-verification` and `sw-integration-verification` as
+/// `verifies` satisfiers for `sw-req`. Both types must therefore declare
+/// a `verifies` link-field whose `target-types` includes `sw-req` — else
+/// the satisfier is unreachable and the schema warns against itself
+/// (issue #652). This regression asserts the embedded common+aspice
+/// schema set surfaces zero `coverage-rule-consistency` diagnostics.
+#[test]
+fn aspice_embedded_schema_has_no_coverage_rule_consistency_diagnostics() {
+    let common = parse_schema("common");
+    let aspice = parse_schema("aspice");
+    let schema = Schema::merge(&[common, aspice]);
+
+    let diags = schema.check_coverage_rule_consistency();
+    assert!(
+        diags.is_empty(),
+        "embedded common+aspice schema must not warn against itself with \
+         coverage-rule-consistency diagnostics; got {} warning(s): {:#?}",
+        diags.len(),
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/schemas/aspice.yaml
+++ b/schemas/aspice.yaml
@@ -212,7 +212,13 @@ artifact-types:
     link-fields:
       - name: verifies
         link-type: verifies
-        target-types: [sw-detail-design]
+        # `sw-req` is included so the SWE.1 coverage rule
+        # `swe1-has-verification` (which lists unit-verification as a
+        # satisfier for sw-req) is reachable — a unit-verification may
+        # link `verifies -> sw-req` alongside the SWE.3 sw-detail-design
+        # link required by the `swe4-verifies-swe3` traceability rule.
+        # Issue #652.
+        target-types: [sw-detail-design, sw-req]
         required: true
         cardinality: one-or-many
 
@@ -251,7 +257,10 @@ artifact-types:
     link-fields:
       - name: verifies
         link-type: verifies
-        target-types: [sw-arch-component, sw-detail-design]
+        # `sw-req` is included so the SWE.1 coverage rule
+        # `swe1-has-verification` (which lists sw-integration-verification
+        # as a satisfier for sw-req) is reachable. Issue #652.
+        target-types: [sw-arch-component, sw-detail-design, sw-req]
         required: true
         cardinality: one-or-many
 


### PR DESCRIPTION
Closes #652.

## What

The embedded aspice schema warned against itself: `rivet validate` on a clean aspice-schema project emitted two `coverage-rule-consistency` warnings because the `swe1-has-verification` coverage rule lists `unit-verification` and `sw-integration-verification` as `verifies` satisfiers for `sw-req`, but those types' `verifies` link-fields only allowed `sw-detail-design` / `sw-arch-component` — the satisfiers were unreachable (facets 1 & 2 of #648; facet 3 was fixed in #650). As a follow-on, any `implemented` sw-req carried a permanent, unfixable `lifecycle-coverage-complete` gap because the coverage demanded exactly those unreachable satisfiers.

This PR widens the `verifies` link-field `target-types` on both types to include `sw-req`, so the coverage rule is reachable end-to-end.

```diff
   - name: unit-verification
     link-fields:
       - name: verifies
         link-type: verifies
-        target-types: [sw-detail-design]
+        target-types: [sw-detail-design, sw-req]

   - name: sw-integration-verification
     link-fields:
       - name: verifies
         link-type: verifies
-        target-types: [sw-arch-component, sw-detail-design]
+        target-types: [sw-arch-component, sw-detail-design, sw-req]
```

Both new target-types carry an inline comment naming #652 and pointing back at the `swe1-has-verification` coverage rule they exist to satisfy.

## Why this direction, not the other one

The alternative would be dropping `unit-verification` / `sw-integration-verification` from the coverage rule's `from-types`. Rejected because:

1. The issue author's own "likely fix direction" prescribes widening the link-fields ("make the declared satisfiers reachable").
2. The V-model's forward trace is `sw-req → sw-arch-component → sw-detail-design`, but the reverse verification chain is expected to be evidenceable at any level — a consumer authoring `unit-verification --verifies--> sw-req` is expressing "this test evidences the requirement directly," which ASPICE 4.0 SUP.10 BP1/BP2 treats as a valid trace.
3. The source-side traceability rule `swe4-verifies-swe3` (require `unit-verification.verifies` to include at least one `sw-detail-design`) is untouched — widening the allowed target-types does not relax that rule; it just permits an additional target alongside the required one.

## Acceptance criteria (from #652)

| # | Criterion | How this PR satisfies it |
| --- | --- | --- |
| 1 | `rivet validate` on an aspice project emits **zero** `coverage-rule-consistency` warnings against the embedded schema. | `unit-verification` and `sw-integration-verification` can now form `verifies → sw-req`, so the `swe1-has-verification` satisfier reachability check in `Schema::check_coverage_rule_consistency` (`rivet-core/src/schema.rs:1235`) no longer fires. |
| 2 | An `implemented` sw-req with a real unit/integration verification linked reaches lifecycle-coverage-complete (no permanent unfixable gap). | A consumer can now author `unit-verification --verifies--> SW-REQ-x` or `sw-integration-verification --verifies--> SW-REQ-x` as the satisfier the coverage rule demands. |
| 3 | A regression test over the embedded aspice schema asserts coverage-rule satisfier reachability. | `rivet-core/tests/schema_validation_rules.rs::aspice_embedded_schema_has_no_coverage_rule_consistency_diagnostics` — merges the embedded `common` + `aspice` and asserts `check_coverage_rule_consistency()` returns `[]`. |

## Why draft

This session's egress policy is scoped to `pulseengine/rivet` only. The workspace transitively depends on `pulseengine/rowan` (git dependency in `Cargo.lock`, pinned at `9e7abd1…`), which the proxy denies with a 403. I could not run `cargo build -p rivet-core --tests` or `cargo test` locally in this session — the fetch of `rowan` cannot succeed. Please flip to Ready-for-review after CI (which has full scope) confirms:

- `cargo test -p rivet-core --test schema_validation_rules aspice_embedded_schema_has_no_coverage_rule_consistency_diagnostics` passes on this branch,
- `cargo test -p rivet-core --test schema_validation_rules aspice_embedded_schema_has_no_coverage_rule_consistency_diagnostics` **fails** on `main` (proves the regression test is real),
- `rivet validate` on the rivet repo remains PASS.

## Test plan

- [ ] CI Format / Clippy / Test gates green on this branch
- [ ] Verify the new test in `schema_validation_rules.rs` fails on `main` (revert the two YAML changes, expect one diagnostic per unreachable from-type)
- [ ] Optionally, downstream: run `rivet validate` on an aspice-schema consumer project and confirm the two `coverage-rule-consistency` warnings are gone

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1a9EsDjFohSRqAYurB2wM)_