### PR TITLE
fix(security): bump quick-xml 0.37→0.41 (RUSTSEC-2026-0194/0195)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,9 +2833,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 urlencoding = "2"
 
 # XML (ReqIF)
-quick-xml = { version = "0.37", features = ["serialize", "overlapped-lists"] }
+quick-xml = { version = "0.41", features = ["serialize", "overlapped-lists"] }
 
 # WASM component model
 # Pinned to >=45.0.3 for RUSTSEC-2026-0188 — WASI hard links and renames

--- a/rivet-core/src/junit.rs
+++ b/rivet-core/src/junit.rs
@@ -372,9 +372,20 @@ fn parse_suites(xml: &str) -> Result<Vec<ParsedSuite>, Error> {
             {
                 if let Some(ref mut c) = current_case {
                     if c.body.is_none() {
+                        // quick-xml 0.41 (RUSTSEC-2026-0194/0195 fix) removed
+                        // `BytesText::unescape()`; it split into `decode()`
+                        // (bytes→str) + the standalone `escape::unescape`
+                        // (entity resolution). Preserve the old decode+unescape
+                        // behavior — JUnit failure/error bodies carry entities
+                        // like `&lt;`/`&amp;` in stack traces.
                         let text = e
-                            .unescape()
-                            .map(|s| s.trim().to_string())
+                            .decode()
+                            .ok()
+                            .and_then(|d| {
+                                quick_xml::escape::unescape(&d)
+                                    .ok()
+                                    .map(|u| u.trim().to_string())
+                            })
                             .unwrap_or_default();
                         if !text.is_empty() {
                             c.body = Some(text);
@@ -416,7 +427,10 @@ fn collect_attrs(e: &quick_xml::events::BytesStart<'_>) -> HashMap<String, Strin
     for attr in e.attributes().flatten() {
         if let (Ok(key), Ok(val)) = (
             std::str::from_utf8(attr.key.local_name().as_ref()),
-            attr.unescape_value(),
+            // quick-xml 0.41 deprecated `unescape_value()` for
+            // `normalized_value(version)` — the spec-compliant attribute-value
+            // normalization (entity resolution + whitespace). JUnit XML is 1.0.
+            attr.normalized_value(quick_xml::XmlVersion::Implicit1_0),
         ) {
             map.insert(key.to_string(), val.into_owned());
         }


### PR DESCRIPTION
## Security bump

`quick-xml` 0.37.5 carries two advisories, both fixed in **>=0.41.0**:
- **RUSTSEC-2026-0194** — quadratic run time when checking a start tag for duplicate attribute names.
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` → memory-exhaustion DoS.

Both are reachable through **reqif import of untrusted XML**, and they were failing the **Security Audit (RustSec)** gate on every PR.

## API adaptation
The 0.37→0.41 shift touched one consumer, `rivet-core/src/junit.rs`:
- `BytesText::unescape()` was removed → `decode()` + `escape::unescape()` (decode bytes, then resolve entities — JUnit failure bodies carry `&lt;`/`&amp;`).
- `Attribute::unescape_value()` deprecated → `normalized_value(XmlVersion::Implicit1_0)` (spec-compliant XML-1.0 attribute-value normalization).
- `reqif.rs` reads via serde (`serialize` feature), so it was unaffected.

## Verification (behavior preserved)
- rivet-core lib suite **1168** incl. junit **25** + reqif module tests
- CLI reqif roundtrip integration test **4/4** (`reqif_export_has_specification_and_roundtrips_via_cli`, etc.)
- `cargo clippy --all-targets -- -D warnings` exit 0 on both crates; `cargo fmt` clean
- Lockfile carries only quick-xml **0.41.0** (no transitive 0.37)

`Trace: skip` — dependency security maintenance; maps to no rivet requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)