### PR TITLE
feat(serve): richer artifact filtering — tag + s-expression predicates (REQ-253)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7731,7 +7731,7 @@ artifacts:
   - id: REQ-253
     type: requirement
     title: "serve: richer artifact filtering (tags / field predicates / SQL), not just basic type+status"
-    status: proposed
+    status: implemented
     description: "#674. The serve dashboard only supports basic filtering (type/status). Users want to narrow by tag, by field predicate, and ideally by the full query surface rivet already has on the CLI. Reuse the existing engines rather than inventing a serve-only filter language: the s-expr filter used by `rivet list` (e.g. `(= status \"approved\")`, `(has-tag \"safety\")`) and/or the gluesql-backed `rivet sql` facade (REQ-229/231). Slice 1: tag + field-predicate filter in the artifacts view wired to the s-expr evaluator; a SQL-query box is a plausible slice 2. Must preserve the active variant scope on filter (see the existing ?variant= handling)."
     release: v0.26.0
     provenance:

--- a/rivet-cli/src/render/artifacts.rs
+++ b/rivet-cli/src/render/artifacts.rs
@@ -123,6 +123,46 @@ pub(crate) fn render_artifacts_list(ctx: &RenderContext, params: &ViewParams) ->
         .filter(|s| !s.trim().is_empty())
         .map(|s| s.trim().to_lowercase());
 
+    // Tag filter: comma-separated; an artifact must carry ALL listed
+    // tags. Compared case-insensitively (trimmed) for ergonomics, unlike
+    // the exact-case `(has-tag …)` s-expr predicate.
+    let tag_filter: Vec<String> = params
+        .tags
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| {
+            s.split(',')
+                .map(|t| t.trim().to_lowercase())
+                .filter(|t| !t.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // S-expression predicate filter (reuses the JSON API / `rivet list`
+    // evaluator). Parse once before iterating. On parse error we render a
+    // note and match nothing rather than silently ignoring the filter.
+    let raw_filter = params
+        .filter
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let (sexpr_filter, filter_error): (Option<rivet_core::sexpr_eval::Expr>, Option<String>) =
+        match raw_filter {
+            Some(f) => match rivet_core::sexpr_eval::parse_filter(f) {
+                Ok(expr) => (Some(expr), None),
+                Err(errs) => {
+                    let msg = errs
+                        .first()
+                        .map(|e| e.message.clone())
+                        .unwrap_or_else(|| "could not parse filter".to_string());
+                    (None, Some(msg))
+                }
+            },
+            None => (None, None),
+        };
+    // A filter that was supplied but failed to parse matches nothing.
+    let filter_supplied_but_invalid = raw_filter.is_some() && sexpr_filter.is_none();
+
     let sort_col = params.sort.as_deref().unwrap_or("id");
     let sort_desc = !params.sort_ascending();
     let per_page = params.items_per_page();
@@ -132,8 +172,24 @@ pub(crate) fn render_artifacts_list(ctx: &RenderContext, params: &ViewParams) ->
     let mut artifacts: Vec<_> = store
         .iter()
         .filter(|a| {
+            // A supplied-but-unparseable s-expr filter narrows to nothing.
+            if filter_supplied_but_invalid {
+                return false;
+            }
             if let Some(ref tf) = type_filter {
                 if !tf.contains(&a.artifact_type.to_lowercase()) {
+                    return false;
+                }
+            }
+            if !tag_filter.is_empty() {
+                let have: Vec<String> = a.tags.iter().map(|t| t.trim().to_lowercase()).collect();
+                if !tag_filter.iter().all(|want| have.contains(want)) {
+                    return false;
+                }
+            }
+            if let Some(ref expr) = sexpr_filter {
+                if !rivet_core::sexpr_eval::matches_filter_with_store(expr, a, ctx.graph, ctx.store)
+                {
                     return false;
                 }
             }
@@ -193,18 +249,34 @@ pub(crate) fn render_artifacts_list(ctx: &RenderContext, params: &ViewParams) ->
         "Search artifacts...",
         q_val,
         "/artifacts",
-        &["types", "sort", "dir", "per_page"],
+        &["types", "filter", "tags", "sort", "dir", "per_page"],
     ));
     html.push_str(&crate::serve::components::type_select(
         &all_types,
         types_val,
         "/artifacts",
-        &["q", "sort", "dir", "per_page"],
+        &["q", "filter", "tags", "sort", "dir", "per_page"],
     ));
     html.push_str(&crate::serve::components::per_page_select(
         per_page,
         "/artifacts",
-        &["q", "types", "sort", "dir"],
+        &["q", "types", "filter", "tags", "sort", "dir"],
+    ));
+    // S-expression predicate filter — same language as the JSON API's
+    // `filter=` param and `rivet list --filter` (REQ-253). Debounced keyup
+    // like the free-text search; `search` fires on native input clear.
+    let filter_val = params.filter.as_deref().unwrap_or("");
+    let filter_hx_include = "[name='q'],[name='types'],[name='tags'],[name='sort'],[name='dir'],[name='per_page'],#variant-selector";
+    html.push_str(&format!(
+        "<input type=\"text\" name=\"filter\" placeholder=\"{ph}\" value=\"{val}\" \
+         hx-get=\"/artifacts\" hx-target=\"#content\" hx-push-url=\"true\" \
+         hx-trigger=\"keyup changed delay:400ms, search\" hx-include=\"{inc}\" \
+         style=\"flex:1;min-width:240px;padding:.6rem .75rem;border:1px solid var(--border);\
+         border-radius:var(--radius-sm);font-size:.875rem;font-family:var(--font-mono,monospace);\
+         background:var(--surface);color:var(--text);outline:none\">",
+        ph = html_escape("(has-tag \"safety\") and (= status \"approved\")"),
+        val = html_escape(filter_val),
+        inc = filter_hx_include,
     ));
     html.push_str(&format!(
         "<input type=\"hidden\" name=\"sort\" value=\"{}\">",
@@ -214,7 +286,22 @@ pub(crate) fn render_artifacts_list(ctx: &RenderContext, params: &ViewParams) ->
         "<input type=\"hidden\" name=\"dir\" value=\"{}\">",
         html_escape(params.dir.as_deref().unwrap_or("asc")),
     ));
+    // Preserve the active `tags` param across the other toolbar controls
+    // (there is no visible tags input in slice 1; the s-expr filter's
+    // `(has-tag …)` covers interactive tag filtering).
+    html.push_str(&format!(
+        "<input type=\"hidden\" name=\"tags\" value=\"{}\">",
+        html_escape(params.tags.as_deref().unwrap_or("")),
+    ));
     html.push_str("</div>"); // form-row
+    // Inline note when the supplied s-expr filter failed to parse.
+    if let Some(ref msg) = filter_error {
+        html.push_str(&format!(
+            "<div class=\"badge badge-error\" style=\"margin-top:.5rem;display:inline-block\">\
+             invalid filter: {}</div>",
+            html_escape(msg),
+        ));
+    }
     html.push_str("</div>"); // filter-bar
 
     // Layout: sidebar + main table

--- a/rivet-cli/src/serve/components.rs
+++ b/rivet-cli/src/serve/components.rs
@@ -47,8 +47,14 @@ pub(crate) struct ViewParams {
     pub types: Option<String>,
     /// Status filter (e.g. "approved", "draft", "error", "warning").
     pub status: Option<String>,
-    /// Comma-separated tag filter.
+    /// Comma-separated tag filter. An artifact matches when it carries
+    /// ALL listed tags.
     pub tags: Option<String>,
+    /// S-expression predicate filter (same language as the JSON API's
+    /// `filter=` param and `rivet list --filter`), e.g.
+    /// `(and (= status "approved") (has-tag "safety"))`. Applied via
+    /// `rivet_core::sexpr_eval`.
+    pub filter: Option<String>,
     /// Free-text search query.
     pub q: Option<String>,
     /// Sort column name.
@@ -86,6 +92,11 @@ impl ViewParams {
         if let Some(ref v) = self.tags {
             if !v.is_empty() {
                 parts.push(format!("tags={}", urlencoding::encode(v)));
+            }
+        }
+        if let Some(ref v) = self.filter {
+            if !v.is_empty() {
+                parts.push(format!("filter={}", urlencoding::encode(v)));
             }
         }
         if let Some(ref v) = self.q {

--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -651,6 +651,55 @@ fn api_artifacts_filter_by_type() {
     child.wait().ok();
 }
 
+/// REQ-253: the HTML `/artifacts` view applies the s-expression predicate
+/// filter (same evaluator as the JSON API), narrowing to matching artifacts.
+#[test]
+fn artifacts_html_sexpr_filter_narrows_results() {
+    let (mut child, port) = start_server();
+
+    // `(has-tag "s-expression")` matches FEAT-106..108 (tagged s-expression)
+    // but not FEAT-110 (tagged variant). URL-encoded in the request line.
+    let (status, body, _headers) = fetch(
+        port,
+        "/artifacts?filter=%28has-tag%20%22s-expression%22%29&per_page=500",
+        false,
+    );
+    assert_eq!(status, 200);
+    assert!(
+        body.contains("FEAT-106"),
+        "s-expr filter (has-tag \"s-expression\") must include FEAT-106"
+    );
+    assert!(
+        !body.contains("FEAT-110"),
+        "s-expr filter (has-tag \"s-expression\") must exclude FEAT-110 (tagged variant)"
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
+/// REQ-253: the HTML `/artifacts` view applies the comma-separated `tags`
+/// param (an artifact must carry all listed tags).
+#[test]
+fn artifacts_html_tags_param_narrows_results() {
+    let (mut child, port) = start_server();
+
+    // tag `variant` matches FEAT-110..114 but not FEAT-106 (tagged s-expression).
+    let (status, body, _headers) = fetch(port, "/artifacts?tags=variant&per_page=500", false);
+    assert_eq!(status, 200);
+    assert!(
+        body.contains("FEAT-110"),
+        "tags=variant must include FEAT-110"
+    );
+    assert!(
+        !body.contains("FEAT-106"),
+        "tags=variant must exclude FEAT-106 (tagged s-expression, not variant)"
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
 #[test]
 fn api_artifacts_pagination() {
     let (mut child, port) = start_server();


### PR DESCRIPTION
## What

Surfaces richer filtering in the serve dashboard `/artifacts` view, **reusing rivet's existing query engine** rather than a serve-only filter language (#674).

- **`tags=`** — comma-separated; matches artifacts carrying *all* listed tags. (This was a `ViewParams` field that had never been applied in the list view.)
- **`filter=`** — a full **s-expression predicate**, the same language as the JSON API's `filter=` and `rivet list --filter`: `(has-tag "safety")`, `(= status "approved")`, `(and (= type "requirement") (has-tag "stpa"))`. Parsed with `rivet_core::sexpr_eval::parse_filter`, applied via `matches_filter_with_store` — so it **composes with the active variant scope**. An unparseable filter narrows to nothing and shows an inline error (no silent pass-through).

A filter text input is added to the artifacts toolbar (htmx, same debounce as the search box), and both `tags` and `filter` are threaded through `ViewParams::to_query_string` so they survive the type/status/sort/pagination controls — the same preservation guarantee as `?variant=`.

Backend note: the JSON API (`/api/v1/artifacts?filter=`) and SQL endpoint (`/api/v1/sql`) already existed; this closes the gap between the API and the HTML dashboard. A dashboard SQL-query box is a plausible slice 2.

## Verification

- Two new `serve_integration` tests — `artifacts_html_sexpr_filter_narrows_results`, `artifacts_html_tags_param_narrows_results` — both pass.
- Full build clean; `cargo clippy --all-targets -- -D warnings` on the **CI toolchain (Rust 1.97)** clean.
- `rivet validate` → PASS (REQ-253 → implemented).

Implements: REQ-253

🤖 Generated with [Claude Code](https://claude.com/claude-code)