### PR TITLE
fix(variant): surface feature-model attribute_warnings on the CLI (REQ-261)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7807,7 +7807,7 @@ artifacts:
   - id: REQ-261
     type: requirement
     title: "surface attribute_warnings (unknown feature-attribute keys) via validate/--strict"
-    status: proposed
+    status: implemented
     description: "P1 silent-drop (DD-076). FeatureModel.attribute_warnings (feature_model.rs:71-75, populated :942) documents 'callers can surface these via --strict or log them on every load' but NO rivet-cli/rivet-mcp caller reads it (only rivet-core unit tests). A misspelled attribute key bypasses type/range checking AND its warning is dropped — bad input, green load. Wire attribute_warnings to `rivet validate` output and/or a --strict flag that fails on them."
     release: v0.28.0
     provenance: {created-by: ai-assisted, model: claude-opus-4-8, timestamp: 2026-07-15T00:00:00Z}

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -5568,9 +5568,17 @@ fn cmd_validate(
     //     name becomes the active overlay key applied via
     //     `validate_variants` on top of the default-view validation.
     //   nothing : ordinary project validation.
+    // REQ-261 / DD-076: attribute warnings from the loaded feature model
+    // (unknown attribute keys) are always surfaced on stderr by
+    // `load_feature_model_via_project`; when `--strict-variants` is set we
+    // additionally fold them into the run's Error diagnostics so the
+    // validate exit code is non-zero. Captured here from whichever
+    // model-bearing arm loads the model.
+    let mut model_attribute_warnings: Vec<String> = Vec::new();
     let (store, graph, variant_scope_name) = match (model_path, variant_path, binding_path) {
         (Some(mp), Some(vp), Some(bp)) => {
             let fm = load_feature_model_via_project(mp)?;
+            model_attribute_warnings = fm.attribute_warnings.clone();
 
             let variant_yaml = std::fs::read_to_string(vp)
                 .with_context(|| format!("reading variant config {}", vp.display()))?;
@@ -5615,6 +5623,7 @@ fn cmd_validate(
             // without resolving a specific variant. Unknown feature names in
             // the binding file are reported as errors.
             let fm = load_feature_model_via_project(mp)?;
+            model_attribute_warnings = fm.attribute_warnings.clone();
 
             let binding_yaml = std::fs::read_to_string(bp)
                 .with_context(|| format!("reading binding {}", bp.display()))?;
@@ -5784,6 +5793,23 @@ fn cmd_validate(
             strict_variants,
         );
         diagnostics.extend(variant_diags);
+    }
+
+    // REQ-261 / DD-076: `--strict-variants` escalates feature-model attribute
+    // warnings (unknown attribute keys, which silently bypass the
+    // type/range/enum audit) to hard errors. They are always emitted on
+    // stderr by the loader; here we additionally fold them into the Error
+    // diagnostic set so `rivet validate --model … --binding … --strict-variants`
+    // exits non-zero.
+    if strict_variants {
+        for w in &model_attribute_warnings {
+            diagnostics.push(validate::Diagnostic::new(
+                Severity::Error,
+                None,
+                "feature-model-attribute",
+                format!("feature-model attribute: {w}"),
+            ));
+        }
     }
 
     // Cited-source validation (Phase 1: kind: file backend).
@@ -14300,8 +14326,19 @@ fn load_feature_model_via_project(
     model_path: &std::path::Path,
 ) -> anyhow::Result<rivet_core::feature_model::FeatureModel> {
     let externals = project_externals_map_for(model_path);
-    rivet_core::feature_model::FeatureModel::load_with_externals(model_path, &externals)
-        .map_err(|e| anyhow::anyhow!("{e}"))
+    let fm = rivet_core::feature_model::FeatureModel::load_with_externals(model_path, &externals)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    // REQ-261 / DD-076: `attribute_warnings` (unknown feature-attribute keys
+    // that thereby bypass the type/range/enum audit) were collected by
+    // `FeatureModel::load` but never surfaced by any CLI path — a typo'd key
+    // like `asil-numric: 3` was silently dropped. Every CLI feature-model
+    // consumer funnels through this loader, so emit them here once, on stderr
+    // (keeping `--format json` on stdout clean). `validate --strict-variants`
+    // additionally escalates them to hard errors at its call site.
+    for w in &fm.attribute_warnings {
+        eprintln!("warning: feature-model attribute: {w}");
+    }
+    Ok(fm)
 }
 
 /// Walk up from `model_path` looking for a `rivet.yaml`; if found, load

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -8153,3 +8153,151 @@ fn next_id_skips_ids_burned_in_git_history() {
         "tree-only id must be below the burned id; got {bare}"
     );
 }
+
+// ── REQ-261: feature-model attribute_warnings surfaced by validate ──────────
+// rivet: verifies REQ-261
+
+/// Scaffold a project whose feature-model declares an `attribute-schema:` and
+/// a per-feature `attributes:` map carrying ONE unknown key (`asil-numric`, a
+/// typo of `asil-numeric`). That unknown key bypasses the type/range audit and
+/// populates `FeatureModel::attribute_warnings`. Returns the project dir.
+fn write_attribute_warning_project(unknown_key: bool) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    assert!(
+        Command::new(rivet_bin())
+            .args(["init", "--preset", "dev", "--dir", dirs])
+            .output()
+            .expect("init")
+            .status
+            .success()
+    );
+
+    // `compliance` is declared + valid; the typo'd `asil-numric` is only
+    // present in the unknown-key variant of the fixture.
+    let unit_attrs = if unknown_key {
+        "    attributes:\n      compliance: unece-r157\n      asil-numric: 3\n"
+    } else {
+        "    attributes:\n      compliance: unece-r157\n"
+    };
+    let model = format!(
+        "kind: feature-model\nroot: app\nattribute-schema:\n  \
+         compliance:\n    type: enum\n    values: [unece-r157]\nfeatures:\n  \
+         app:\n    group: mandatory\n    children: [unit]\n  \
+         unit:\n    group: leaf\n{unit_attrs}"
+    );
+    std::fs::write(dir.join("artifacts/feature-model.yaml"), model).unwrap();
+    // Empty bindings keep the model+binding path clean of unknown-feature /
+    // dangling-artifact errors, isolating the attribute-warning behaviour.
+    std::fs::write(dir.join("artifacts/bindings.yaml"), "bindings: {}\n").unwrap();
+    tmp
+}
+
+/// (a) A model with an unknown attribute key surfaces a `warning:`-prefixed
+/// line on stderr through `validate --model … --binding …`, and still exits 0
+/// (the load succeeded; the warning is advisory without `--strict-variants`).
+#[test]
+fn validate_model_binding_surfaces_attribute_warning_on_stderr() {
+    let tmp = write_attribute_warning_project(true);
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "validate",
+            "--model",
+            dir.join("artifacts/feature-model.yaml").to_str().unwrap(),
+            "--binding",
+            dir.join("artifacts/bindings.yaml").to_str().unwrap(),
+        ])
+        .output()
+        .expect("validate --model --binding");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("warning: feature-model attribute:") && stderr.contains("asil-numric"),
+        "unknown attribute key must be surfaced on stderr; stderr:\n{stderr}"
+    );
+    // Advisory only: exit 0.
+    assert!(
+        out.status.success(),
+        "without --strict-variants the attribute warning must not fail the run; \
+         stdout:\n{}\nstderr:\n{stderr}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+/// (b) `--strict-variants` escalates the attribute warning to a hard error, so
+/// the run exits non-zero.
+#[test]
+fn validate_strict_variants_escalates_attribute_warning_to_error() {
+    let tmp = write_attribute_warning_project(true);
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "validate",
+            "--model",
+            dir.join("artifacts/feature-model.yaml").to_str().unwrap(),
+            "--binding",
+            dir.join("artifacts/bindings.yaml").to_str().unwrap(),
+            "--strict-variants",
+        ])
+        .output()
+        .expect("validate --strict-variants");
+
+    assert!(
+        !out.status.success(),
+        "--strict-variants must fail the run when the model has attribute warnings; \
+         stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("asil-numric"),
+        "the failing run must still name the offending key; stderr:\n{stderr}"
+    );
+}
+
+/// (c) Regression: a model whose every attribute key IS declared produces no
+/// attribute warning and passes clean (exit 0, no `feature-model attribute`
+/// line on stderr) even under `--strict-variants`.
+#[test]
+fn validate_known_attributes_only_produces_no_warning() {
+    let tmp = write_attribute_warning_project(false);
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "validate",
+            "--model",
+            dir.join("artifacts/feature-model.yaml").to_str().unwrap(),
+            "--binding",
+            dir.join("artifacts/bindings.yaml").to_str().unwrap(),
+            "--strict-variants",
+        ])
+        .output()
+        .expect("validate known-only --strict-variants");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("feature-model attribute:"),
+        "a model with only declared attribute keys must emit no attribute warning; \
+         stderr:\n{stderr}"
+    );
+    assert!(
+        out.status.success(),
+        "known-only attributes must pass even under --strict-variants; stdout:\n{}\nstderr:\n{stderr}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}


### PR DESCRIPTION
## What (v0.28 slice 2 — variant P1 silent-drops, DD-076)

`FeatureModel.attribute_warnings` (unknown feature-attribute keys) was collected at load but **never surfaced by any CLI path** — a typo'd attribute key silently bypassed type/range checking *and* dropped its warning.

- Emit warnings from the single shared loader `load_feature_model_via_project`, so **every** consumer (`validate --model --binding`, `release check --variant`, `variant solve/check/check-all/features`) prints `warning: feature-model attribute: <msg>` on **stderr** (stdout `--format json` stays clean).
- `rivet validate --strict-variants` escalates them to `Severity::Error` diagnostics → non-zero exit (matches the existing strict-variant mechanism).

## Verification
- 3 new tests: `validate_model_binding_surfaces_attribute_warning_on_stderr`, `validate_strict_variants_escalates_attribute_warning_to_error`, `validate_known_attributes_only_produces_no_warning` — pass; full validate/variant sweep 30 pass.
- Build clean; `cargo clippy --all-targets -- -D warnings` on **Rust 1.97** clean; fresh-binary `rivet validate` PASS.

Implements: REQ-261 · Refs: DD-076

🤖 Generated with [Claude Code](https://claude.com/claude-code)