### PR TITLE
docs: runner pool operations runbook (#509)

### DIFF
--- a/docs/ci-runners.md
+++ b/docs/ci-runners.md
@@ -1,0 +1,167 @@
+---
+id: DOC-CI-RUNNERS
+title: CI runner pool operations runbook
+type: reference
+status: current
+tags: [reference, ci, runners, ops, runbook]
+---
+
+# CI runner pool operations runbook
+
+Rivet's gating CI jobs (`fmt`, `clippy`, `test`, `mutation`, `Kani`,
+Playwright) all run on the self-hosted pool labeled
+`[self-hosted, linux, x64, <class>]`. That pool is a **single point of
+failure**: when it goes offline, every gate queues indefinitely with no
+fallback, and — without the liveness workflow that fires on GitHub-hosted
+runners — the failure is invisible to anyone not watching the queue by
+hand. This document is the runbook for the two situations that matter:
+
+1. The scheduled liveness workflow raised the tracker issue.
+2. You are diagnosing the pool by hand (liveness workflow missing, or
+   confirming what it reported).
+
+Not covered here: the liveness workflow itself (see
+`.github/workflows/runner-liveness.yml`), and the routing-fast-gates-to-
+GitHub-hosted option (open under #509, tracked separately).
+
+> **Reminder (REQ-051).** Pre-commit hooks are convenience; CI is the
+> gate. Anything that skips CI does not have a traceability claim behind
+> it. If the pool is down, treat merges to `main` with the same caution
+> you would a `--no-verify` commit — the four-gate pipeline
+> (`pre-commit → bazel → CI → verify-matrix`) is running on three legs.
+
+## Runner classes
+
+Three self-hosted classes are pinned by workflows:
+
+| Label | Purpose | Jobs that use it |
+| --- | --- | --- |
+| `light` | Fast, low-RAM checks — `fmt`, `yaml-lint`, `validate`, `clippy`, doc renders. | The bulk of `ci.yml`'s per-PR gates. |
+| `rust-cpu` | CPU-heavy Rust builds — `test`, `Kani`, coverage runs. | Test / proof shards. |
+| `lean-mem` | Memory-constrained shards (host-level `MemoryHigh=32 GiB`, adding `MemoryMax=~48 GiB` per #590). | `mutants-core`, Miri. Never route a job here without a per-process memory cap. |
+
+A single class going offline while the others stay up produces
+**partial** failure: the queued-age liveness alert still fires because
+some workflows can't be scheduled, but a `runner list` may still show
+online runners. Diagnose per-class, not just aggregate.
+
+## The two diagnostic commands
+
+`runner-liveness.yml` runs these on a `*/15 * * * *` cadence; if the
+tracker issue is open, these are also the commands you run by hand.
+
+**Are runners registered and online?** (best-effort — needs the
+`administration:read` scope, which the default `GITHUB_TOKEN` does not
+carry):
+
+```sh
+gh api repos/pulseengine/rivet/actions/runners \
+  --jq '{total: .total_count,
+         online: [.runners[] | select(.status=="online")] | length,
+         classes: [.runners[] | .labels[].name] | unique}'
+```
+
+- `total: 0` → pool is not registered with the repo at all (likely
+  org-level pool — the repo-scoped API returns empty; check the org's
+  runner page instead).
+- `total > 0`, `online: 0` → runners are registered but their agent
+  processes are down or offline. Restart on the runner host is usually
+  enough; see "Bring the pool back" below.
+- `online > 0` but no jobs picking up → check the queued-age query below;
+  runners are online but not accepting the queued job's label set (label
+  mismatch or an org-level concurrency cap).
+
+**Are jobs stuck queued?** (authoritative — needs only `actions:read`,
+works even when the runner list returns empty for permission reasons):
+
+```sh
+gh api repos/pulseengine/rivet/actions/runs?status=queued \
+  --jq '.workflow_runs[] | "\(.id)  age=\(((now - (.created_at | fromdateiso8601)) / 60 | floor))m  \(.name) — \(.head_branch)"'
+```
+
+- Any run age over the liveness threshold (`QUEUE_THRESHOLD_MINUTES`,
+  currently **30**) is the alarm shape. A single stuck run 30+ minutes
+  old is enough to fire the tracker; two or more is a durable outage.
+- If the oldest queued run is on `main` (a push run for a merged PR),
+  the CI record for that merge is missing — the merge landed with no
+  verification. Note it in the tracker issue for the next audit.
+
+## When the liveness tracker issue is open
+
+`runner-liveness.yml` auto-opens (and updates every 15 min, then
+auto-closes on recovery) the tracker labeled `runner-down` titled
+`🚨 CI runner pool liveness alert`. When it's open:
+
+1. **Confirm the shape** — re-run the two commands above. Match against
+   the tracker's most recent probe comment. If they now report the
+   pool healthy, the next probe (≤ 15 min) will auto-close; no manual
+   action.
+2. **Identify which class is affected** — a `runner list` at `total > 0`
+   with `online > 0` but jobs still queued means the class the job
+   asked for (`lean-mem` / `rust-cpu` / `light`) has no live members.
+3. **Bring the pool back** — see below.
+4. **Post the outage window** on the tracker issue as one comment before
+   it auto-closes: start time, end time, affected class, root cause if
+   known. That comment becomes the durable audit record after the
+   tracker closes.
+5. **Note affected `main` runs** in the same comment. Any `main` push
+   run that queued and expired without running is a merge that reached
+   `main` without CI verification. Those need the next PR against them
+   to re-exercise the same gates.
+
+Do NOT close the tracker manually — let the next probe close it on
+recovery. A manual close on a still-down pool is a false-recovery signal
+and re-arms only when the pool next transitions.
+
+## Bring the pool back
+
+The action lives on the runner host, not this repo — outside this
+repo's write surface. The steps every operator needs:
+
+1. `ssh` to the runner host (`pulseengine-ci-<NN>`).
+2. Check the runner-agent service status:
+   `systemctl --user status actions.runner.pulseengine-rivet.<host>.service`
+   (or `github-runner@<name>` per the host's install layout).
+3. Inspect the last few log entries:
+   `journalctl --user -u actions.runner.pulseengine-rivet.<host>.service -n 50 --no-pager`.
+   Common failure shapes:
+   - `disk full` → clear per-runner `_work/` and the shared
+     `$CARGO_HOME/registry/cache/**`; see #567 for the coordination
+     rules on the shared cargo state.
+   - `token expired` / `Not configured` → re-register the runner via
+     `./config.sh --url … --token …` (org owner has to mint the token).
+   - Process alive but no jobs picking up → label mismatch (the runner
+     lost or never had the class label the job asks for); re-run
+     `./config.sh` with the correct `--labels`.
+4. Restart the service:
+   `systemctl --user restart actions.runner.pulseengine-rivet.<host>.service`.
+5. Confirm via the two diagnostic commands above that the runner is
+   online and jobs drain.
+
+If more than one host is affected, work them in parallel — the tracker
+issue auto-closes on the first passing probe after all classes recover.
+
+## Escalation
+
+- **Pool has been down > 2 hours** and no operator on the runner host is
+  reachable: the maintainer's call is whether to admin-merge without CI
+  or wait. Default is to wait; #509 option 2 (route fast gates to
+  `ubuntu-latest`) is the durable answer here and is tracked
+  separately.
+- **Every host reports full disk**: coordinate the cleanup with #567
+  (the shared-cargo race). Do not `rm -rf` shared registry state on any
+  host while jobs are running on another — the "in-flight build
+  corruption" failure mode.
+- **Runners online but jobs still queue for a specific class only**:
+  check whether the org-level pool has a per-class concurrency cap set
+  above the actual live count.
+
+## Related
+
+- `.github/workflows/runner-liveness.yml` — the alerting workflow itself.
+- #509 — parent issue; options 1 (liveness) shipped, option 2 (fallback
+  routing) open, option 3 (this runbook).
+- #567 — self-hosted-runner disk exhaustion / shared-`CARGO_HOME` race.
+- #590 — `rivet_core` test-binary memory shape (why `lean-mem`
+  exists in the first place).
+- REQ-051 — hooks are convenience; CI is the gate.


### PR DESCRIPTION
Refs #509 (slice 3 of the three suggested fixes in the issue body).

## What

New reference doc at `docs/ci-runners.md`, matching the top-level `docs/*.md` layout for shipped operational reference material (adopts the same frontmatter shape as `docs/pre-commit.md` and `docs/verification.md`). It is the runbook the liveness alert (slice 1, `.github/workflows/runner-liveness.yml`) points at when it opens the `runner-down` tracker issue.

Covers:

- **The three self-hosted classes** (`light` / `rust-cpu` / `lean-mem`) and which jobs pin each. A partial outage — one class down while the others stay up — is diagnosable without grepping every workflow file.
- **The two diagnostic commands** — `gh api …/runners` (best-effort; needs `administration:read`, which `GITHUB_TOKEN` cannot carry) and the queued-run-age query (authoritative — needs only `actions:read`). Both mirror what `runner-liveness.yml` probes on its 15-min cadence, so an operator running them by hand sees the same shape the tracker issue reports.
- **What to do when the tracker is open** — confirm the shape, identify the affected class, bring the pool back, post the outage window as one comment before auto-close (that comment becomes the durable audit record after the tracker closes), note any `main` push runs that queued and expired (merges that reached `main` without CI verification).
- **Host-side recovery steps** — systemd unit paths, common failure shapes (disk-full → coordinate with #567's shared-cargo race, token-expired, label-mismatch). Off-scope for this repo but referenced so an on-call operator can act.
- **Escalation** — > 2 hour outage, every-host-full disk, class-specific queueing.

Also carries the REQ-051 reminder in the callout (hooks are convenience, CI is the gate — if the pool is down, treat merges to `main` with the same caution as a `--no-verify` commit) so a reader doesn't need to hunt the constraint down separately.

## Direction picked (option (c) from the triage sketch)

Options 1 and 2 from the #509 body are separately tracked:

- **Option 1 — liveness alert** already landed as `.github/workflows/runner-liveness.yml`. This runbook cross-references it as the source of truth for the tracker-issue lifecycle (auto-open on the first bad probe, auto-update every 15 min, auto-close on recovery).
- **Option 2 — route fast gates to `ubuntu-latest`** is a policy call with billing implications; kept out of scope per the issue body's own "these are choices for the maintainer" framing.

## Blog process pre-check

Re-fetched `https://pulseengine.eu/blog/` at the start of this run. No posts on team workflow / branching / PR flow / testing conventions beyond the spec-driven-development post already reflected here. Nothing overrides this PR.

## Test plan

- [x] `rivet validate` on the rivet repo — PASS, 497 warnings (unchanged from `main`; the new doc carries the standard `DOC-CI-RUNNERS` frontmatter so the docs scanner picks it up cleanly).
- [x] `cargo fmt --all --check` — clean (docs-only change, no Rust touched).
- [ ] CI Format / YAML-lint / Docs Check gates green on this branch.
- [ ] Reviewer smoke-test: read the runbook top-to-bottom on the assumption the pool is down right now — every step should be actionable from the two commands the doc provides.

## Not this PR

- `runner-liveness.yml` itself — already shipped.
- Any host-side change (systemd unit, `_work/` cleanup, `CARGO_HOME` layout) — off-scope; #567 tracks the shared-cargo hazard.
- Fast-gate routing to `ubuntu-latest` — option 2 of #509, separate policy call.

Commit trailer: `Trace: skip` (docs is an exempt type per CLAUDE.md's commit-traceability section), `Refs: #509, #567, #590, REQ-051`.

---
_Generated by [Claude Code](https://claude.ai/code) — issue-triage agent run 2026-07-02._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jj8RPdbnK66ZeYgRuCxAdW)_