### PR TITLE
chore(release): v0.28.0 — variant hardening P1 (silent-drops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-07-16
+
+### Fixed (variant hardening P1 — DD-076: broken config must fail loud, not present as absent)
+- **`serve` variant discovery surfaces parse errors** (REQ-260) — a malformed,
+  cyclic, or attribute-invalid feature model (or binding) used to be `.ok()`-
+  swallowed into `model: None`, so `resolve()` reported "no feature model
+  configured for this project" — actively misleading, since the model exists but
+  is broken. The dashboard now renders a red "Feature model failed to load" banner
+  with the parse diagnostic instead of presenting a broken config as an absent one.
+- **Unknown feature-attribute keys reach `validate`** (REQ-261) —
+  `FeatureModel.attribute_warnings` (a misspelled `attributes:` key that bypasses
+  type/range checking) was populated but no CLI/MCP caller read it. `rivet validate
+  --model --binding` now emits these on stderr, and `--strict-variants` escalates
+  them to a nonzero exit — bad input no longer produces a green load.
+- **`serve` accepts the wrapped variant shape** (REQ-262) — variant discovery
+  parsed only the flat `VariantConfig` shape, so an init-scaffolded `variant:`-
+  wrapped file (the shape `rivet variant init` writes, #514) was silently invisible
+  in the dashboard. Discovery now uses `VariantConfig::from_yaml_str` + `load`, so
+  wrapped variants and composed feature-model-binding files are both honored.
+
+### Added
+- **CI variant + binding gate** (REQ-263) — the Traceability job now runs
+  `rivet variant check` over every `artifacts/variants/*.yaml` and
+  `rivet validate --model --binding --strict-variants` on the project's bindings,
+  failing the PR on a nonsensical variant or a binding that maps a feature to a
+  nonexistent artifact ID. No broken variant can ship again (the repo's own
+  `full-desktop.yaml` was committed broken precisely because nothing ran it).
+
 ## [0.27.0] - 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.28.0 — variant hardening P1 (silent-drops)

Release-prep for **v0.28.0**. Bumps `[workspace.package]`, `Cargo.lock`, and the
VS Code extension to `0.28.0`, and adds the CHANGELOG section.

### Scope (DD-076: a broken config must fail loud, not present as absent)
All four requirements are `implemented` on main:

| REQ | What shipped |
|-----|--------------|
| REQ-260 | `serve` variant discovery surfaces parse errors instead of `.ok()`-swallowing a broken model into a misleading "no model configured"; red dashboard banner. |
| REQ-261 | Unknown feature-attribute keys (`attribute_warnings`) now reach `rivet validate` on stderr; `--strict-variants` escalates to a nonzero exit. |
| REQ-262 | `serve` accepts the `variant:`-wrapped shape (regression of #514 on the serve path); wrapped + composed binding files honored. |
| REQ-263 | CI Traceability job gates PRs on `variant check` + binding validation, so a broken variant/binding can no longer ship. |

### Self-verify (fresh 0.28.0 binary)
- `cargo build --release` — OK
- `rivet validate` — **PASS**
- `rivet docs check` — **PASS** (0 violations; VersionConsistency clean)

### Falsification statement
If a feature model, binding, or variant file in this repo is malformed,
references a nonexistent artifact ID, uses an unevaluatable constraint predicate,
or carries an unknown attribute key, then CI (or `serve`/`validate --strict-variants`)
must report it — a broken config can no longer render as an absent or green one.
Verified by the REQ-263 gate running over the repo's own `artifacts/variants/*`.

Next: signed `v0.28.0` tag → release.yml + release-npm.yml → verify GitHub assets + npm.

Refs: REQ-260, REQ-261, REQ-262, REQ-263, DD-076

🤖 Generated with [Claude Code](https://claude.com/claude-code)
