### PR TITLE
fix(feature-model): don't mis-report a shared child as a cycle (REQ-269)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7876,7 +7876,7 @@ artifacts:
   - id: REQ-269
     type: requirement
     title: "feature-model validate_tree mis-reports a shared child (diamond/DAG) as a cycle"
-    status: proposed
+    status: implemented
     description: "Surfaced by REQ-266 coverage. FeatureModel::from_yaml -> validate_tree() detects cycles with a BFS that inserts each node into a global `visited` set on dequeue and errors if a node is seen twice (rivet-core/src/feature_model.rs ~1129). A feature reachable through two parents (a diamond: root->a, root->b, a->shared, b->shared) is enqueued from BOTH parents, dequeued twice, and wrongly reported as `cycle detected involving feature shared` — even though it is an acyclic DAG. Real feature models legitimately share a child (a common sub-feature under two optional branches). Fix: detect genuine cycles via the current DFS/BFS PATH (recursion stack), not global-visited-as-cycle; a node already fully visited on a different path is a shared child, not a cycle. The parent link is separately last-writer-wins (~888-892) which is acceptable, but the traversal must not treat re-encounter as a cycle. Regression test exists (ignored): rivet-core/tests/proptest_feature_model.rs::diamond_shared_child_is_not_a_cycle — un-ignore when fixed. Composition core touches the wasm seam, so verify `cargo build -p rivet-cli --features wasm` after the fix."
     release: v0.29.0
     provenance:

--- a/rivet-core/src/feature_model.rs
+++ b/rivet-core/src/feature_model.rs
@@ -42,7 +42,7 @@
     clippy::print_stderr
 )]
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -1121,25 +1121,53 @@ impl FeatureModel {
             )));
         }
 
-        // Cycle detection via BFS from root, tracking visited.
+        // Cycle detection via iterative DFS, tracking the current path (the
+        // recursion stack) separately from fully-explored nodes.
+        //
+        // A feature re-encountered while still ON the current path is a
+        // genuine cycle (a back edge — a feature that is its own ancestor).
+        // A feature reached again by a second, disjoint path — a shared
+        // child / diamond, e.g. `root -> {a, b}` and `a -> shared`,
+        // `b -> shared` — is a legal DAG edge, NOT a cycle: it is skipped
+        // once fully explored. The previous BFS used a single global
+        // `visited` set and reported every second encounter as a cycle,
+        // so it mis-flagged any shared child (REQ-269).
+        enum Step {
+            Enter(String),
+            Leave(String),
+        }
         let mut visited = BTreeSet::new();
-        let mut queue = VecDeque::new();
-        queue.push_back(self.root.clone());
+        let mut on_path: BTreeSet<String> = BTreeSet::new();
+        let mut stack: Vec<Step> = vec![Step::Enter(self.root.clone())];
 
-        while let Some(name) = queue.pop_front() {
-            if !visited.insert(name.clone()) {
-                return Err(Error::Schema(format!(
-                    "cycle detected involving feature `{name}`"
-                )));
-            }
-            if let Some(f) = self.features.get(&name) {
-                for child in &f.children {
-                    if !self.features.contains_key(child) {
+        while let Some(step) = stack.pop() {
+            match step {
+                Step::Leave(name) => {
+                    on_path.remove(&name);
+                }
+                Step::Enter(name) => {
+                    if on_path.contains(&name) {
                         return Err(Error::Schema(format!(
-                            "feature `{name}` references unknown child `{child}`"
+                            "cycle detected involving feature `{name}`"
                         )));
                     }
-                    queue.push_back(child.clone());
+                    // Already fully explored via another path — a shared
+                    // child (diamond), not a cycle. Skip re-traversal.
+                    if !visited.insert(name.clone()) {
+                        continue;
+                    }
+                    on_path.insert(name.clone());
+                    stack.push(Step::Leave(name.clone()));
+                    if let Some(f) = self.features.get(&name) {
+                        for child in &f.children {
+                            if !self.features.contains_key(child) {
+                                return Err(Error::Schema(format!(
+                                    "feature `{name}` references unknown child `{child}`"
+                                )));
+                            }
+                            stack.push(Step::Enter(child.clone()));
+                        }
+                    }
                 }
             }
         }
@@ -2045,6 +2073,42 @@ constraints: []
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(msg.contains("cycle"), "expected cycle error, got: {msg}");
+    }
+
+    #[test]
+    fn validate_tree_rejects_dangling_child_reference() {
+        // The `from_yaml` path auto-inserts any referenced-but-undefined child
+        // as a Leaf before `validate_tree` runs, so this guard is only
+        // reachable by constructing the model directly (e.g. a future internal
+        // path that skips the auto-insert pass). Exercise it here so the
+        // safety net stays covered — `root` names a child `ghost` that is not
+        // in the feature map.
+        let mut features = BTreeMap::new();
+        features.insert(
+            "root".to_string(),
+            Feature {
+                name: "root".to_string(),
+                group: GroupType::Mandatory,
+                children: vec!["ghost".to_string()],
+                parent: None,
+                attributes: BTreeMap::new(),
+            },
+        );
+        let model = FeatureModel {
+            root: "root".to_string(),
+            features,
+            constraints: vec![],
+            attribute_schema: BTreeMap::new(),
+            attribute_warnings: vec![],
+        };
+        let err = model
+            .validate_tree()
+            .expect_err("a dangling child reference must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("unknown child") && msg.contains("ghost"),
+            "expected unknown-child error, got: {msg}"
+        );
     }
 
     #[test]

--- a/rivet-core/tests/proptest_feature_model.rs
+++ b/rivet-core/tests/proptest_feature_model.rs
@@ -537,16 +537,15 @@ fn solve_accepts_valid_feature_constraint() {
     assert!(resolved.effective_features.contains("opt"));
 }
 
-/// REQ-266: a shared child reachable through two parents (a diamond / DAG)
+/// REQ-269: a shared child reachable through two parents (a diamond / DAG)
 /// must NOT be mis-reported as a cycle.
 ///
-/// `validate_tree`'s BFS (feature_model.rs) inserts each node into a global
-/// `visited` set on dequeue and reports a cycle if a node is seen twice --
-/// but a diamond enqueues the shared child from both parents, so it is
-/// dequeued twice and wrongly flagged. Tracked for fix by REQ-269; ignored
-/// until then so CI stays green. Flip to enforced when REQ-269 lands.
+/// `validate_tree` now uses a DFS that tracks the current path (recursion
+/// stack) rather than a single global `visited` set, so a shared child
+/// reached by two disjoint paths is a legal DAG edge, not a cycle. A genuine
+/// cycle (a feature that is its own ancestor) is still rejected -- see
+/// `genuine_cycle_is_rejected`.
 #[test]
-#[ignore = "REQ-269: diamond (shared child) mis-reported as cycle by validate_tree BFS"]
 fn diamond_shared_child_is_not_a_cycle() {
     let yaml = "kind: feature-model\n\
                 root: root\n\
@@ -567,5 +566,27 @@ fn diamond_shared_child_is_not_a_cycle() {
         res.is_ok(),
         "diamond (shared child) mis-reported as a cycle: {:?}",
         res.err()
+    );
+}
+
+/// REQ-269 guard: a genuine cycle (a feature that is its own ancestor) must
+/// STILL be rejected -- the diamond fix must not make cycle detection
+/// permissive. `root -> mid -> root` is a real back edge.
+#[test]
+fn genuine_cycle_is_rejected() {
+    let yaml = "kind: feature-model\n\
+                root: root\n\
+                features:\n\
+               \x20 root:\n\
+               \x20   group: mandatory\n\
+               \x20   children: [mid]\n\
+               \x20 mid:\n\
+               \x20   group: mandatory\n\
+               \x20   children: [root]\n";
+    let res = FeatureModel::from_yaml(yaml);
+    let err = res.expect_err("a self-ancestor cycle must be rejected");
+    assert!(
+        err.to_string().contains("cycle"),
+        "expected a cycle error, got: {err}"
     );
 }


### PR DESCRIPTION
## REQ-269 — shared child (diamond/DAG) no longer mis-reported as a cycle (v0.29.0)

Surfaced by REQ-266's coverage. `validate_tree`'s cycle detection used a single
global `visited` set + BFS and reported **every** second encounter of a node as
a cycle. A feature reachable through two parents — a diamond, `root -> {a, b}`
with `a -> shared` and `b -> shared` — was enqueued from both parents, dequeued
twice, and wrongly rejected: `cycle detected involving feature `shared``. Real
feature models legitimately share a sub-feature under two branches.

### Fix
Iterative DFS tracking the **current path** (recursion stack) vs fully-explored
nodes:
- Re-encounter **on the current path** → genuine cycle (back edge, a feature that
  is its own ancestor). Still rejected.
- Re-encounter by a **disjoint path** → shared child, fully explored → skipped,
  not flagged.

Parent link stays last-writer-wins (unchanged, acceptable); only the traversal's
cycle criterion changes.

### Tests
- Un-ignored `diamond_shared_child_is_not_a_cycle` — now passes.
- Added `genuine_cycle_is_rejected` — `root -> mid -> root` must still error.

### Verification
Full feature-model + variant suites green (proptest **14**, lib feature_model
**62**, variant_gap_check **2**, variant_phase2 **8**); `clippy --all-targets`
(1.97.0) clean; **wasm seam builds** — `cargo build -p rivet-cli --features wasm`
OK (composition core touched, WIT/component unchanged so no cargo-component
rebuild).

Fixes: REQ-269 · Refs: REQ-266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
