### PR TITLE
chore(release): v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-07-11
+
+### Added
+- **Richer serve dashboard filtering** (REQ-253, #674) — the `/artifacts` view now
+  accepts a `tags=` filter (comma-separated; matches artifacts carrying all listed
+  tags) and a full **s-expression `filter=`** predicate — the same language as
+  `rivet list --filter` and the JSON API, e.g. `(has-tag "safety")`,
+  `(= status "approved")`, `(and (= type "requirement") (has-tag "stpa"))`. A
+  filter input is added to the toolbar; the filter composes with the active
+  variant scope and survives the type/status/sort/pagination controls. An
+  unparseable filter narrows to nothing with an inline error rather than passing
+  silently.
+- **`rivet release check --variant`** (REQ-254, DD-075, #673) — checks a release
+  against a variant's scope in one view: partitions release-tagged artifacts into
+  in-scope (release ∩ variant), out-of-scope (tagged but excluded by the variant),
+  and variant-only, then reports cuttability scoped to the intersection. Exits
+  non-zero when not cuttable, or under `--strict` when any artifact is out-of-scope.
+  The release-readiness predicate is now shared with `rivet release status` so the
+  two cannot drift.
+
+### Fixed
+- **Compliance-report tarball size guard** (#671) — the release compliance action
+  now fails if the produced tarball exceeds a hard MB cap (default 50 MB), so a
+  producer regression can't ship an ~800 MB "compliance report" again.
+- **cargo-mutants memory guard** (#590) — both mutation-testing jobs cap per-process
+  address space at 48 GiB (`ulimit -v`) so a memory-runaway mutant aborts ENOMEM
+  process-local instead of tripping the system-wide OOM-killer on shared runners.
+
 ## [0.25.0] - 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.26.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.26.0

Serve dashboard rich filtering, release-vs-variant checking, and two CI-reliability fixes.

### Added
- **Richer serve filtering** (REQ-253, #674) — `tags=` + s-expression `filter=` in the `/artifacts` view, reusing the `rivet list`/API evaluator
- **`rivet release check --variant`** (REQ-254, DD-075, #673) — release ∩ variant consistency (in/out/variant-only) + cuttability scoped to the intersection

### Fixed
- Compliance-report tarball size guard (#671)
- cargo-mutants address-space cap — no more shared-host OOM (#590)

### Falsification
Each Added item is reachable from the shipped binary and its artifact's V is closed at its declared status. If any REQ-253/254 behavior is absent from `main`, or a claimed-merged PR's CI was `cancelled` not `success`, this release is falsified.

Version bumped across Cargo.toml, Cargo.lock (etch/rivet-core/rivet-cli), vscode-rivet/package.json. `rivet validate` → PASS, `docs check` → 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)