### PR TITLE
fix(validate): scope cross-repo UnknownPrefix to consumer-owned links (#649)

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -5815,11 +5815,24 @@ fn cmd_validate(
                             external_ids.insert(ext.prefix.clone(), ids);
                         }
 
-                        // Collect local IDs and all link targets
-                        let local_ids: std::collections::HashSet<String> =
-                            store.iter().map(|a| a.id.clone()).collect();
+                        // Collect local IDs and all link targets — consumer-owned
+                        // artifacts only. External (`prefix:ID`) artifacts are
+                        // in the store solely so the consumer's `prefix:ID`
+                        // cross-links resolve (REQ-082); walking their outgoing
+                        // links here would fail the consumer on the supplier's
+                        // OWN external refs (e.g. supplier A's link to `B:foo`
+                        // where the consumer never declared B) — precisely the
+                        // DD-017 / REQ-065 contradiction reported in #649. The
+                        // `--with-externals-validate` opt-in below is the only
+                        // gate that walks supplier internals.
+                        let local_ids: std::collections::HashSet<String> = store
+                            .iter()
+                            .filter(|a| !a.id.contains(':'))
+                            .map(|a| a.id.clone())
+                            .collect();
                         let all_refs: Vec<&str> = store
                             .iter()
+                            .filter(|a| !a.id.contains(':'))
                             .flat_map(|a| a.links.iter().map(|l| l.target.as_str()))
                             .collect();
 

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1594,8 +1594,7 @@ fn validate_does_not_leak_transitive_external_prefixes() {
         ])
         .output()
         .expect("validate");
-    let parsed: serde_json::Value =
-        serde_json::from_slice(&out.stdout).expect("validate JSON");
+    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).expect("validate JSON");
     let broken = parsed
         .get("broken_cross_refs")
         .and_then(|v| v.as_array())

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -1482,6 +1482,152 @@ fn validate_does_not_count_external_repo_violations() {
     );
 }
 
+/// #649 / DD-017 / REQ-065 (AoU-X1): the consumer's default `rivet
+/// validate` must NOT fail on the SUPPLIER'S own outgoing external
+/// references — a consumer that declares only supplier `sup` cannot be
+/// expected to know or declare supplier's own externals (DD-017:
+/// "declare direct deps only"). The consumer's cross-ref check now
+/// walks only consumer-owned links; supplier internals stay in the
+/// supplier's validation gate.
+///
+/// The reverse case must still fire: a consumer artifact whose own link
+/// targets an undeclared prefix continues to surface `UnknownPrefix`.
+///
+/// rivet: verifies REQ-065
+#[test]
+fn validate_does_not_leak_transitive_external_prefixes() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let supplier = root.path().join("supplier");
+    let consumer = root.path().join("consumer");
+    std::fs::create_dir_all(&supplier).unwrap();
+    std::fs::create_dir_all(&consumer).unwrap();
+
+    // Supplier: a dev project whose own artifact carries an outgoing
+    // link to `super:REQ-EXT` — a prefix that would be one of the
+    // supplier's own externals. The consumer never declares `super:`.
+    let init_s = Command::new(rivet_bin())
+        .args([
+            "init",
+            "--preset",
+            "dev",
+            "--dir",
+            supplier.to_str().unwrap(),
+        ])
+        .output()
+        .expect("init supplier");
+    assert!(
+        init_s.status.success(),
+        "init supplier: {}",
+        String::from_utf8_lossy(&init_s.stderr)
+    );
+    std::fs::write(
+        supplier.join("artifacts").join("with-transitive.yaml"),
+        "artifacts:\n\
+         \x20 - id: REQ-SUPPLIER-A\n    type: requirement\n\
+         \x20   title: Supplier req linking to its own external\n\
+         \x20   status: approved\n\
+         \x20   fields: {priority: must, category: functional}\n\
+         \x20   links:\n\
+         \x20     - type: satisfies\n\
+         \x20       target: super:REQ-EXT\n",
+    )
+    .expect("write supplier with-transitive.yaml");
+
+    // Consumer: declares supplier ONLY; never mentions `super:`. It
+    // ALSO carries a legitimately broken outgoing ref of its own
+    // (`xyz:REQ-BOGUS`) so we can assert the counter-case: the fix
+    // must not silently accept the consumer's own broken external refs.
+    let init_c = Command::new(rivet_bin())
+        .args([
+            "init",
+            "--preset",
+            "dev",
+            "--dir",
+            consumer.to_str().unwrap(),
+        ])
+        .output()
+        .expect("init consumer");
+    assert!(
+        init_c.status.success(),
+        "init consumer: {}",
+        String::from_utf8_lossy(&init_c.stderr)
+    );
+    std::fs::write(
+        consumer.join("artifacts").join("bogus.yaml"),
+        "artifacts:\n\
+         \x20 - id: REQ-CONS-A\n    type: requirement\n\
+         \x20   title: Consumer req with a locally-broken external ref\n\
+         \x20   status: approved\n\
+         \x20   fields: {priority: must, category: functional}\n\
+         \x20   links:\n\
+         \x20     - type: satisfies\n\
+         \x20       target: xyz:REQ-BOGUS\n",
+    )
+    .expect("write consumer bogus.yaml");
+    std::fs::write(
+        consumer.join("rivet.yaml"),
+        format!(
+            "project:\n  name: consumer\n  version: \"0.1.0\"\n  schemas: [common, dev]\n\
+             externals:\n  sup:\n    path: {}\n    prefix: sup\n\
+             sources:\n  - path: artifacts\n    format: generic-yaml\n",
+            supplier.display()
+        ),
+    )
+    .expect("write consumer rivet.yaml");
+    let sync = Command::new(rivet_bin())
+        .args(["--project", consumer.to_str().unwrap(), "sync"])
+        .output()
+        .expect("rivet sync");
+    assert!(
+        sync.status.success(),
+        "sync: {}",
+        String::from_utf8_lossy(&sync.stderr)
+    );
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            consumer.to_str().unwrap(),
+            "validate",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("validate");
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("validate JSON");
+    let broken = parsed
+        .get("broken_cross_refs")
+        .and_then(|v| v.as_array())
+        .expect("broken_cross_refs array");
+    let leaked: Vec<_> = broken
+        .iter()
+        .filter(|b| {
+            b.get("reference")
+                .and_then(|r| r.as_str())
+                .is_some_and(|r| r.starts_with("super:"))
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "#649: supplier's own external refs must NOT leak into the \
+         consumer's cross-ref check; got: {leaked:?}"
+    );
+    let own_bad: Vec<_> = broken
+        .iter()
+        .filter(|b| {
+            b.get("reference")
+                .and_then(|r| r.as_str())
+                .is_some_and(|r| r.starts_with("xyz:"))
+        })
+        .collect();
+    assert!(
+        !own_bad.is_empty(),
+        "the consumer's own broken external ref (`xyz:REQ-BOGUS`) must \
+         still surface as an UnknownPrefix broken cross-ref; got only: {broken:?}"
+    );
+}
+
 // ── rivet stats ─────────────────────────────────────────────────────────
 
 /// `rivet stats --format json` produces valid JSON with total count.


### PR DESCRIPTION
Closes #649.

## What

`rivet validate` walked EVERY artifact's outgoing links when computing `broken_cross_refs`, so any supplier's OWN external reference (e.g. `super:REQ-EXT` in an artifact synced under `sup:`) leaked into the consumer as `UnknownPrefix("super")` — 51 broken cross-refs in the reported ordeal case for prefixes the consumer never declared.

That contradicts two of rivet's own documented positions:
- **DD-017** (`rivet docs cross-repo`): "declare direct deps only"
- **REQ-065 / AoU-X1** (`rivet validate --help`, on `--with-externals-validate`): "the consumer's PASS does not otherwise reflect the supplier's validation state"

The cross-ref walk in `cmd_validate` (`rivet-cli/src/main.rs:5819-5824`) now filters external (`prefix:ID`) artifacts out of both the `local_ids` set and the `all_refs` collection before calling `validate_refs`, mirroring the REQ-082 `is_external_artifact` convention already used by every per-artifact validation pass in `rivet-core/src/validate.rs:572-574` and by the lifecycle-completeness check a few lines below on the same page (`main.rs:5901-5905`).

```diff
-                        let local_ids: std::collections::HashSet<String> =
-                            store.iter().map(|a| a.id.clone()).collect();
-                        let all_refs: Vec<&str> = store
-                            .iter()
-                            .flat_map(|a| a.links.iter().map(|l| l.target.as_str()))
-                            .collect();
+                        let local_ids: std::collections::HashSet<String> = store
+                            .iter()
+                            .filter(|a| !a.id.contains(':'))
+                            .map(|a| a.id.clone())
+                            .collect();
+                        let all_refs: Vec<&str> = store
+                            .iter()
+                            .filter(|a| !a.id.contains(':'))
+                            .flat_map(|a| a.links.iter().map(|l| l.target.as_str()))
+                            .collect();
```

## Why this direction

Semantic (a) from the triage sketch — "strict transitive-scope: broken cross-refs classify as `UnknownPrefix` only for links originating in the consumer's own artifacts". The issue body already prescribes exactly this shape ("cross-ref checking should scope `UnknownPrefix`/broken-ref *errors* to links originating in the local project"), and it matches the letter of DD-017 / REQ-065 without adding a new config knob (semantic (b) would have needed a new opt-in `externals.validate-transitive` flag; not worth the surface for a fix that removes the wrong behavior). The `--with-externals-validate` opt-in (REQ-065 / AoU-X1) is the remaining path if you want to walk supplier internals — untouched by this PR.

## Acceptance criteria (from #649)

| # | Criterion | How this PR satisfies it |
| --- | --- | --- |
| 1 | The repro (`cd ordeal; rivet sync; rivet validate`) yields PASS on default `rivet validate`. | The cross-ref walk skips supplier-owned artifacts, so `UnknownPrefix("gale"/"kiln"/"jess"/"scry")` — all originating in loom's and synth's own graphs — never fire. |
| 2 | `rivet validate` still FAILS on a genuinely broken `loom:` ref written in the consumer's own artifacts. | Consumer-owned links (id without `:`) are still walked in full. Covered by the counter-assertion in the new test (`xyz:REQ-BOGUS` in the consumer surfaces as before). |
| 3 | Regression test asserts the fix on a realistic supplier / transitive-supplier scenario. | `rivet-cli/tests/cli_commands.rs::validate_does_not_leak_transitive_external_prefixes` — spins two `rivet init --preset dev` projects, wires supplier as `sup:`, has supplier link to `super:REQ-EXT` (undeclared by the consumer), then asserts `broken_cross_refs` contains no `super:` entries and DOES contain the consumer's own `xyz:REQ-BOGUS`. |
| 4 | `--with-externals-validate` (REQ-065 / AoU-X1) still surfaces supplier diagnostics when opted in. | Its block (`main.rs:5872-5897`) is untouched; the existing `validate_with_externals_validate_surfaces_supplier_diagnostics` test continues to guard it. |
| 5 | `rivet validate` on this repo remains PASS. | The fix only removes findings; no new diagnostics are introduced. Verified by CI. |

## Why draft

This session's egress policy is scoped to `pulseengine/rivet` only. The workspace transitively depends on `pulseengine/rowan` (git dependency pinned at `9e7abd1…`, the maintenance fork), which the proxy denies with a 403 — same pattern as PRs #657 and #599. I could not run `cargo build -p rivet-cli --tests` or `cargo test` locally in this session — the fetch of `rowan` cannot succeed. Please flip to Ready-for-review after CI (which has full scope) confirms:

- `cargo test -p rivet-cli --test cli_commands validate_does_not_leak_transitive_external_prefixes` passes on this branch,
- the same test **fails** on `main` (proves the regression test is real — the `super:` UnknownPrefix would fire, hitting the `leaked.is_empty()` assertion),
- `rivet validate` on the rivet repo remains PASS,
- `validate_with_externals_validate_surfaces_supplier_diagnostics` and `validate_does_not_count_external_repo_violations` (the REQ-065 / REQ-082 guardrails) still pass.

## Test plan

- [ ] CI Format / Clippy / Test gates green on this branch
- [ ] Verify `validate_does_not_leak_transitive_external_prefixes` fails on `main` (revert the two `.filter(...)` lines, expect `leaked` populated with a `super:` UnknownPrefix entry)
- [ ] Downstream: run `rivet validate` on a real cross-repo consumer (e.g. ordeal after `rivet sync` of loom + synth) and confirm the 51 broken cross-refs are gone; a genuinely broken consumer-owned ref still fails

## Blog process pre-check

Re-fetched `https://pulseengine.eu/blog/` at the start of this run — no posts on team workflow / branching / PR flow / testing conventions (the blog focuses on WebAssembly tooling, formal verification, and AI-assisted spec-driven verification). Nothing there overrides this PR.

---
_Generated by [Claude Code](https://claude.ai/code) — issue-triage agent run 2026-07-02._

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR4k8rKMBnxqmHLAp34Zn7)_