### PR TITLE
chore(release): v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,41 @@
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-10
+
+### Added
+- **Schema-aware LSP completion** (REQ-246, DD-071, #546) — the language server
+  now offers context-sensitive completions for artifact `type`, link `type`, and
+  field keys, driven by the active schema. First slice; enum-value and snippet
+  completion are follow-ons.
+- **Backend-unavailable banner on the dashboard** (REQ-245, #621) — when the
+  `rivet serve` backend is down, the browser view surfaces a clear banner instead
+  of silently serving stale or broken content.
+- **Per-result tracking links** (REQ-248, DD-072, #548) — test results can carry
+  links to the PRs / remote issues that produced them, and the dashboard renders
+  a Tracking column. Only `http`/`https` URLs become live links (XSS guard).
+- **Schema version pin drift warning** (REQ-249, DD-073, #431) — a project can
+  declare expected schema versions in `rivet.yaml :: project.schema-pins`;
+  `rivet validate` warns on stderr when a resolved embedded-schema version drifts
+  from its pin, catching silent-upgrade changes to validation semantics.
+
+### Changed
+- **crates.io publishing investigated; decision + blocker recorded** (REQ-250,
+  REQ-252, DD-074, #557). Publishing is blocked on two walls — the natural crate
+  names are squatted upstream (resolved by a deferred `rivet-sdlc-*` rename,
+  DD-074) and the dependency closure includes git-only crates (`pulseengine/spar`
+  + a `rowan` fork) that crates.io rejects transitively (REQ-252). No packaging
+  code lands until those clear; rivet remains npm-distributed for now.
+
 ### Fixed
+- **Security: crossbeam-epoch 0.9.18 → 0.9.20** (RUSTSEC-2026-0204).
+- **Security: quick-xml 0.37 → 0.41** (RUSTSEC-2026-0194, RUSTSEC-2026-0195).
+- **Serializer field-drop guard** (#634) — `mutate::render_artifact_yaml` is a
+  hand-rolled allowlist emitter; a compile-time exhaustiveness guard now fails
+  the build if an `Artifact` field is added without wiring it into the emitter,
+  so new fields can no longer be silently dropped on write.
+- **Cross-repo UnknownPrefix scoping** (#649) — `rivet validate` no longer flags
+  externally-owned link prefixes; the check is scoped to consumer-owned links.
 - **Embedded aspice schema is self-consistent** (#652). The
   `swe1-has-verification` coverage rule lists `unit-verification` and
   `sw-integration-verification` as `verifies` satisfiers for `sw-req`, but

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.24.0"
+version = "0.25.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -1186,7 +1186,7 @@ fn graph_focused_view_renders_svg() {
     assert!(
         body.contains("<svg"),
         "focused /graph must render SVG, got body starting with: {}",
-        &body.chars().take(200).collect::<String>()
+        body.chars().take(200).collect::<String>()
     );
 
     child.kill().ok();

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.25.0

Schema pins, test-result tracking links, schema-aware LSP completion, serve UX, two security bumps, and the crates.io publishing investigation.

### Added
- Schema-aware LSP completion (REQ-246, #546)
- Backend-unavailable dashboard banner (REQ-245, #621)
- Per-result tracking links (REQ-248, #548)
- Schema version pin drift warning (REQ-249, #431)

### Changed
- crates.io publishing investigated — decision (DD-074) + blocker (REQ-252) recorded; no packaging code lands (rivet stays npm-distributed)

### Fixed
- Security: crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204), quick-xml 0.41 (RUSTSEC-2026-0194/0195)
- Serializer field-drop guard (#634), UnknownPrefix scoping (#649), aspice schema self-consistency (#652)

### Falsification
The release claims each Added item is reachable from the shipped binary and each artifact's V is closed at its declared status. If any REQ-24x feature is absent from `main`'s code, or a claimed-merged PR's CI was `cancelled` rather than `success`, this release is falsified.

Version bumped across Cargo.toml, Cargo.lock (etch/rivet-core/rivet-cli), vscode-rivet/package.json. `rivet validate` → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)