### PR TITLE
fix(security): bump crossbeam-epoch 0.9.18→0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Transitive dependency. **RUSTSEC-2026-0204** — invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid; fixed in >=0.9.20. Was failing **Security Audit (RustSec)** on main and every open PR.

Lockfile-only bump (`cargo update -p crossbeam-epoch --precise 0.9.20`); not a direct dependency of any rivet crate, so no API impact.

`Trace: skip` — dependency security maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)