### PR TITLE
ci(variant): gate PRs on variant + binding soundness (REQ-263)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,31 @@ jobs:
       # above `--fail-on` (default: error).
       - name: rivet validate (fail on errors)
         run: cargo run --release -p rivet-cli -- validate
+      # Gate 1b (REQ-263): the project's own variants + bindings must be sound.
+      # Every artifacts/variants/*.yaml must solve against the feature model
+      # (catches a broken variant like the once-committed full-desktop.yaml,
+      # which selected features absent from the model), and the binding must
+      # reference real features + real artifact IDs with no unknown-attribute
+      # warnings (REQ-258/259/261, --strict-variants). Reuses the binary the
+      # validate step above already built, so no extra compile.
+      - name: rivet variant + binding validation (REQ-263)
+        run: |
+          set -euo pipefail
+          model=artifacts/feature-model.yaml
+          if [ ! -f "$model" ]; then
+            echo "no $model — skipping variant gate"; exit 0
+          fi
+          shopt -s nullglob
+          for v in artifacts/variants/*.yaml artifacts/variants/*.yml; do
+            echo "::group::variant check $v"
+            cargo run --release -q -p rivet-cli -- variant check --model "$model" --variant "$v"
+            echo "::endgroup::"
+          done
+          if [ -f artifacts/bindings.yaml ]; then
+            echo "::group::binding validation (artifact IDs + feature names + attribute keys)"
+            cargo run --release -q -p rivet-cli -- validate --model "$model" --binding artifacts/bindings.yaml --strict-variants
+            echo "::endgroup::"
+          fi
       # Gate 2: no ORPHAN commits and no BROKEN trailer refs introduced by
       # THIS PR. Scoped to the PR's own commits (base..HEAD). NOT `--strict`,
       # which promotes whole-store "artifact has no commit coverage" findings

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7823,7 +7823,7 @@ artifacts:
   - id: REQ-263
     type: requirement
     title: "CI gate: run variant check-all + binding validation so broken variants can't ship"
-    status: proposed
+    status: implemented
     description: "P1 (DD-076). No local or CI gate exercises variant bindings; plain `rivet validate` is binding-unaware; the repo's own artifacts/variants/full-desktop.yaml is committed broken (proof nothing runs it). Add a ci.yml gate that runs `rivet variant check-all` (and, once REQ-258/259 land, the binding-artifact validation) over the project's variants, failing the PR on a nonsensical variant/binding."
     release: v0.28.0
     provenance: {created-by: ai-assisted, model: claude-opus-4-8, timestamp: 2026-07-15T00:00:00Z}


### PR DESCRIPTION
## What (v0.28 slice 3 — final variant P1, DD-076)

No CI gate exercised the project's variants/bindings — the committed-broken `full-desktop.yaml` shipped because nothing ran it. Adds a step to the existing **Traceability** job (reuses the binary the `validate` step already built — no extra compile):

- **`rivet variant check --model --variant`** on every `artifacts/variants/*.yaml` — fails on `UnknownFeature`, unsolvable configs, etc.
- **`rivet validate --model --binding --strict-variants`** on `artifacts/bindings.yaml` — dangling artifact IDs (REQ-258), unknown constraint feature names (REQ-259), and unknown attribute keys (REQ-261) all fail here.

`set -euo pipefail` ⇒ any broken variant/binding fails the PR. Runs on **every** PR (Traceability isn't paths-gated), so breakage can't slip through a non-Rust change.

## Verification
Ran the gate's exact commands locally with a fresh binary: all 3 variants + the binding validation exit 0 on the current (fixed) repo; a broken variant exits 1 (per the earlier review). `ci.yml` parses.

**This completes v0.28** (REQ-260/261/262/263) — the variant-hardening P1 silent-drops. Next: cut v0.28.0.

Refs: REQ-263, REQ-258/259/261, DD-076

🤖 Generated with [Claude Code](https://claude.com/claude-code)