### PR TITLE
docs(release): explain `require: coverage` semantics — coverage-rules ≠ every V-level (#612)

### DIFF
--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -1,0 +1,147 @@
+---
+id: DOC-RELEASE-STATUS
+title: "Release readiness — rivet release status"
+type: reference
+status: current
+tags: [release, cuttability, coverage, aspice, v-model, reference]
+---
+
+# Release readiness — `rivet release status`
+
+`rivet release status <version>` is the cuttability gate for a release
+scope. It reports a per-status burn-down for every artifact carrying
+`release: <version>` and exits non-zero when the scope is not release-ready
+— the CI-gating contract.
+
+Two `rivet.yaml` knobs (REQ-240, [#612]) widen what counts as ready so
+V-model / ASPICE projects — which verify via links, not a status flip —
+can green the gate. This page pins the semantics of those knobs, in
+particular the subtle one: `require: coverage` greens when the configured
+**coverage-rules are satisfied**, which is not the same thing as "every
+verification level is present".
+
+## The knobs
+
+`rivet.yaml`:
+
+```yaml
+release:
+  ready-when: [approved]      # extend the ready status set
+  require: coverage           # OR: derive readiness from validate V-closure
+```
+
+### `ready-when: [<status>, ...]`
+
+Extends the release-ready status set beyond the built-in
+`verified` / `accepted`. Purely additive — the built-ins still count. Use
+this when the project's own lifecycle terminal is a status string other
+than the built-ins (e.g. an `approved` sign-off).
+
+### `require: coverage`
+
+Also counts an artifact ready when every applicable **validate coverage
+rule** for its type is satisfied, regardless of the status string. Purely
+additive: a `verified` / `accepted` / `ready-when` artifact still counts,
+so switching to `coverage` never makes a release *less* cuttable.
+
+This is the escape hatch for V-model / ASPICE projects that carry
+requirements at a terminal status like `approved` and express verification
+through links (`verified-by` / `verifies`) rather than a further status
+flip.
+
+## The precision note
+
+`require: coverage` reads whatever coverage-rules the project's schema
+declares. It is **not** a hard-coded "every V level is present" gate. What
+counts as V-closed depends entirely on how the schema's coverage-rules are
+written.
+
+The ASPICE built-ins ship a permissive shape. `swe1-has-verification` is
+declared as:
+
+> An `sw-req` at a lifecycle status of `implemented` or later is verified
+> by **≥ 1** of `{sw-verification, unit-verification, sw-integration-verification}`.
+> **severity: warning**.
+
+So a requirement with **one** verification measure linked (e.g. formal
+verification via `sw-verification`) passes the rule and counts as ready
+under `require: coverage`, even though the granular `rivet validate`
+breakdown for the same requirement will still list `missing:
+unit-verification, sw-integration-verification` at info severity.
+
+Both outputs are internally correct. They answer different questions:
+
+| View                       | Question it answers                            |
+|----------------------------|------------------------------------------------|
+| `rivet release status` under `require: coverage` | Does the schema's `swe1-has-verification` rule pass? (≥ 1 measure) |
+| `rivet validate` granular breakdown              | Is every declared verification level present? (per-level) |
+
+The `release status` verdict follows the rule literally. If a green
+verdict means "≥ 1 measure exists somewhere" and the project needs it to
+mean "every level is closed", the schema must be tightened, not the
+release-status command.
+
+### Concrete example
+
+A project runs `rivet release status v0.1.0` on eleven `sw-req` artifacts
+under an aspice-flavoured schema. Each requirement carries a formal
+verification link (`sw-verification`) plus a system-level verification
+link but no unit / integration verification.
+
+| `rivet.yaml` `release:` config | Verdict          |
+|--------------------------------|------------------|
+| *(none — default status-mode)* | ✗ NOT cuttable — no artifact is `verified`/`accepted` |
+| `ready-when: [approved]`       | ✓ Cuttable — every `sw-req` is `approved` |
+| `require: coverage`            | ✓ Cuttable — the ≥ 1-measure rule passes |
+
+Under `require: coverage` the gate greens because
+`swe1-has-verification` fires only when *zero* verification measures are
+linked. `rivet validate` on the same repo still reports the per-level
+gaps as info because those are a separate check.
+
+## When "≥ 1 measure" isn't strict enough
+
+An ASIL-D (or DAL-A, or IEC 62304 Class C) project wanting the gate to
+mean **full per-level V-closure** — every declared verification level
+present, not just at least one — should express that in the schema's
+coverage-rules, not by reinterpreting the command. Two options that keep
+the command's contract:
+
+1. **Split the built-in rule.** Replace the single ≥ 1-of-many rule with
+   per-level rules — one for `sw-verification`, one for
+   `unit-verification`, one for `sw-integration-verification` — each with
+   `severity: error`. `require: coverage` then greens only when every
+   level's rule passes; a missing unit-verification blocks the gate the
+   same way a missing formal verification would.
+2. **Author the coverage-rules from scratch.** For a project that already
+   diverges from the aspice built-ins, declare a project-specific
+   coverage-rule per verification level at `severity: error`. Same effect.
+
+Both keep readiness derived from the schema — the intended shape — rather
+than embedding "every level" into the tool. Projects that keep the ≥ 1
+warning-severity rule opt in to that meaning of green.
+
+## Backwards compatibility
+
+The default mode is unchanged: no `release:` block in `rivet.yaml` means
+`rivet release status` gates on `status ∈ {verified, accepted}` exactly
+as before. The knobs are strictly additive; a project can adopt
+`ready-when` and `require: coverage` without ever making a previously
+cuttable release non-cuttable.
+
+The `--format json` output continues to expose `cuttable` as a boolean
+under a stable key; the exit code stays consistent with that verdict
+(non-zero when `cuttable == false`) so the CI-gating contract is
+untouched.
+
+## See also
+
+- [`docs/schemas.md`](schemas.md) — coverage-rule authoring shape.
+- [`docs/verification.md`](verification.md) — how verification maps to
+  ASPICE SWE.4 / SWE.5 / SWE.6.
+- [REQ-240](../artifacts/requirements.yaml) — the requirement anchoring
+  the `ready-when` + `require: coverage` widening.
+- [#612](https://github.com/pulseengine/rivet/issues/612) — the original
+  friction report against a link-verification project (gale).
+
+[#612]: https://github.com/pulseengine/rivet/issues/612

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1510,8 +1510,20 @@ enum BaselineAction {
 enum ReleaseAction {
     /// Readiness burn-down for a release (REQ-233, #516): per-status counts of
     /// the artifacts scoped to `release: <version>`, plus the set that is not
-    /// yet `verified`/`accepted`. The release is cuttable when that set is
-    /// empty. Exits non-zero when not cuttable (so CI can gate on it).
+    /// yet release-ready. The release is cuttable when that set is empty.
+    /// Exits non-zero when not cuttable (so CI can gate on it).
+    ///
+    /// By default an artifact is release-ready at `status ∈
+    /// {verified, accepted}`. `rivet.yaml`'s `release:` block widens that:
+    /// `ready-when: [<status>...]` extends the ready status set;
+    /// `require: coverage` (REQ-240, #612) ALSO counts an artifact ready
+    /// when every applicable validate coverage rule passes for its type —
+    /// the escape hatch for V-model / ASPICE projects that verify via
+    /// links rather than a status flip. `require: coverage` greens when
+    /// the configured coverage-rules pass, which is NOT the same as
+    /// "every verification level present" — see `docs/release-status.md`
+    /// for the precision note and how to tighten the schema when a
+    /// stricter meaning is required.
     Status {
         /// Release version, e.g. v0.22.0
         version: String,


### PR DESCRIPTION
Closes #612 (the docs sliver — the implementation of `ready-when` + `require: coverage` already landed in REQ-240 / [#641](https://github.com/pulseengine/rivet/pull/641) and was confirmed working on gale).

## What

`rivet release status` under `require: coverage` (REQ-240, #612) greens when the configured coverage-rules pass — which is not the same thing as **"every verification level is present"**. The ASPICE `swe1-has-verification` rule ships as "≥ 1 of `{sw-verification, unit-verification, sw-integration-verification}`" at `severity: warning`, so a `sw-req` with just formal + system verification passes the rule and counts as ready even though `rivet validate`'s granular breakdown still lists the per-level gaps as info. Both are internally correct — they answer different questions:

| View | Question it answers |
|---|---|
| `rivet release status` under `require: coverage` | Does the schema's `swe1-has-verification` rule pass? (≥ 1 measure) |
| `rivet validate` granular breakdown | Is every declared verification level present? (per-level) |

An ASIL-D (or DAL-A, IEC 62304 Class C) project that wants the gate to mean **full per-level V-closure** should express that in the schema's coverage-rules — split the ≥ 1-of-many rule into per-level rules at `severity: error`, or author project-specific coverage-rules — rather than reinterpret the command.

## Changes

- **`docs/release-status.md`** (new, `type: reference` / `status: current`) — reference doc for `rivet release status`, the `release:` config, and the two readiness knobs. The precision note is the central section: it names the ≥ 1-vs-per-level distinction, gives a concrete before/after table using aspice's built-in rule (mirroring @avrabe's own gale confirmation matrix on #612), and points ASIL-D projects at the schema-tightening options.
- **`rivet-cli/src/main.rs`** — the `Status` command's doc-comment (drives `rivet release status --help`) now cites REQ-240 / #612, distinguishes the built-in status-only path from `ready-when` and `require: coverage`, and points readers at `docs/release-status.md` for the precision note.

## Acceptance criteria (from [#612 last comment](https://github.com/pulseengine/rivet/issues/612#issuecomment-4868791407), 17:37 UTC 2026-07-02)

| # | Criterion | How this PR satisfies it |
| --- | --- | --- |
| 1 | `docs/release-status.md` grows a section explaining `require: coverage` == "the configured coverage-rules are satisfied", NOT "every verification level is present". Concrete before/after example using an aspice-shaped `swe1-has-verification` warning-severity ≥ 1 rule. | New file created. "The precision note" section states the semantics exactly. "Concrete example" table below it walks the three-verdict matrix (default / `ready-when: [approved]` / `require: coverage`) on eleven aspice-flavoured `sw-req` artifacts, matching @avrabe's gale confirmation shape. |
| 2 | Names the choice an ASIL-D project should make: tighten the coverage-rules (per-level, `severity: error`) rather than rely on the built-in ≥ 1 warning — otherwise the green can overstate readiness. | "When '≥ 1 measure' isn't strict enough" section presents both concrete options (split the built-in rule; author project-specific per-level rules) and states each with `severity: error`. |
| 3 | `rivet release status --help` (or `rivet.yaml --explain` / `rivet docs release`) points to the new section. | The `Status` doc-comment in `rivet-cli/src/main.rs` now lands in `--help` with the precision note summary and an explicit `see docs/release-status.md` pointer. Verified live: `./target/release/rivet release status --help` prints the pointer. |
| 4 | Regression: golden-file test if docs-test harness exists, else manual link check + `rivet validate` PASS. | No `docs/` golden-file harness exists (`rivet docs check` is the closest — validates frontmatter and reference invariants, not content golden files). PASS on both mechanical gates: `rivet validate` PASS (450 warnings, unchanged from `main`), `rivet docs check` PASS (60 files scanned, 0 violations). Internal links checked by hand: [`docs/schemas.md`](../blob/main/docs/schemas.md), [`docs/verification.md`](../blob/main/docs/verification.md), REQ-240, and #612 all resolve. |
| 5 | Commit trailers: `Refs: REQ-XXX` (the REQ anchoring the v0.23.0 release-readiness widening), `Refs: #612`. | Trailers are `Refs: REQ-240` (REQ-240 anchors ready-when + require-coverage per the commit `61e297d`) and `Refs: #612`. Exempt from `Implements:` because this PR is docs-only under CLAUDE.md's `docs` exempt type; `Refs:` carries the traceability. |
| 6 | **Explicitly out of scope (file separately if wanted):** any change to the coverage-rule semantics themselves; a new `require: full-v-closure` (per-level) mode. | Untouched. The doc names both options as schema-tightening choices for the consumer, not as new command modes. |

## Blog process pre-check

Re-fetched `https://pulseengine.eu/blog/` at the start of this run. The blog carries the spec-driven-development / oracle-gated post that's already reflected in rivet's conventions; no team-workflow / branching / PR-flow / testing-conventions post overrides this PR.

## Test plan

- [x] `rivet validate` on the rivet repo — PASS (450 warnings, unchanged from `main`).
- [x] `rivet docs check` on the rivet repo — PASS (60 files, 0 violations).
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy -p rivet-cli --release --bins -- -D warnings` — clean (the pre-existing MSRV mismatch between `clippy.toml` and `Cargo.toml` is untouched by this PR).
- [x] `./target/release/rivet release status --help` renders the new doc-comment with the REQ-240 / #612 reference and the `docs/release-status.md` pointer.
- [ ] CI Format / YAML-lint / Docs Check / Clippy gates green on this branch.
- [ ] Reviewer smoke-test: read `docs/release-status.md` top-to-bottom on the assumption you're a new ASIL-D adopter — every design choice (`ready-when`, `require: coverage`, the ≥ 1-vs-per-level distinction) should be actionable from the page alone.

## Not this PR

- Any change to what `require: coverage` computes — the command's contract stays exactly as REQ-240 shipped (schema coverage-rule satisfaction, purely additive to `verified`/`accepted`/`ready-when`).
- A `require: full-v-closure` per-level mode — an ASIL-D project can already reach that meaning by tightening the schema's coverage-rules; the doc names how.
- Repurposing #612 further; the docs sliver was the last remaining item on it.

Commit trailer: `Refs: REQ-240`, `Refs: #612` (docs is an exempt type per CLAUDE.md's commit-traceability section).

---
_Generated by [Claude Code](https://claude.ai/code) — issue-triage agent run 2026-07-02._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCRFEHiCTnJArCQvkNvJMH)_