### PR TITLE
ci(toolchain): pin nightly to 2026-07-11 while upstream nightly ICEs (REQ-267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
       # rustc_ast/src/attr/mod.rs), reddening those jobs and masking the Miri UB
       # signal. The pin keeps them ENFORCING on a working compiler. UNPIN back
       # to @nightly once a newer nightly no longer ICEs (retry periodically).
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # SHA-pinned (REQ-267); dated toolchain in `with:` below
         with:
           toolchain: nightly-2026-07-11
       - uses: Swatinem/rust-cache@v2
@@ -486,7 +486,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # SHA-pinned (REQ-267); dated toolchain in `with:` below
         with:
           toolchain: nightly-2026-07-11
           components: miri
@@ -524,7 +524,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # SHA-pinned (REQ-267); dated toolchain in `with:` below
         with:
           toolchain: nightly-2026-07-11
           components: miri
@@ -755,7 +755,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # SHA-pinned (REQ-267); dated toolchain in `with:` below
         with:
           toolchain: nightly-2026-07-11
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,9 @@ jobs:
       # rustc_ast/src/attr/mod.rs), reddening those jobs and masking the Miri UB
       # signal. The pin keeps them ENFORCING on a working compiler. UNPIN back
       # to @nightly once a newer nightly no longer ICEs (retry periodically).
-      - uses: dtolnay/rust-toolchain@nightly-2026-07-11
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-07-11
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -484,8 +486,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly-2026-07-11
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-07-11
           components: miri
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
@@ -521,8 +524,9 @@ jobs:
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly-2026-07-11
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-07-11
           components: miri
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
@@ -751,7 +755,9 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly-2026-07-11
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-07-11
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,7 +437,13 @@ jobs:
     runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      # REQ-267: nightly pinned to 2026-07-11 (last known-good) across every
+      # nightly job (this Coverage job + both Miri jobs + Fuzz). Nightlies from
+      # 2026-07-14 on ICE the compiler while building rivet-core (rustc panic in
+      # rustc_ast/src/attr/mod.rs), reddening those jobs and masking the Miri UB
+      # signal. The pin keeps them ENFORCING on a working compiler. UNPIN back
+      # to @nightly once a newer nightly no longer ICEs (retry periodically).
+      - uses: dtolnay/rust-toolchain@nightly-2026-07-11
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -478,7 +484,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly-2026-07-11
         with:
           components: miri
       - uses: Swatinem/rust-cache@v2
@@ -515,7 +521,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, lean-mem]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly-2026-07-11
         with:
           components: miri
       - uses: Swatinem/rust-cache@v2
@@ -745,7 +751,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly-2026-07-11
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7851,3 +7851,13 @@ artifacts:
     description: "P4 (DD-076). rivet-core/tests/proptest_feature_model.rs:142 hard-codes `constraints: vec![]`, so every fuzzed model is constraint-free — the highest-risk code (eval_constraint's _ => true fallback, implies propagation, excludes, cross-tree assertions) has zero property-test coverage. Add proptest strategies that generate constraints so REQ-257's fail-loud behaviour and the solver's constraint handling are fuzzed. Also add coverage for the shared-child/duplicate-child mis-reported-as-cycle case (feature_model.rs:884-894 last-writer-wins parent + :1129-1134 BFS)."
     release: v0.28.0
     provenance: {created-by: ai-assisted, model: claude-opus-4-8, timestamp: 2026-07-15T00:00:00Z}
+
+  - id: REQ-267
+    type: requirement
+    title: "pin CI nightly toolchain to a known-good date while upstream nightly ICEs"
+    status: implemented
+    description: "CI health. The Miri (safety + full), Code Coverage, and Fuzz jobs use `dtolnay/rust-toolchain@nightly` (unpinned → latest). Nightlies from 2026-07-14 ICE the compiler while building rivet-core (rustc panic in rustc_ast/src/attr/mod.rs, exit 104), reddening every nightly job repo-wide and masking the Miri UB/safety signal — while the core gates (Test/Clippy/Format) stayed green, so main was healthy but CI read red. Pin all four to nightly-2026-07-11 (the last run where Miri passed on main) so they keep ENFORCING on a working compiler. Not a versioned release (CI-config only, shipped binary unchanged). Unpin to @nightly once a newer nightly stops ICEing. Kani's exit-143 failures are a separate runner-shutdown flake, not this ICE."
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-07-15T00:00:00Z


### PR DESCRIPTION
## What

Pins the four `dtolnay/rust-toolchain@nightly` uses (Code Coverage, Miri safety-surface, Miri full, Fuzz) to **`@nightly-2026-07-11`** — the last main run where the Miri job passed.

## Why

Nightlies from **2026-07-14** onward ICE the compiler building `rivet-core` (`rustc panic at rustc_ast/src/attr/mod.rs`, exit 104), reddening every nightly job repo-wide and **masking the Miri UB/safety signal**. The core gates (Test/Clippy/Format) stayed green — so main was healthy, but every PR's CI read red and had to `--admin`-merge past the cluster. Pinning keeps these jobs **enforcing on a working compiler** instead of disabling them.

Unpin back to `@nightly` once a newer nightly stops ICEing (retry periodically). Kani's exit-143 failures are a *separate* runner-shutdown flake, untouched here.

**CI-config only — no version bump** (shipped binary unchanged).

Expected effect: Miri (safety) + Code Coverage go green on this PR; Kani may still show exit-143 (unrelated infra).

Refs: REQ-267

🤖 Generated with [Claude Code](https://claude.com/claude-code)