### PR TITLE
docs(release): record crates.io publishing decision + blocker (REQ-250, REQ-252, DD-074)

### DIFF
--- a/artifacts/decisions.yaml
+++ b/artifacts/decisions.yaml
@@ -1545,3 +1545,56 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-09T00:00:00Z
+
+  - id: DD-074
+    type: design-decision
+    title: Publish crates.io packages as rivet-sdlc-* with unchanged lib/bin names
+    status: proposed
+    description: >
+      REQ-250 (#557): to distribute rivet via crates.io the workspace crates
+      must be published, but the natural names are all taken by unrelated
+      authors — `rivet-core` (0.1.0), `rivet-cli` (0.17.0), `etch` (0.4.2) and
+      even `rivet` (0.1.0). Decision: publish under `rivet-sdlc-core`,
+      `rivet-sdlc-cli`, and `rivet-etch`, while KEEPING the in-tree/import names
+      via Cargo target renames — `[lib] name = "rivet_core"`, the etch lib name
+      `etch`, and `[[bin]] name = "rivet"`. Downstream `package =` renames on the
+      path deps preserve `use rivet_core::` / `use etch::` at every call site, so
+      the public-name change is confined to three Cargo.toml manifests with zero
+      source churn.
+    tags: [release, cratesio, packaging, naming]
+    links:
+      - type: satisfies
+        target: REQ-250
+    fields:
+      baseline: v0.25.0-track
+      source-ref: >
+        Decision only — no code change lands here. The mechanism is: rename the
+        packages in etch/Cargo.toml (name = rivet-etch, [lib] name = etch),
+        rivet-core/Cargo.toml (name = rivet-sdlc-core, [lib] name = rivet_core,
+        etch dep package rename), rivet-cli/Cargo.toml (name = rivet-sdlc-cli,
+        [[bin]] name = rivet, core + etch dep package renames), plus per-crate
+        crates.io metadata + README.md and a leaf-first release-crates.yml. That
+        rename is DEFERRED to the REQ-252 publish PR: it ripples through every
+        `-p rivet-cli` / `-p rivet-core` specifier across ci.yml, release.yml,
+        rivet-delta.yml, the compliance action, and scripts/*.sh (~40 sites), so
+        it must land atomically with the publish, not ahead of an
+        indefinitely-blocked one.
+      rationale: >
+        Keeping the lib and bin target names decouples the public crates.io
+        identity from the import surface: the binary users run is still `rivet`,
+        existing `use rivet_core::…` and `use etch::…` lines are untouched, and
+        only the crates.io package identity carries the `-sdlc-`/`rivet-`
+        disambiguating prefix. `rivet-sdlc-*` reads as "the rivet SDLC
+        traceability toolchain" and sidesteps the four squatted short names.
+      alternatives: >
+        (1) pulseengine-rivet-* org prefix — rejected: longer, and the org is
+        already implied by the repository field. (2) rivet-trace-* — rejected:
+        narrower than the tool's SDLC-wide scope. (3) Contact the existing
+        `rivet*`/`etch` owners to transfer names — rejected: slow, uncertain,
+        and out of our control. (4) Publish a reduced no-AADL core to dodge the
+        git-dep wall — rejected (see REQ-252): materially weaker than the shipped
+        binary, user-confusing.
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-07-10T00:00:00Z

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7701,12 +7701,21 @@ artifacts:
     type: requirement
     title: publish rivet to crates.io (currently npm-only)
     status: proposed
-    description: "Distribution is npm-only; add crates.io publishing to the release standard so `cargo install` works and the Rust ecosystem can depend on rivet-core. #557."
+    description: "Distribution is npm-only; add crates.io publishing to the release standard so `cargo install` works and the Rust ecosystem can depend on the core library. #557. Investigated in the v0.25 loop: the publish is BLOCKED on two independent walls, so no packaging code lands yet. (1) All natural crate names are squatted upstream (rivet-core, rivet-cli, etch, rivet) — resolved by the rivet-sdlc-* rename decided in DD-074, but that rename ripples through ~40 `-p <crate>` specifiers across CI + scripts so it is deferred to the publish PR to land atomically with the publish rather than ahead of an indefinitely-blocked one. (2) REQ-252: the dependency closure includes git-only crates (pulseengine/spar's 9 spar-* crates + a rowan fork) and crates.io forbids git deps transitively, so those must reach crates.io first. This requirement stays open (unassigned to a release) until REQ-252 clears and a CARGO_REGISTRY_TOKEN secret exists."
     provenance:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-01T00:00:00Z
-    release: v0.25.0
+
+  - id: REQ-252
+    type: requirement
+    title: publish the git-only dependency closure (spar + rowan fork) to crates.io
+    status: proposed
+    description: "Prerequisite for REQ-250. rivet-core's dependency closure pulls git-only crates that crates.io will not accept: the 9 pulseengine/spar crates (spar-hir, spar-hir-def, spar-base-db, spar-annex, spar-syntax, spar-parser, spar-analysis, spar-network, + facade) pinned at tag v0.10.0 via the default `aadl` feature, and the pulseengine/rowan fork (branch fix/miri-soundness-v3, 0.16.2) pulled by the default `rowan-yaml` parser — carrying a Stacked-Borrows soundness fix over upstream rowan 0.16.1. crates.io requires every transitive dep to be a published version (git deps are rejected even behind non-default features), so rivet cannot `cargo publish` until this closure is on crates.io. Scope: publish the spar toolchain from its own repo, and either upstream the rowan SB fix (so the published crate can depend on a crates.io rowan) or publish the fork under a distinct name. Cross-repo; larger than a single rivet release."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-07-10T00:00:00Z
 
   - id: REQ-251
     type: requirement


### PR DESCRIPTION
## What

Investigating crates.io publishing (REQ-250) hit two independent walls. Rather than land breaking packaging churn for a publish that's blocked indefinitely, this PR records the findings as **traceable artifacts only** — no code/CI changes, so the paths-filter fast-tracks it.

## The two walls

**1. All natural crate names are squatted** on crates.io by unrelated authors — `rivet-core`@0.1.0, `rivet-cli`@0.17.0, `etch`@0.4.2, `rivet`@0.1.0. Resolved by **DD-074**: publish as `rivet-sdlc-core` / `rivet-sdlc-cli` / `rivet-etch`, keeping `[lib]`/`[[bin]]` names so imports and the `rivet` binary are unchanged. **The rename is deferred to the publish PR** — it ripples through ~40 `-p rivet-cli` / `-p rivet-core` specifiers across `ci.yml`, `release.yml`, `rivet-delta.yml`, the compliance action, and scripts, so it must land *atomically with* the publish, not ahead of an indefinitely-blocked one.

**2. The dependency closure is git-only (REQ-252).** `rivet-core` pulls the 9 `pulseengine/spar` crates (via the default `aadl` feature) and a `rowan` fork (via `rowan-yaml`). crates.io forbids git deps transitively, even behind non-default features, so those must be published to crates.io first. Cross-repo, larger than one rivet release.

## Why artifact-only

The rename, per-crate metadata, READMEs, and `release-crates.yml` are all publish-time work with **zero value until REQ-252 clears** — and the rename actively risks breaking CI on every interim PR. So the durable deliverable of this investigation is the **decision + the blocker**, recorded traceably. The publish-facing code lands in the REQ-252 follow-through PR.

## Needs maintainer before REQ-250 can close

1. Clear REQ-252 (publish spar + rowan fork to crates.io) — or decide rivet stays npm-only and close REQ-250 won't-do.
2. Add a `CARGO_REGISTRY_TOKEN` repo secret.

## Verification

- `rivet validate` → **Result: PASS**
- `rivet docs check` → 0 violations

Refs: REQ-250, REQ-252, DD-074, FEAT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)