### PR TITLE
ci(compliance): hard MB cap on the report tarball so #671 can't recur

### DIFF
--- a/.github/actions/compliance/action.yml
+++ b/.github/actions/compliance/action.yml
@@ -91,6 +91,19 @@ inputs:
     required: false
     default: '.'
 
+  max-archive-size-mb:
+    description: >
+      Hard upper bound on the produced tarball size, in megabytes.
+      When `archive: true`, the action fails immediately if the tarball
+      exceeds this cap — prevents a producer regression from shipping an
+      oversized "compliance report" again (issue #671: v0.4.x / v0.7-0.9
+      shipped ~800 MB tarballs due to bundled build output). Legitimate
+      reports are 1-5 MB single-page and ~100s of MB multi-page, so pick
+      50 MB for single-page (default) or bump this input for multi-page
+      callers. Set to '0' to disable the guard.
+    required: false
+    default: '50'
+
   # ── Audit bundle additions (REQ-090) ───────────────────────────────
   include-data-formats:
     description: >
@@ -298,3 +311,13 @@ runs:
         tar -czf "${NAME}.tar.gz" -C "$REPORT_OUTPUT" .
         echo "archive-path=${NAME}.tar.gz" >> "$GITHUB_OUTPUT"
         echo "Created ${NAME}.tar.gz"
+
+    - name: Verify archive size (#671 regression guard)
+      if: inputs.archive == 'true'
+      shell: bash
+      working-directory: ${{ inputs.project-dir }}
+      env:
+        ARCHIVE_PATH: ${{ steps.archive.outputs.archive-path }}
+        MAX_MB: ${{ inputs.max-archive-size-mb }}
+      run: |
+        "${GITHUB_ACTION_PATH}/verify_archive_size.sh" "$ARCHIVE_PATH" "$MAX_MB"

--- a/.github/actions/compliance/verify_archive_size.sh
+++ b/.github/actions/compliance/verify_archive_size.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression guard for #671: refuse compliance-report tarballs above a
+# hard MB cap so a producer regression (e.g. build output packed into
+# the report) cannot ship an ~800 MB "compliance report" again.
+#
+# Usage:
+#   verify_archive_size.sh <archive-path> <max-mb>
+#
+# Behaviour:
+#   * Prints "compliance report size: N MB (B bytes) — cap: M MB" always.
+#   * Exits 0 if size <= cap (or cap == 0, which disables the guard).
+#   * Exits 1 with a ::error:: line otherwise.
+#   * When $GITHUB_STEP_SUMMARY is set, appends a size table.
+#
+# MB is decimal (1 MB = 1_000_000 bytes) to match release-asset UIs.
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "usage: $0 <archive-path> <max-mb>" >&2
+    exit 2
+fi
+
+ARCHIVE_PATH="$1"
+MAX_MB="$2"
+
+if [ ! -f "$ARCHIVE_PATH" ]; then
+    echo "::error::archive not found: ${ARCHIVE_PATH}" >&2
+    exit 2
+fi
+
+SIZE_BYTES=$(stat -c%s "$ARCHIVE_PATH" 2>/dev/null || stat -f%z "$ARCHIVE_PATH")
+SIZE_MB=$(( (SIZE_BYTES + 999999) / 1000000 ))
+echo "compliance report size: ${SIZE_MB} MB (${SIZE_BYTES} bytes) — cap: ${MAX_MB} MB"
+
+if [ "$MAX_MB" = "0" ]; then
+    echo "size guard disabled (max-archive-size-mb=0)"
+    exit 0
+fi
+
+MAX_BYTES=$(( MAX_MB * 1000000 ))
+if [ "$SIZE_BYTES" -gt "$MAX_BYTES" ]; then
+    echo "::error::compliance report is ${SIZE_MB} MB, exceeds ${MAX_MB} MB cap. \
+This is the #671 producer regression — the report is HTML + YAML + SVG \
+and should be single-digit MB. Check that build output (e.g. target/) \
+is not being packed into the report directory, then rerun. \
+If a multi-page report is intentional, raise \`max-archive-size-mb\` \
+on the calling workflow."
+    exit 1
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+        echo "### Compliance report size"
+        echo ""
+        echo "| Archive | Size | Cap |"
+        echo "| --- | --- | --- |"
+        echo "| \`$(basename "$ARCHIVE_PATH")\` | ${SIZE_MB} MB | ${MAX_MB} MB |"
+    } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/actions/compliance/verify_archive_size_test.sh
+++ b/.github/actions/compliance/verify_archive_size_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regression test for verify_archive_size.sh (#671 size guard).
+#
+# Coverage:
+#   1. Small archive under the cap -> exit 0.
+#   2. Archive over the cap -> exit 1 with #671 marker in message.
+#   3. Cap of 0 disables the guard (any size -> exit 0).
+#   4. Missing archive -> exit 2 (usage error).
+#   5. Reference report shape (~2 MB) sails well under the 50 MB default.
+#   6. GITHUB_STEP_SUMMARY is appended only on the pass path.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${HERE}/verify_archive_size.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+expect() {
+    local name="$1" expected_rc="$2"
+    shift 2
+    local out rc
+    out="$("$@" 2>&1)" && rc=0 || rc=$?
+    if [ "$rc" -eq "$expected_rc" ]; then
+        echo "  PASS: $name (rc=$rc)"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $name (rc=$rc, expected $expected_rc)"
+        # shellcheck disable=SC2001 # sed needed for per-line ^ anchor
+        echo "$out" | sed 's/^/    | /'
+        fail=$((fail + 1))
+    fi
+    LAST_OUT="$out"
+}
+
+# Case 1 — small archive under cap.
+head -c 1000000 /dev/zero > "$TMP/small.tar.gz"  # 1 MB
+GITHUB_STEP_SUMMARY="$TMP/summary1" expect "1MB under 50MB cap" 0 "$GUARD" "$TMP/small.tar.gz" 50
+grep -q "compliance report size: 1 MB" <<<"$LAST_OUT" || { echo "  FAIL: expected size line missing"; fail=$((fail + 1)); }
+[ -s "$TMP/summary1" ] || { echo "  FAIL: step summary not written on green"; fail=$((fail + 1)); }
+grep -q "1 MB" "$TMP/summary1" || { echo "  FAIL: step summary missing size"; fail=$((fail + 1)); }
+
+# Case 2 — archive over cap (simulate an 800 MB regression by capping tiny archive at 1 MB).
+head -c 5000000 /dev/zero > "$TMP/big.tar.gz"  # 5 MB
+GITHUB_STEP_SUMMARY="$TMP/summary2" expect "5MB over 1MB cap fails" 1 "$GUARD" "$TMP/big.tar.gz" 1
+grep -q "exceeds 1 MB cap" <<<"$LAST_OUT" || { echo "  FAIL: expected 'exceeds N MB cap' message"; fail=$((fail + 1)); }
+grep -q "#671" <<<"$LAST_OUT" || { echo "  FAIL: message must reference #671 for traceability"; fail=$((fail + 1)); }
+[ ! -s "$TMP/summary2" ] || { echo "  FAIL: step summary written on red (should skip)"; fail=$((fail + 1)); }
+
+# Case 3 — cap == 0 disables the guard.
+head -c 900000000 /dev/zero > "$TMP/huge.tar.gz"  # 900 MB (worst-case #671 shape).
+expect "cap=0 disables guard on 900MB archive" 0 "$GUARD" "$TMP/huge.tar.gz" 0
+grep -q "size guard disabled" <<<"$LAST_OUT" || { echo "  FAIL: expected disable notice"; fail=$((fail + 1)); }
+
+# Case 4 — missing archive is a usage error.
+expect "missing archive -> rc=2" 2 "$GUARD" "$TMP/does-not-exist.tar.gz" 50
+
+# Case 5 — reference report shape (v0.13.0+ ships 1-2 MB) sails under the 50 MB default.
+head -c 2000000 /dev/zero > "$TMP/ref.tar.gz"  # 2 MB
+expect "2MB reference report under 50MB default" 0 "$GUARD" "$TMP/ref.tar.gz" 50
+
+# Case 6 — bad-args usage error.
+expect "no args -> usage rc=2" 2 "$GUARD"
+
+echo
+echo "results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,11 @@ jobs:
           python-version: '3.12'
       - run: pip install yamllint
       - run: yamllint -c .yamllint.yaml schemas/ artifacts/ rivet.yaml .github/
+      # #671 regression coverage — the compliance-report size guard is a
+      # shell script exercised by a shell test; run it here (no compile
+      # cost) so a broken guard fails PRs early.
+      - name: Compliance report size-guard tests (#671)
+        run: bash .github/actions/compliance/verify_archive_size_test.sh
 
   # ── Schema version-bump advisory (#485) ───────────────────────────────
   # Warn (don't fail) when a PR changes a schema's rules but leaves its


### PR DESCRIPTION
## Summary

Scope: **Part A** of the #671 remediation (additive-only CI defense).

v0.4.x / v0.7-0.9 shipped ~800 MB compliance-report tarballs — a report is HTML + YAML + SVG and should be single-digit MB. The producer has since been fixed (v0.13.0+ is 1-2 MB), but nothing stopped the regression from recurring.

This PR adds a hard `max-archive-size-mb` cap on the compliance composite action:

- **Default 50 MB** — legit single-page reports are 1-5 MB, so the cap has ~10-50× headroom without touching multi-page callers who can raise it explicitly. `0` disables.
- Fails the job with a `::error::` line naming **#671** when the tarball exceeds the cap; the message points at the likely root cause (build output packed into the report directory) so an operator sees the shape immediately, not a bare exit code.
- Emits `compliance report size: N MB` and a step-summary table on green so a slow creep is visible **before** it trips the cap.
- Guard logic lives in `verify_archive_size.sh` (not inline YAML) so it is independently testable.

## Test plan

- [x] `bash .github/actions/compliance/verify_archive_size_test.sh` — 6/6 pass:
  1. 1 MB archive under 50 MB cap → exit 0, size printed, step-summary emitted.
  2. 5 MB archive over 1 MB cap → exit 1, message contains `exceeds 1 MB cap`, message contains `#671`, step-summary skipped.
  3. Cap of 0 disables guard even on a 900 MB archive → exit 0 with "size guard disabled" notice.
  4. Missing archive path → exit 2 (usage error).
  5. 2 MB reference-report shape (v0.13.0+ range) sails under the 50 MB default → exit 0.
  6. No args → exit 2 (usage error).
- [x] `shellcheck` clean on both scripts.
- [x] `yamllint` clean on `action.yml` + `ci.yml` (only pre-existing warnings on unrelated lines).
- [x] Regression test wired into the existing **yaml-lint** job so a broken guard fails PRs early — no compile cost added.
- [ ] Post-merge: next release run's `build-compliance` step should print `compliance report size: 1-2 MB` and emit the summary table (real-world verification the AC calls "operational verification").

## Acceptance-criteria mapping (Part A, from the #671 triage comment)

| AC bullet | How it is satisfied |
| --- | --- |
| Producer workflow grows a size gate immediately after the tarball is written; fail if > 50 MB; cap hard-coded in the workflow | New "Verify archive size (#671 regression guard)" step in `.github/actions/compliance/action.yml`. Default of 50 MB lives on the input. |
| Failure message prints actual size + threshold ("compliance report is 803 MB, exceeds 50 MB cap") | `verify_archive_size.sh` emits `compliance report is ${SIZE_MB} MB, exceeds ${MAX_MB} MB cap` with the `::error::` prefix. |
| Emit a summary line on green so slow creep is visible | Green path prints `compliance report size: N MB` **and** appends a `### Compliance report size` table to `$GITHUB_STEP_SUMMARY`. |
| Regression coverage: unit test / fixture packs a reference report and asserts < 50 MB | `verify_archive_size_test.sh` includes a 2 MB reference-shape case and 5 additional edge cases; wired into the yaml-lint job on every PR. |
| Commit trailers: `Trace: skip` + `Refs: #671` | Present on the commit. |
| Part A explicitly out-of-scope: modification of already-published release assets | This PR only adds CI-side code; no existing artifact is touched. |

## What's not in this PR

**Part B** — deleting the 7 stale ~800 MB assets on `v0.4.x` / `v0.7-0.9` release pages — is a public-facing, non-reversible action against tagged releases. Per the triage AC on the issue it needs an explicit "yes, delete these seven assets" comment from @avrabe before a deletion branch opens. Filing that as a separate PR keeps the blast radii separated.

Closes #671 (Part A)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — issue-triage routine run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZALij2Z78ciVz26KUkWfX)_