### PR TITLE
docs(variant): canonical feature-model attributes documentation (REQ-264, #546)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7820,7 +7820,7 @@ artifacts:
   - id: REQ-264
     type: requirement
     title: "canonical feature-model attributes documentation — disambiguate attribute-schema vs attributes"
-    status: proposed
+    status: implemented
     description: "P2 docs (DD-076), the review's trigger. The word 'attribute' does triple duty with zero reference coverage: attribute-schema: (top-level TYPE DECLARATIONS, feature_model.rs:70), per-feature attributes: (the VALUES, :128), and a design-doc PHANTOM variant-config attributes: (never implemented). docs/feature-model-schema.md never mentions attributes at all; getting-started.md:1060 calls them 'typed' though they are untyped without a schema; docs/pure-variants-comparison.md frames the SHIPPED attribute-schema: as an unbuilt 'Gap/Remediation'; the design doc mixes shipped reality with never-built proposals (variant-config attributes:, fields-per-variant:) unlabeled. There is NO `documentation` field (a phantom the colleagues confused for real). Deliver: a canonical attributes section in feature-model-schema.md disambiguating the two real mechanisms + a worked example threading schema+typed-attrs+variant+bindings; relabel design/comparison docs shipped-vs-proposed; document `required:` + accepted type synonyms (bool/boolean, int/integer, float/double, string/str); fix the stale file:line citations."
     release: v0.27.0
     provenance: {created-by: ai-assisted, model: claude-opus-4-8, timestamp: 2026-07-15T00:00:00Z}

--- a/docs/design/variant-aware-properties.md
+++ b/docs/design/variant-aware-properties.md
@@ -1,6 +1,15 @@
 # Variant-Aware Properties on Requirements
 
-Status: design report, draft.
+> **This is a design/exploration note, not the reference.** For the
+> shipped, canonical spec of feature-model attributes and per-variant
+> field overrides, see
+> [`feature-model-schema.md`](../feature-model-schema.md). This document
+> records the design space that led to those features; where it proposes
+> shapes, they are labelled **SHIPPED** or **NOT IMPLEMENTED** inline.
+
+Status: design report. Its two headline proposals have since diverged:
+option A (`fields-per-variant:` on artifacts) **shipped** as issue #255;
+the variant-config `attributes:` shape (option D) was **not implemented**.
 Audience: rivet maintainers; future SAT/SMT solver authors; safety
 auditors evaluating rivet's variant story.
 Date: 2026-04-27.
@@ -75,20 +84,22 @@ tool that produces it from a maintained-once source.
 What rivet's data model commits to right now:
 
 - `Artifact.fields: BTreeMap<String, serde_yaml::Value>` — the
-  field map is variant-blind. There is one slot per field name.
-  (`rivet-core/src/model.rs:131`)
+  default field map. **Update:** since this doc was drafted, `Artifact`
+  also gained `fields_per_variant` (option A below shipped as #255).
+  (`Artifact` in `rivet-core/src/model.rs`)
 - `FeatureBinding.bindings[feature].artifacts: Vec<String>` — features
   bind to artifact *IDs*, not field-level slots.
-  (`rivet-core/src/feature_model.rs:213`)
+  (`struct FeatureBinding` in `rivet-core/src/feature_model.rs`)
 - `SourceEntry.when: Option<String>` — *source globs* can carry a
   per-variant `when:` predicate (Gap 5 in the PV comparison). This is
-  the only existing per-variant-value mechanism in rivet, and it
+  one existing per-variant-value mechanism in rivet, and it
   proves the predicate plumbing is already in place.
-  (`rivet-core/src/feature_model.rs:243`)
+  (`struct SourceEntry` in `rivet-core/src/feature_model.rs`)
 - `attribute-schema:` on the feature model gives typed feature
   attributes (`AttributeKind::{Bool, Int, Float, Str, Enum}`), but
-  again these live on the *feature*, not the artifact field.
-  (`rivet-core/src/feature_model.rs:87`)
+  these live on the *feature*, not the artifact field. **This is
+  shipped** — see [`feature-model-schema.md`](../feature-model-schema.md).
+  (`struct AttributeTypeDecl` in `rivet-core/src/feature_model.rs`)
 - `rivet variant solve / value / attr / verify-config` operate on
   `ResolvedVariant` — a flat selected feature set plus per-feature
   origins and source manifest. There is no
@@ -231,7 +242,14 @@ Five candidate shapes. I score each on
 **(T) traceability preservation**, **(A) AI-tool friendliness**,
 **(F) audit-friendliness**.
 
-### A. Field overrides per variant — `fields-per-variant:`
+### A. Field overrides per variant — `fields-per-variant:` — **SHIPPED (#255)**
+
+> **Status: implemented.** This is the option that was built.
+> `Artifact.fields_per_variant` deserializes from a `fields-per-variant:`
+> YAML block, `Artifact::fields_for_variant(Some(name))` returns the
+> merged (default-overlaid-by-variant) view, and `rivet validate
+> --variant <name>` validates the merged view (`validate_with_variant`).
+> The description below is the original proposal; it matches what shipped.
 
 ```yaml
 - id: REQ-THERMAL-01
@@ -317,7 +335,14 @@ artifact, linked back to a parent abstract requirement.
 
 This is the no-design option. Including it for completeness; rejected.
 
-### D. Reference into variant attributes — `max-temp-c: "$variant.max-temp-c"`
+### D. Reference into variant attributes — `max-temp-c: "$variant.max-temp-c"` — **NOT IMPLEMENTED**
+
+> **Status: not implemented.** This shape relies on a `VariantConfig`
+> carrying an `attributes:` map. It does not: a `VariantConfig` is
+> `{ name, selects }` only (`struct VariantConfig` in
+> `rivet-core/src/feature_model.rs`). There is no `$variant.X` resolver
+> and no variant-config `attributes:` block. Treat the YAML below as
+> design-only.
 
 The values live on the **variant config** (or on a feature attribute);
 the artifact field references them.
@@ -378,6 +403,13 @@ artifact with the variants it applies to, and filter at render time.
 Rejected. Too disruptive.
 
 ## 5. Recommendation
+
+> **Outcome: option A was adopted and shipped (#255).** The subsections
+> below are the original design detail. `fields-per-variant:` on
+> artifacts, the merged-view resolver, and variant-aware `validate` are
+> in the shipped product; the remaining items (option B expressions,
+> predicate-keyed overrides, exhaustiveness checks, ReqIF explode) remain
+> unbuilt design.
 
 **Adopt option A as the v1 mechanism, with a forward-compatible
 escape hatch into option B for advanced cases.**

--- a/docs/feature-model-schema.md
+++ b/docs/feature-model-schema.md
@@ -134,6 +134,205 @@ constraints:
   - (implies adas (or asil-b asil-c asil-d))
 ```
 
+### Feature attributes
+
+Features can carry key/value **attributes** — for example an ISO 26262
+numeric rating on each safety level, or the market-compliance standard on
+each market. This subsection is the canonical reference for how attributes
+are declared, typed, and validated.
+
+> **There is no `documentation` field.** A `Feature` in rivet is exactly
+> `{ name, group, children, parent, attributes }` and nothing else
+> (`rivet-core/src/feature_model.rs`, `struct Feature`). Free-form
+> descriptive text is not a first-class feature field. If you want to
+> attach a human-readable note to a feature, add it as a *string
+> attribute* (e.g. `attributes: { note: "…" }`) — there is no separate
+> documentation slot.
+
+#### The word "attribute" means two different things
+
+Two distinct YAML keys both use the word "attribute", at two different
+levels. Keeping them apart is the single most important thing to
+understand:
+
+| Key                 | Level                 | Holds            | Purpose                                                              |
+| ------------------- | --------------------- | ---------------- | ------------------------------------------------------------------- |
+| `attribute-schema:` | **top-level** (once)  | TYPE declarations | Declares the *type* (and optional range / enum / required-ness) of each attribute key. |
+| `attributes:`       | **per-feature**       | VALUES           | The actual key/value data attached to one feature.                  |
+
+`attribute-schema:` is optional and appears at most once, at the top level
+of the model file next to `root:` and `features:`. `attributes:` appears
+inside any `features[name]` entry. The schema names a key *once* and
+constrains it everywhere; each feature supplies its own values.
+
+> A third variant — an `attributes:` block on a **variant configuration**
+> — appears in some design notes but is **not implemented**. A
+> `VariantConfig` is `{ name, selects }` only. See
+> [design/variant-aware-properties.md](design/variant-aware-properties.md)
+> for what is and isn't shipped.
+
+#### `attribute-schema:` — type declarations (top-level, optional)
+
+Each entry under `attribute-schema:` is keyed by attribute name and
+declares its type:
+
+| Field      | Type                 | Applies to         | Meaning                                                          |
+| ---------- | -------------------- | ------------------ | --------------------------------------------------------------- |
+| `type`     | string               | all                | One of the type kinds below. Required.                          |
+| `range`    | `[lo, hi]`           | `int`, `float`     | Inclusive numeric bounds. Optional.                             |
+| `values`   | `[v1, v2, …]`        | `enum`             | The allowed string values. Required for `enum`.                 |
+| `required` | bool (default false) | all                | When `true`, the attribute must be present on **every feature** in the model; a missing value is a hard error. |
+
+Accepted type kinds — each with its synonyms (both spellings are
+accepted; see `build_attribute_decl` in `feature_model.rs`):
+
+| `type:` value        | Accepts                          | Extra fields          |
+| -------------------- | -------------------------------- | --------------------- |
+| `bool` / `boolean`   | YAML boolean                     | —                     |
+| `int` / `integer`    | YAML integer                     | optional `range: [lo, hi]` |
+| `float` / `double`   | YAML number                      | optional `range: [lo, hi]` |
+| `string` / `str`     | YAML string                      | —                     |
+| `enum`               | a string equal to one of `values` | required `values: [..]` |
+
+```yaml
+attribute-schema:
+  asil-numeric:
+    type: int
+    range: [0, 4]
+  reqs:
+    type: string
+  compliance:
+    type: enum
+    values: [unece-r157, fmvss-127, gb-7258]
+```
+
+#### `attributes:` — values (per-feature)
+
+A feature attaches values under its own `attributes:` map. Values are kept
+as raw YAML, so a feature can carry strings, integers, booleans, or small
+sub-maps:
+
+```yaml
+features:
+  asil-c:
+    group: leaf
+    attributes:
+      asil-numeric: 3
+      reqs: "fmea-dfa"
+```
+
+Attribute values are looked up by `rivet variant attr FEATURE KEY` and are
+consumed by the variant emitters when producing build-system output.
+
+#### Typed only when a schema is declared
+
+Validation of attribute values runs **only when an `attribute-schema:` is
+present**. This validation happens at load time, *before* the tree is
+structurally validated.
+
+- **No `attribute-schema:`** — `attributes:` are entirely free-form and
+  untyped. A YAML string and a YAML integer are both accepted in the same
+  slot; nothing is range- or enum-checked.
+- **With an `attribute-schema:`** — for every feature, each attribute
+  whose key appears in the schema is checked: type match, `range` bounds,
+  `enum` membership, and `required:` presence. A mismatch is a **hard
+  error**. An attribute key that is *not* declared in the schema produces
+  a **warning** (not an error), so new keys can be introduced before the
+  schema is updated.
+
+#### Worked example: schema + attributes + variant + bindings
+
+This is the real, working example in
+[`examples/variant/`](../examples/variant/). It threads all four pieces
+together: a typed `attribute-schema:`, per-feature `attributes:`, a
+variant configuration, and a binding model.
+
+`feature-model.yaml` (typed attributes on a FODA tree):
+
+```yaml
+kind: feature-model
+root: vehicle-platform
+
+attribute-schema:
+  asil-numeric: { type: int, range: [0, 4] }
+  reqs:         { type: string }
+  compliance:   { type: enum, values: [unece-r157, fmvss-127, gb-7258] }
+  locale:       { type: string }
+
+features:
+  vehicle-platform:
+    group: mandatory
+    children: [market, safety-level, feature-set]
+
+  market:
+    group: alternative
+    children: [eu, us, cn]
+  eu:
+    group: leaf
+    attributes: { compliance: "unece-r157", locale: "en_EU" }
+  us:
+    group: leaf
+    attributes: { compliance: "fmvss-127", locale: "en_US" }
+  cn:
+    group: leaf
+    attributes: { compliance: "gb-7258", locale: "zh_CN" }
+
+  safety-level:
+    group: alternative
+    children: [qm, asil-a, asil-b, asil-c, asil-d]
+  asil-c:
+    group: leaf
+    attributes: { asil-numeric: 3, reqs: "fmea-dfa" }
+  asil-d:
+    group: leaf
+    attributes: { asil-numeric: 4, reqs: "fmea-dfa-fta" }
+  # … qm, asil-a, asil-b likewise carry asil-numeric + reqs …
+
+  feature-set:
+    group: or
+    children: [base, adas, autonomous]
+  adas:
+    group: mandatory
+    children: [lane-keeping, adaptive-cruise, pedestrian-detection]
+  # … remaining features omitted for brevity …
+
+constraints:
+  - (implies eu pedestrian-detection)
+  - (implies adas (or asil-b asil-c asil-d))
+```
+
+A **variant configuration** picks a leaf on each alternative axis
+(`eu-adas-c.yaml`):
+
+```yaml
+name: eu-adas-c
+selects: [eu, adas, asil-c]
+```
+
+A **binding model** ties features (including the attribute-bearing `eu`
+and `asil-c`) to artifacts and source (`bindings.yaml`):
+
+```yaml
+bindings:
+  pedestrian-detection:
+    artifacts: [REQ-042, REQ-043]
+    source: ["src/perception/pedestrian/**"]
+  eu:
+    artifacts: [REQ-200]
+  asil-c:
+    artifacts: [REQ-101]
+```
+
+Resolving the variant selects `eu`, `adas`, `asil-c` (plus their
+ancestors, mandatory descendants, and constraint-implied features), and
+the emitter carries each selected feature's typed attributes — e.g.
+`asil-c` contributes `asil-numeric: 3` — into the build configuration:
+
+```sh
+rivet variant solve --model feature-model.yaml \
+  --variant eu-adas-c.yaml --binding bindings.yaml
+```
+
 ## 2. Variant configuration
 
 A user-level selection against a feature model.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1057,8 +1057,12 @@ rivet variant attr   --model fm.yaml --variant v.yaml asil-c asil-numeric
 
 ### Feature attributes
 
-Each feature may declare an `attributes:` map — typed key/value metadata
-that a release script can turn into build-system configuration. Example:
+Each feature may declare an `attributes:` map — key/value metadata that a
+release script can turn into build-system configuration. Attributes are
+free-form (untyped) unless the model declares a top-level
+`attribute-schema:`, which type-checks them at load time; see
+[feature-model-schema.md](feature-model-schema.md#feature-attributes) for
+the reference. Example:
 
 ```yaml
 # feature-model.yaml (excerpt)

--- a/docs/pure-variants-comparison.md
+++ b/docs/pure-variants-comparison.md
@@ -8,6 +8,13 @@ tags: [research, comparison, variant, feature-model, pure-variants]
 
 # Rivet vs pure::variants — Feature Framework Comparison
 
+> **This is a comparison/research note, not the reference.** For the
+> shipped, canonical spec of feature-model attributes (`attribute-schema:`
+> and per-feature `attributes:`), see
+> [`feature-model-schema.md`](feature-model-schema.md). The "Gap" list
+> below was written against the v0.4.3 baseline; **Gap 1 (typed feature
+> attributes) has since shipped** and is relabelled accordingly.
+
 Status: research report, v0.4.3 baseline.
 Scope: Rivet's `rivet-core/src/feature_model.rs` + `variant_emit.rs` + the
 `rivet variant *` CLI commands, compared against the pure::variants User
@@ -66,7 +73,8 @@ update/merge loop (§5.10 line 1610).
 
 ## 1. Feature Model Semantics
 
-Rivet declares five group types (`rivet-core/src/feature_model.rs:82`):
+Rivet declares five group types (`enum GroupType` in
+`rivet-core/src/feature_model.rs`):
 
 | Rivet | PV analogue (§10.3 line 6314) | Notes |
 |-------|-------------------------------|-------|
@@ -79,8 +87,8 @@ Rivet declares five group types (`rivet-core/src/feature_model.rs:82`):
 PV supports **range-bounded cardinality** on `ps:alternative` and
 `ps:or` groups (line 6335 — "although this can be changed using range
 expressions"). Rivet's `Alternative` is hard-coded to exactly-one
-(`feature_model.rs:548-560`) and `Or` is hard-coded to at-least-one
-(`feature_model.rs:562-568`). There is no way in Rivet to say "select
+and `Or` is hard-coded to at-least-one (the group-cardinality checks in
+`solve`, `feature_model.rs`). There is no way in Rivet to say "select
 exactly 2-of-3 sensors" or "at most 1 of these optional diagnostics".
 
 **PV exclusion constraint:** PV forbids having both an `ps:or` and
@@ -88,7 +96,7 @@ exactly 2-of-3 sensors" or "at most 1 of these optional diagnostics".
 allows only one ps:or group for the same parent element."). Rivet's
 tree schema allows one group type per feature, so the constraint is
 structurally honoured but not checked by `validate_tree`
-(`feature_model.rs:322`).
+(`feature_model.rs`).
 
 ## 2. Attribute Types
 
@@ -103,14 +111,15 @@ required value) or **non-fixed** (default, overridable), can be
 determine which value from a list of candidate values wins (§5.8 line
 1488 — first-value-with-true-restriction semantics).
 
-Rivet's attributes (`feature_model.rs:78`) are
-`BTreeMap<String, serde_yaml::Value>`. They have **no declared types**
+Rivet's per-feature attributes (`Feature.attributes` in
+`feature_model.rs`) are a `BTreeMap<String, serde_yaml::Value>`. Absent
+an `attribute-schema:` they have **no declared types**
 (a YAML integer and a YAML string are silently acceptable in the same
 slot), no collection flavour (list vs set), no restriction machinery,
 no default/fixed distinction, and no cross-attribute references
 (PV's `ps:feature` type allows an attribute to point at another
 feature; the solver resolves the reference). The emitter
-(`variant_emit.rs:114`) accepts only scalars and errors loudly on
+(`emit` in `variant_emit.rs`) accepts only scalars and errors loudly on
 maps/sequences for every non-JSON format — deliberately loud, but the
 root problem is that the schema never committed to a type.
 
@@ -159,7 +168,7 @@ What Rivet's constraints **cannot** express:
 - `LET` or named sub-expressions.
 - User-defined functions / macros (`DEF`).
 - Iterators over a feature's *children* (`forall` is artifact-scoped).
-- Three-valued logic — `eval_constraint` (`feature_model.rs:707`)
+- Three-valued logic — `eval_constraint` (`feature_model.rs:1592`)
   defaults unknown expression shapes to `true`, which is the opposite
   of PV's behaviour (open = not-yet-decided).
 - Cardinality at the group level inside a constraint (e.g.
@@ -256,7 +265,7 @@ actual source code: the Family Model enumerates parts and source
 elements; their restrictions reference features from the FM.
 
 Rivet's closest analogue is `bindings.yaml`
-(`feature_model.rs:152-167`):
+(`struct FeatureBinding` in `feature_model.rs`):
 ```yaml
 bindings:
   pedestrian-detection:
@@ -289,7 +298,7 @@ PV VDM inheritance (§5.7 line 1295) supports:
 - Four error rules (line 1342): conflicting selects, conflicting
   attribute values, missing inherited VDM, self-inheritance.
 
-**Rivet: no inheritance.** A `VariantConfig` (`feature_model.rs:101`)
+**Rivet: no inheritance.** A `VariantConfig` (`feature_model.rs:151`)
 is
 ```rust
 pub struct VariantConfig { name: String, selects: Vec<String> }
@@ -312,36 +321,46 @@ is a defect waiting to surface at a later release.
 Ordered by user impact for safety-critical variants. Each gap has a
 concrete remediation path.
 
-### Gap 1 — Typed Feature Attributes
+### Gap 1 — Typed Feature Attributes — **SHIPPED**
 
-**Description.** Rivet attributes are
-`BTreeMap<String, serde_yaml::Value>` (feature_model.rs:78). There is
-no declared type per attribute key, no cross-feature checks, no
-constraint that `asil-numeric` is an integer 0..=4.
+> **Status: implemented.** The remediation below was built. Rivet now
+> accepts an optional top-level `attribute-schema:` section that
+> type-checks every feature attribute at load time. See
+> [`feature-model-schema.md` → Feature attributes](feature-model-schema.md#feature-attributes)
+> for the canonical reference. The rest of this entry is the original
+> gap analysis, retained for history.
+
+**Description (v0.4.3).** Rivet attributes were an untyped
+`BTreeMap<String, serde_yaml::Value>` (`Feature.attributes` in
+`feature_model.rs`). There was no declared type per attribute key, no
+cross-feature checks, no constraint that `asil-numeric` is an integer
+0..=4.
 
 **User impact.** Attribute values leak into every emitted format;
 wrong type = wrong `-D` / `#define` / `set(... VAR ...)` in
 downstream builds. For safety audits, attribute provenance and
-type-correctness need to be machine-checkable. Today they are not.
+type-correctness need to be machine-checkable.
 
-**Remediation.** Introduce an optional per-feature-model
-`attribute-schema:` section with keys like
+**Remediation — DONE.** An optional per-feature-model
+`attribute-schema:` section, with keys like
 ```yaml
 attribute-schema:
   asil-numeric: { type: int, range: [0, 4] }
   compliance:   { type: enum, values: [unece-r157, fmvss-127, gb-7258] }
 ```
-Parsed in `feature_model.rs::from_yaml` around line 250, stored on
-`FeatureModel`, validated after `validate_tree` at line 375. The
-emitter (`variant_emit.rs:114`) consumes the schema instead of
-duck-typing the YAML node.
+It is parsed in `FeatureModel::from_yaml` (via `from_yaml_struct` /
+`build_attribute_decl`), stored on `FeatureModel.attribute_schema`, and
+validated at load time **before** `validate_tree` runs. Accepted type
+kinds are `bool`/`boolean`, `int`/`integer`, `float`/`double`,
+`string`/`str`, and `enum`, plus a `required:` flag. Type / range / enum
+/ missing-required mismatches are hard errors; undeclared keys warn.
 
 ### Gap 2 — Partial Configuration / Three-Valued Logic
 
-**Description.** `solve` (feature_model.rs:430) is all-or-nothing —
+**Description.** `solve` (feature_model.rs:1227) is all-or-nothing —
 features are either in `effective_features` or not. PV's
 three-valued `open` state (§5.8.2 line 1447) is absent. `eval_constraint`
-(feature_model.rs:707) silently treats unknown shapes as `true`; a
+(feature_model.rs:1592) silently treats unknown shapes as `true`; a
 partial solver would treat them as `open`.
 
 **User impact.** Cannot model "150% configurations" (product-line
@@ -355,11 +374,11 @@ one. New `solve_partial` returning
 `BTreeMap<String, FeatureState>` instead of `BTreeSet<String>`. Keep
 the existing `solve` as `solve_full` (full-configuration mode) for
 back-compat. New location: fresh `solve_partial` function next to
-`solve` at feature_model.rs:430.
+`solve` at feature_model.rs:1227.
 
 ### Gap 3 — Variant Description Inheritance
 
-**Description.** `VariantConfig` (feature_model.rs:101) has no
+**Description.** `VariantConfig` (feature_model.rs:151) has no
 `extends` field. Each variant repeats its full select list.
 
 **User impact.** Products with shared baselines drift; ASIL-D variants
@@ -379,12 +398,12 @@ pub struct VariantConfig {
 Plus `resolve_inheritance` that topologically sorts the `extends` DAG,
 detects cycles, unions `selects`, unions `deselects`, errors on
 conflict per PV rules (§5.7.1 line 1342). Location: new function in
-`feature_model.rs`, called by `solve` before propagation at line 446.
+`feature_model.rs`, called by `solve` before propagation.
 
 ### Gap 4 — Group Cardinality Ranges
 
 **Description.** Rivet's `Alternative` is hard-coded to exactly-1
-(feature_model.rs:548) and `Or` to at-least-1 (line 562). PV
+(the group-cardinality checks in `solve`, feature_model.rs) and `Or` to at-least-1. PV
 range expressions on groups (line 6335) allow `[2..3]`,
 `[1..]`, `[..2]` etc.
 
@@ -397,14 +416,14 @@ group semantics and complicates error messages.
 `GroupType::Or` with `GroupType::Cardinality { min: usize, max:
 Option<usize> }`. Keep YAML shortcuts: `group: alternative` maps to
 `{min:1, max:Some(1)}`, `group: or` to `{min:1, max:None}`. Add a
-`group: [2, 3]` tuple syntax. Validation at feature_model.rs:357 must
+`group: [2, 3]` tuple syntax. Validation in `validate_tree` (feature_model.rs) must
 learn the new shape. New `SolveError::CardinalityViolation { parent,
 selected, min, max }`.
 
 ### Gap 5 — Family-Model-Level Artifact Restrictions
 
 **Description.** `bindings.yaml` maps each feature to a static list of
-source globs (feature_model.rs:152). There is no per-source restriction
+source globs (`Binding.source` in feature_model.rs). There is no per-source restriction
 expression; a file is either always in scope for a feature or never.
 
 **User impact.** Cannot express "`src/perception/pedestrian/**` is
@@ -423,7 +442,7 @@ pub struct SourceEntry {
     #[serde(default)] when: Option<String>,  // s-expr constraint
 }
 ```
-`solve` (feature_model.rs:430) evaluates each `when` expression against
+`solve` (feature_model.rs:1227) evaluates each `when` expression against
 the resolved selection and emits an expanded `BTreeMap<String, Vec<PathBuf>>`
 on the `ResolvedVariant`. The emitter can then produce a manifest
 (`--format manifest`) listing exactly which files participate in the


### PR DESCRIPTION
## What (P2 of the variant-hardening review, DD-076)

Disambiguates the "attribute" overload that confused contributors. **There is no `documentation` field** — the confusion is the word "attribute" doing triple duty.

- **`docs/feature-model-schema.md`** — new canonical "Feature attributes" section: states no `documentation` field exists (`Feature = {name,group,children,parent,attributes}`); a table separating top-level **`attribute-schema:`** (type declarations) from per-feature **`attributes:`** (values); `required:` + accepted type kinds/synonyms; the "typed only when a schema is declared, else free-form" rule; one worked example threading schema+attrs+variant+bindings (from the real `examples/variant/` files).
- **`docs/design/variant-aware-properties.md`** + **`docs/pure-variants-comparison.md`** — banner marking them design/comparison notes (not the reference); `attribute-schema:` relabelled **SHIPPED** (was framed as an unbuilt Gap); the phantom variant-config `attributes:` marked **NOT IMPLEMENTED**; stale `file:line` cites corrected/softened. Also corrected: **`fields-per-variant:` is actually SHIPPED** (#255), not a never-built proposal.
- **`docs/getting-started.md`** — the misleading "typed key/value metadata" line corrected to free-form-unless-schema.

## Verification
`rivet docs check` → 0 violations; `rivet validate` → PASS.

Implements: REQ-264 · Refs: DD-076

🤖 Generated with [Claude Code](https://claude.com/claude-code)