### PR TITLE
ci: skip compile-heavy Rust jobs on artifact/docs-only PRs (runner load)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,45 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  # Gate the compile-heavy Rust jobs so artifact/docs-only PRs stop running the
+  # full matrix and saturating the shared self-hosted pool. Pure `git diff` — no
+  # third-party action, so the supply chain stays auditable. On push/main,
+  # schedule and workflow_dispatch the filter always reports rust=true, so a
+  # merge or the nightly run still exercises everything. Content-validating jobs
+  # (traceability = `rivet validate`, docs-check, yaml-lint) are deliberately
+  # NOT gated on this — they must run on artifact/doc PRs.
+  changes:
+    name: Detect changed areas
+    runs-on: [self-hosted, linux, x64, light]
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "non-PR event (${{ github.event_name }}) → full matrix"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          changed="$(git diff --name-only "$base"...HEAD)"
+          echo "changed files:"; echo "$changed"
+          if echo "$changed" | grep -qE '(\.rs$)|((^|/)Cargo\.(toml|lock)$)|(^\.github/workflows/)'; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "→ Rust/Cargo/workflow changes present; running full matrix"
+          else
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+            echo "→ no Rust/Cargo/workflow changes; skipping compile-heavy jobs"
+          fi
+
   # ── Fast checks ───────────────────────────────────────────────────────
   fmt:
     name: Format
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v6
@@ -41,6 +77,8 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v6
@@ -154,6 +192,8 @@ jobs:
   # ── Tests ─────────────────────────────────────────────────────────────
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, rust-cpu]
     env:
       RIVET_ACTIONLINT: "1"
@@ -338,6 +378,8 @@ jobs:
     # Renamed: skipping advisories until smithy ships an upgraded
     # rustsec parser (see audit job comment). Same workaround as spar.
     name: Cargo Deny (licenses, bans, sources)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v6
@@ -363,7 +405,8 @@ jobs:
   # escape to a release.
   semver-checks:
     name: Semver Checks (rivet-core public API)
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v6
@@ -384,7 +427,8 @@ jobs:
   # ── Code coverage (Rust nightly for source-based instrumentation) ───
   coverage:
     name: Code Coverage
-    needs: [test]
+    needs: [changes, test]
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v6
@@ -424,7 +468,8 @@ jobs:
   # (sexpr + yaml_cst); the FULL sweep runs nightly (miri-full, #498 pattern).
   miri:
     name: Miri (safety surface)
-    if: github.event_name != 'schedule'
+    needs: changes
+    if: github.event_name != 'schedule' && needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
@@ -483,6 +528,8 @@ jobs:
   # ── Property-based testing (extended) ───────────────────────────────
   proptest:
     name: Proptest (extended)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v6
@@ -626,7 +673,8 @@ jobs:
   # RAM-bound gating jobs (Miri, Verus) and the nightly mutants-core fan-out.
   mutants-cli:
     name: Mutation Testing (rivet-cli)
-    needs: [test]
+    needs: [changes, test]
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 45
     steps:
@@ -703,6 +751,8 @@ jobs:
   # ── Supply chain verification ───────────────────────────────────────
   supply-chain:
     name: Supply Chain (cargo-vet)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, light]
     timeout-minutes: 10
     steps:
@@ -866,6 +916,8 @@ jobs:
   # ── MSRV check ──────────────────────────────────────────────────────
   msrv:
     name: MSRV (1.89)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Why
The shared self-hosted runner pool is contended (maintainer + multiple agents). A YAML/artifact- or docs-only PR currently runs the **entire** Rust matrix (Clippy, Test, Miri, Coverage, mutants-cli, MSRV, semver, deny, supply-chain) — ~15 self-hosted jobs, ~75 runner-min, including the scarce 4-runner `lean-mem` class (Miri) — for changes that touch no code.

## What
Adds a `changes` gate job (**pure `git diff`, no third-party action** — keeps the supply chain auditable) that computes `rust=true` when a PR touches `**/*.rs`, `Cargo.{toml,lock}`, or `.github/workflows/`, else `rust=false`. On `push`/main, `schedule`, and `workflow_dispatch` it is **always `true`**, so merges and the nightly run still exercise everything.

The compile-heavy self-hosted jobs gate on `needs.changes.outputs.rust == 'true'`:
`fmt, clippy, test, coverage, miri, proptest, mutants-cli, semver-checks, msrv, deny, supply-chain`.

**Deliberately NOT gated** (they validate artifact/doc content and must run on those PRs):
`traceability` (`rivet validate` + commits), `docs-check` (`rivet docs check`), `yaml-lint`.

**Unchanged**: GitHub-hosted jobs (playwright, zola, vscode-ext, audit, kani, verus, rocq) — they don't touch the shared self-hosted pool.

## Effect
- Artifact/docs-only PR: ~15 self-hosted jobs → **3** (the validators). Near-zero compile load.
- Rust PR / merge to main / nightly: **unchanged** — full matrix.

Complements the existing `concurrency: cancel-in-progress` (already kills superseded PR runs) and the nightly-only heavy matrices (#498). This PR touches `.github/workflows/`, so it self-tests: `changes` reports `rust=true` and the full matrix runs once here to prove the gate doesn't break Rust PRs.

Validated locally: `python3 yaml.safe_load` OK; `actionlint` clean (ignoring the pre-existing custom-runner-label warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)