### PR TITLE
chore(release): v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-07-15
+
+### Added
+- **LSP enum-value + base-key completion** (REQ-256, #546) — the language server
+  completes a field's allowed values from the schema (e.g. `status:` →
+  draft/proposed/…/accepted, sourced from `schema.base_fields`, never hardcoded)
+  and the base artifact keys (id/type/title/status/tags/links/fields) at the
+  artifact top level.
+
+### Fixed (variant hardening — a 4-persona review, DD-076: fail-loud over silent-pass)
+- **Constraints fail loud** (REQ-257) — a feature-model constraint using a
+  predicate the solver can't evaluate (e.g. `(> asil-numeric 2)`) previously
+  *silently passed*; `solve()` now emits `SolveError::UnevaluatableConstraint`
+  instead of a vacuous success.
+- **Binding + constraint linkage is validated** (REQ-258, REQ-259) —
+  `rivet validate --model --binding` now errors on a binding that maps a feature
+  to a **nonexistent artifact ID**, and a constraint referencing a **feature name
+  not in the model** now errors instead of being vacuously satisfied. Also fixes
+  the committed-broken `artifacts/variants/full-desktop.yaml` (it selected
+  features absent from the model) and widens the model's `scope` group so a
+  composite CLI+dashboard variant is expressible.
+- **`modify --set-field` colon-space corruption** (#687) — values are now quoted
+  so a `key: value`-style field value no longer corrupts the YAML on write.
+
+### Docs
+- **Canonical feature-model attributes documentation** (REQ-264, #546) —
+  disambiguates the "attribute" overload (top-level `attribute-schema:` type
+  declarations vs per-feature `attributes:` values), documents that there is no
+  `documentation` field, and relabels the design/comparison docs shipped-vs-proposed.
+
 ## [0.26.0] - 2026-07-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.27.0 — variant hardening + LSP completion

### Added
- LSP enum-value + base-key completion (REQ-256, #546)

### Fixed (variant hardening — DD-076, fail-loud over silent-pass)
- Constraints fail loud on unevaluatable predicates (REQ-257)
- Binding/constraint linkage validated — dangling artifact IDs + unknown feature names error; fixed the committed-broken `full-desktop.yaml` (REQ-258/259)
- `modify --set-field` colon-space corruption (#687)

### Docs
- Canonical feature-model attributes documentation (REQ-264)

### Falsification
Each variant-hardening claim is backed by a fail-loud test (unevaluatable constraint, dangling artifact ID, unknown constraint feature) + the full 62-core/35-cli variant suite passing. If any of REQ-256/257/258/259/264 is absent from `main`, or a claimed-merged PR's CI was `cancelled`, this release is falsified.

Version bumped across Cargo.toml/lock (etch/rivet-core/rivet-cli) + vscode-rivet. `rivet validate` PASS, `docs check` 0 violations.

**Note:** the repo-wide nightly jobs (Miri/Coverage/Kani) are currently red on a nightly rustc ICE (unrelated to this release) — the core gates are the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)