### PR TITLE
plan: REQ-255 — ingest ordeal certificates as re-checkable evidence (rivet#693)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7749,3 +7749,13 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-11T00:00:00Z
+
+  - id: REQ-255
+    type: requirement
+    title: "ingest ordeal certificates as re-checkable evidence artifacts (certified variant consistency)"
+    status: proposed
+    description: "rivet#693 / ordeal#67 (FEAT-011, the certificate-as-evidence spine). rivet's variant/release consistency check (REQ-254, `rivet release check --variant`) decides consistency but emits no certificate, while EU AI Act Art. 12 / DO-178C / ISO 26262 audits demand per-configuration re-checkable trace evidence. Two parts: (1) define an `ordeal-certificate` evidence artifact type — carries the certificate blob (or content-addressed pointer + hash), the transform it attests, the standard(s) satisfied, and a `recheck` command/hash so `rivet validate` treats a re-checked certificate as a verification link, not a claimed status; generalizes across the toolchain (loom/synth/sigil/spar/gale). (2) a `--certify` hook on `rivet release check --variant` / `rivet variant solve` that shells the resolved feature model + config to ordeal's propositional-SAT front-end and emits the cert.recheck()-able artifact. BLOCKED-BY ordeal#67: the SAT front-end + a stable certificate serialization must exist first. Part (1) schema design can be co-designed now against ordeal's proposed serialization; part (2) waits on ordeal#67 shipping (ordeal v0.13.0). Needs a design decision before implementation."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-07-11T00:00:00Z


### PR DESCRIPTION
Files the rivet-side requirement for **rivet#693 / ordeal#67** (FEAT-011, certificate-as-evidence).

- **Part 1** — an `ordeal-certificate` evidence artifact type; `rivet validate` treats a re-checked certificate as a verification link. Co-designable now against ordeal's serialization.
- **Part 2** — a `--certify` hook on `rivet release check --variant` (the REQ-254 seam shipped in v0.26.0) that shells the resolved model to ordeal's SAT front-end.

**Blocked-by ordeal#67** (SAT front-end + cert serialization). Artifact-only; `rivet validate` + `docs check` PASS.

Refs: REQ-255

🤖 Generated with [Claude Code](https://claude.com/claude-code)