### PR TITLE
ci(mutants): cap address space at 48 GiB so a runaway mutant can't OOM the host (#590)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,7 +639,17 @@ jobs:
         # each shard takes ~2x as long (was 12-20 min, now 20-40 min),
         # but the lean-mem pool stops needing emergency cgroup-ceiling
         # bumps every quarter.
-        run: cargo mutants -p ${{ matrix.crate }} --shard ${{ matrix.shard }} --timeout 30 --jobs 2 --output mutants-out -- --lib || true
+        # #590 memory guard: cap per-process virtual address space at 48 GiB
+        # (RLIMIT_AS) so a memory-runaway MUTANT — cargo-mutants can delete an
+        # allocation bound and produce a rivet_core test binary that allocates
+        # ~100 G in seconds, faster than the 30 s timeout — aborts with ENOMEM
+        # inside its own process instead of tripping the system-wide OOM-killer
+        # and taking down neighboring jobs on the shared lean-mem host. The
+        # `|| true` already records a clipped mutant as timeout/error, not a
+        # gate failure. Defense-in-depth alongside the infra cgroup MemoryMax.
+        run: |
+          ulimit -v 50331648
+          cargo mutants -p ${{ matrix.crate }} --shard ${{ matrix.shard }} --timeout 30 --jobs 2 --output mutants-out -- --lib || true
       - name: Check surviving mutants
         run: |
           MISSED=0
@@ -697,7 +707,13 @@ jobs:
           rm -rf mutants-out
           find target -maxdepth 2 -name 'mutants.out*' -mtime +1 -exec rm -rf {} + 2>/dev/null || true
       - name: Run cargo-mutants
-        run: cargo mutants -p rivet-cli --shard 0/1 --timeout 30 --jobs 2 --output mutants-out -- --lib || true
+        # #590 memory guard (see mutants-core above): cap address space at
+        # 48 GiB so a memory-runaway mutant aborts ENOMEM process-local instead
+        # of OOM-killing the shared host. `|| true` keeps a clipped mutant as
+        # error, not a gate failure.
+        run: |
+          ulimit -v 50331648
+          cargo mutants -p rivet-cli --shard 0/1 --timeout 30 --jobs 2 --output mutants-out -- --lib || true
       - name: Check surviving mutants
         run: |
           MISSED=0


### PR DESCRIPTION
## What

Adds `ulimit -v 50331648` (48 GiB `RLIMIT_AS`) before both `cargo mutants` invocations so a memory-runaway mutant aborts with ENOMEM inside its own process instead of tripping the **system-wide** OOM-killer and taking down neighboring jobs on the shared lean-mem host.

## Root cause (why there's no single "offending test" to bound)

#590's kernel OOM logs name `rivet_core-<hash>` — native test binaries — hitting 70–100 GB `anon-rss`. But every generator in rivet-core's test suite is tightly bounded (`1..10`, `0..1000`, `1..50`); no *real* test allocates that much. The culprit is **cargo-mutants**: a mutation can delete an allocation bound and produce a test binary that allocates ~100 G in seconds — faster than the 30 s per-mutant timeout — so the kernel OOM-killer fires before the timeout can clip it. The `ulimit` makes that abort process-local.

## Why not just merge #599

#599 had the same idea but its branch predates the mutation-matrix-to-nightly (#498/#504) and paths-filter (#664) ci.yml changes — merging it would revert 57 lines of later work. This re-applies the guard cleanly to current `main`. Closing #599 as superseded.

## Safety / coverage

`|| true` already records a clipped mutant as timeout/error, not a gate failure, so mutation coverage is unaffected. This is defense-in-depth alongside the infra-side cgroup `MemoryMax`.

If a *non-mutant* rivet_core OOM ever recurs (in the plain Test job), that'd be a separate real finding — but the evidence and #599's analysis both point to mutation-induced runaway.

Fixes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)