### PR TITLE
feat(serve): variant source-linkage slices a+b (REQ-265, DD-077)

### DIFF
--- a/artifacts/decisions.yaml
+++ b/artifacts/decisions.yaml
@@ -1728,3 +1728,75 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-15T00:00:00Z
+
+  - id: DD-077
+    type: design-decision
+    title: "Variant source-linkage completeness (REQ-265) — slice into 4 boundary fixes, reuse existing scoping"
+    status: proposed
+    description: >
+      REQ-265 found that variant source-linkage is correct within one repo but
+      degrades at every boundary beyond it. Rather than one cross-cutting change,
+      slice it into four independently-shippable fixes, each grounded in an
+      existing mechanism (no new subsystem, no new directive) — consistent with
+      the reuse-existing-patterns doctrine. Governing decision: an external
+      artifact has NO binding to this project's feature model, so it cannot be
+      variant-scoped; under an active variant it is excluded, not leaked in
+      unscoped. Source links must be honest (never a dead link), and a variant's
+      resolved source manifest must be populated on the paths that claim it.
+      Slices:
+      (a) external source links honest — `resolve_source_file` (serve/api.rs)
+      falls back to the raw absolute path for an external artifact (source_file
+      outside the project root), which the `/source` guard (serve/render/source.rs)
+      then rejects: a dead link. Fix: return None for out-of-project paths so the
+      UI shows no link rather than a broken one. Serving external source from a
+      configured external root is a larger, security-sensitive follow-on
+      (relaxing the path-traversal guard) and is intentionally deferred.
+      (b) variant scope leak — the `/artifacts` external loop (serve/api.rs) adds
+      externals without consulting `variant_scope`, so a variant-scoped view
+      still shows unscoped externals. Fix: skip externals when a variant is
+      active, mirroring the existing stats/diagnostics exclusion.
+      (c) binding source globs reach serve — serve variant discovery and
+      `variant check` call plain `solve()`, leaving `ResolvedVariant.source_manifest`
+      empty; only `variant solve` uses `solve_with_bindings`. Fix: call
+      `solve_with_bindings` on the discovery path when a binding exists, and
+      verify the globbed paths against disk (loud on missing dirs, per the
+      DD-076 fail-loud doctrine).
+      (d) `export --variant` — reuse the `resolve_variant_arg` + `fields_for_variant`
+      overlay that `list --variant` / `query --variant` already use, so a
+      variant-scoped compliance export needs no hand-translation of IDs into an
+      s-expr `--filter`.
+      Slices (a) and (b) ship first (small, serve-side, unambiguous); (c) and (d)
+      follow. All under release v0.29.0.
+    links:
+      - type: satisfies
+        target: REQ-265
+    fields:
+      baseline: v0.29.0-track
+      source-ref: >
+        resolve_source_file serve/api.rs (absolute-path fallback for externals);
+        /source guard serve/render/source.rs (rejects out-of-project paths);
+        /artifacts external loop serve/api.rs:538-563 (no variant_scope consult);
+        ResolvedVariant.source_manifest + solve/solve_with_bindings
+        feature_model.rs; serve discovery + variant check use plain solve();
+        export command main.rs has --filter but no --variant; resolve_variant_arg
+        main.rs:6453 + fields_for_variant model.rs:445 (list/query reuse pattern).
+      rationale: >
+        Each boundary failure is a place where the variant view is dishonest — a
+        dead source link, an unscoped external leaking into a scoped view, an
+        empty source manifest on a path that claims one. Slicing keeps every fix
+        shippable and verifiable on its own, and grounding each in an existing
+        helper (variant_scope exclusion, solve_with_bindings, resolve_variant_arg
+        overlay) avoids a new subsystem for a completeness fix.
+      alternatives: >
+        (1) One cross-cutting change — rejected: harder to verify, bigger blast
+        radius on the composition/serve seam. (2) For (a), serve external source
+        by relaxing the /source path guard — deferred: security-sensitive
+        (path traversal), and honest-no-link is the correct minimal fix now.
+        (3) For (d), filter the artifact SET by variant instead of overlaying
+        fields — rejected for the first slice: `list`/`query --variant` overlay
+        fields (filtering is composed via `--filter`), and export should match
+        that established semantics.
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-07-16T00:00:00Z

--- a/rivet-cli/src/serve/api.rs
+++ b/rivet-cli/src/serve/api.rs
@@ -385,10 +385,16 @@ fn resolve_source_file(
     artifact: &rivet_core::model::Artifact,
     project_path: &Path,
 ) -> Option<String> {
+    // Only emit a source_file the `/source` route can actually serve — a path
+    // INSIDE the project root. An external artifact's `source_file` is an
+    // absolute path outside the project; the old `.or(Some(p.as_path()))`
+    // fallback emitted that raw path, producing a link the `/source`
+    // path-traversal guard then rejects (a dead link). Return None for
+    // out-of-project paths so the UI renders no link rather than a broken one
+    // (REQ-265a).
     artifact.source_file.as_ref().and_then(|p| {
         p.strip_prefix(project_path)
             .ok()
-            .or(Some(p.as_path()))
             .map(|rel| rel.display().to_string())
     })
 }
@@ -534,8 +540,12 @@ pub(crate) async fn artifacts(
         }
     }
 
-    // External artifacts (only when explicitly requested)
-    if include_externals {
+    // External artifacts (only when explicitly requested). An external
+    // artifact has no binding to this project's feature model, so it cannot be
+    // variant-scoped; under an active variant, exclude externals rather than
+    // leak them into a scoped view unscoped (REQ-265b) — mirrors the
+    // stats/diagnostics external exclusion under scope.
+    if include_externals && variant_scope.is_none() {
         for ext in &guard.externals {
             let ext_origin = format!("external:{}", ext.prefix);
             let origin_matches = params
@@ -865,5 +875,51 @@ pub(crate) async fn sql(
             Json(serde_json::json!({ "error": e })),
         )
             .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn artifact_with_source(source: Option<PathBuf>) -> rivet_core::model::Artifact {
+        rivet_core::model::Artifact {
+            id: "REQ-001".into(),
+            artifact_type: "requirement".into(),
+            source_file: source,
+            ..Default::default()
+        }
+    }
+
+    /// REQ-265a: an in-project source path resolves to a project-relative
+    /// string the `/source` route can serve.
+    #[test]
+    fn resolve_source_file_in_project_is_relative() {
+        let proj = PathBuf::from("/home/x/proj");
+        let art = artifact_with_source(Some(proj.join("artifacts").join("reqs.yaml")));
+        let expected = PathBuf::from("artifacts").join("reqs.yaml");
+        assert_eq!(
+            resolve_source_file(&art, &proj),
+            Some(expected.display().to_string())
+        );
+    }
+
+    /// REQ-265a: an external artifact's source path (outside the project root)
+    /// resolves to None — no dead link the `/source` guard would reject —
+    /// rather than the raw absolute path the old fallback emitted.
+    #[test]
+    fn resolve_source_file_external_is_none() {
+        let proj = PathBuf::from("/home/x/proj");
+        let art = artifact_with_source(Some(PathBuf::from("/other/repo/components.yaml")));
+        assert_eq!(resolve_source_file(&art, &proj), None);
+    }
+
+    /// An artifact with no source_file resolves to None.
+    #[test]
+    fn resolve_source_file_absent_is_none() {
+        let proj = PathBuf::from("/home/x/proj");
+        let art = artifact_with_source(None);
+        assert_eq!(resolve_source_file(&art, &proj), None);
     }
 }

--- a/rivet-cli/tests/serve_integration.rs
+++ b/rivet-cli/tests/serve_integration.rs
@@ -541,6 +541,63 @@ fn api_stats_response_shape() {
     child.wait().ok();
 }
 
+/// REQ-265b: external artifacts have no binding to this project's feature
+/// model, so under an active `--variant` scope they must be excluded, not
+/// leaked in unscoped. Baseline: `origin=all` (no variant) DOES include the
+/// `spar:` externals; adding `variant=minimal-ci` must drop every
+/// `external:`-origin row.
+///
+/// rivet: verifies REQ-265
+#[test]
+fn api_artifacts_external_excluded_under_variant_scope() {
+    let (mut child, port) = start_server();
+
+    // Baseline — externals present when a variant is NOT active.
+    let (status, body, _h) = fetch(port, "/api/v1/artifacts?limit=1000&origin=all", false);
+    assert_eq!(status, 200);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let externals_unscoped = json["artifacts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|a| {
+            a["origin"]
+                .as_str()
+                .is_some_and(|o| o.starts_with("external:"))
+        })
+        .count();
+    assert!(
+        externals_unscoped > 0,
+        "premise: origin=all must include external artifacts (spar fixture). body: {body}"
+    );
+
+    // Scoped — the same request under an active variant must exclude externals.
+    let (status_v, body_v, _h) = fetch(
+        port,
+        "/api/v1/artifacts?limit=1000&origin=all&variant=minimal-ci",
+        false,
+    );
+    assert_eq!(status_v, 200);
+    let json_v: serde_json::Value = serde_json::from_str(&body_v).unwrap();
+    let externals_scoped = json_v["artifacts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|a| {
+            a["origin"]
+                .as_str()
+                .is_some_and(|o| o.starts_with("external:"))
+        })
+        .count();
+    assert_eq!(
+        externals_scoped, 0,
+        "externals must be excluded under an active variant scope (REQ-265b). body: {body_v}"
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+}
+
 #[test]
 fn api_artifacts_unfiltered() {
     let (mut child, port) = start_server();


### PR DESCRIPTION
## REQ-265 slices a+b — variant source-linkage (v0.29.0)

**DD-077** scopes REQ-265 (variant source-linkage completeness) into four
independently-shippable slices. This PR lands the two small, serve-side ones;
(c) and (d) follow, so REQ-265 stays `proposed`.

### Slice (a) — external source links are honest
`resolve_source_file` fell back to the raw **absolute path** for an external
artifact (source_file outside the project root), producing a link the
`/source` path-traversal guard then **rejects — a dead link**. Now returns
`None` for out-of-project paths so the UI renders no link instead of a broken
one. (Serving external source from a configured external root is a larger,
security-sensitive follow-on — deferred.)

### Slice (b) — variant scope leak
The `/artifacts` external loop added externals **without consulting
`variant_scope`**, so a variant-scoped view still showed unscoped externals.
An external has no binding to this project's feature model and cannot be
variant-scoped, so under an active variant it is now **excluded** — mirroring
the existing stats/diagnostics exclusion.

### Tests
- 3 unit tests for `resolve_source_file` (in-project → relative; external →
  None; absent → None).
- Serve integration test: `origin=all` includes the `spar:` externals, but
  `origin=all&variant=minimal-ci` excludes every external-origin row.

### Verification
New tests pass · `clippy --all-targets` (1.97.0) clean · `rivet validate` +
`docs check` PASS. **Serve only — composition core and wasm seam untouched.**

Refs: REQ-265, DD-077

🤖 Generated with [Claude Code](https://claude.com/claude-code)
