### PR TITLE
feat(variant): disk-verify the source manifest, fail-loud (REQ-265c)

### DIFF
--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -1956,6 +1956,13 @@ enum VariantAction {
         /// Output format: "text" (default) or "json"
         #[arg(short, long, default_value = "text")]
         format: String,
+
+        /// Escalate a source glob whose base directory does not exist on
+        /// disk from a warning to a nonzero exit (REQ-265c). Off by default
+        /// the manifest still WARNS loudly on missing sources, but only
+        /// `--strict` fails the command — matching `validate --strict-variants`.
+        #[arg(long)]
+        strict: bool,
     },
 
     /// Emit a CI matrix driven by the declared variants in a binding file.
@@ -2662,7 +2669,15 @@ fn run(cli: Cli) -> Result<bool> {
                     variant,
                     binding,
                     format,
-                } => cmd_variant_manifest(model, &rv(variant)?, binding, format),
+                    strict,
+                } => cmd_variant_manifest(
+                    model,
+                    &rv(variant)?,
+                    binding,
+                    format,
+                    &cli.project,
+                    *strict,
+                ),
                 VariantAction::Matrix {
                     model,
                     binding,
@@ -15027,6 +15042,62 @@ fn cmd_variant_explain(
     Ok(true)
 }
 
+/// A source glob from a variant's binding manifest whose literal base
+/// directory does not exist on disk under the project root (REQ-265c).
+struct MissingSourceBase {
+    feature: String,
+    glob: String,
+    base: std::path::PathBuf,
+}
+
+/// The leading run of a glob's path components that contain no glob
+/// metacharacter (`*`, `?`, `[`, `{`) — the literal directory prefix a
+/// pattern like `src/auth/**/*.rs` is rooted at (`src/auth`). A pattern with
+/// no metacharacters returns the whole path (a literal file/dir); a pattern
+/// that starts with a wildcard returns an empty path (anchored at the root).
+fn glob_literal_base(glob: &std::path::Path) -> std::path::PathBuf {
+    let mut base = std::path::PathBuf::new();
+    for comp in glob.components() {
+        let s = comp.as_os_str().to_string_lossy();
+        if s.contains(['*', '?', '[', '{']) {
+            break;
+        }
+        base.push(comp);
+    }
+    base
+}
+
+/// Return every source glob in a resolved manifest whose literal base
+/// directory is absent from disk under `project_root`. A binding source
+/// manifest that points at nonexistent directories is emitted `exit 0`
+/// today (REQ-265c); surfacing these lets the caller warn — or, under
+/// `--strict`, fail — instead of trusting a manifest whose sources don't
+/// exist.
+fn missing_source_bases(
+    manifest: &std::collections::BTreeMap<String, Vec<std::path::PathBuf>>,
+    project_root: &std::path::Path,
+) -> Vec<MissingSourceBase> {
+    let mut missing = Vec::new();
+    for (feature, globs) in manifest {
+        for glob in globs {
+            let base = glob_literal_base(glob);
+            // An empty base means the pattern begins with a wildcard, so it
+            // is anchored at the project root itself — nothing to verify.
+            if base.as_os_str().is_empty() {
+                continue;
+            }
+            if !project_root.join(&base).exists() {
+                missing.push(MissingSourceBase {
+                    feature: feature.clone(),
+                    glob: glob.display().to_string(),
+                    base,
+                });
+            }
+        }
+    }
+    missing
+}
+
 /// `rivet variant manifest` — print the per-feature source manifest for
 /// a resolved variant. The manifest is the audit-facing output
 /// described in `docs/pure-variants-comparison.md` Gap 5.
@@ -15035,6 +15106,8 @@ fn cmd_variant_manifest(
     variant_path: &std::path::Path,
     binding_path: &std::path::Path,
     format: &str,
+    project_root: &std::path::Path,
+    strict: bool,
 ) -> Result<bool> {
     validate_format(format, &["text", "json"])?;
 
@@ -15060,6 +15133,11 @@ fn cmd_variant_manifest(
             )
         })?;
 
+    // REQ-265c: verify every source glob's base directory exists under the
+    // project root, so a manifest pointing at nonexistent sources is surfaced
+    // rather than emitted unverified.
+    let missing = missing_source_bases(&resolved.source_manifest, project_root);
+
     if format == "json" {
         let manifest_json: serde_json::Map<String, serde_json::Value> = resolved
             .source_manifest
@@ -15073,12 +15151,23 @@ fn cmd_variant_manifest(
             })
             .collect();
         let total_globs: usize = resolved.source_manifest.values().map(|v| v.len()).sum();
+        let warnings_json: Vec<serde_json::Value> = missing
+            .iter()
+            .map(|m| {
+                serde_json::json!({
+                    "feature": m.feature,
+                    "glob": m.glob,
+                    "missing_base": m.base.display().to_string(),
+                })
+            })
+            .collect();
         let output = serde_json::json!({
             "variant": resolved.name,
             "feature_count": resolved.effective_features.len(),
             "manifest_entry_count": resolved.source_manifest.len(),
             "manifest_glob_count": total_globs,
             "manifest": manifest_json,
+            "source_warnings": warnings_json,
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
@@ -15093,6 +15182,27 @@ fn cmd_variant_manifest(
                 }
             }
         }
+    }
+
+    // Surface missing-source warnings loudly on stderr regardless of format,
+    // so the manifest can no longer report globs whose base directory is
+    // absent without saying so (REQ-265c).
+    for m in &missing {
+        eprintln!(
+            "warning: source glob `{}` (feature `{}`): base directory `{}` does not exist under {}",
+            m.glob,
+            m.feature,
+            m.base.display(),
+            project_root.display()
+        );
+    }
+
+    if strict && !missing.is_empty() {
+        eprintln!(
+            "error: {} source glob(s) reference a missing base directory (--strict)",
+            missing.len()
+        );
+        return Ok(false);
     }
 
     Ok(true)

--- a/rivet-cli/tests/variant_manifest.rs
+++ b/rivet-cli/tests/variant_manifest.rs
@@ -210,3 +210,118 @@ bindings:
         "us is not selected; the us-conditional glob must not appear"
     );
 }
+
+/// Write a minimal model + variant + single-source-glob binding into `dir`.
+/// The variant selects `core`, whose binding carries one `source:` glob.
+fn write_min_manifest_fixture(dir: &std::path::Path, glob: &str) {
+    fs::write(
+        dir.join("model.yaml"),
+        "kind: feature-model\nroot: app\nfeatures:\n  app:\n    group: mandatory\n    children: [core]\n  core:\n    group: leaf\nconstraints: []\n",
+    )
+    .unwrap();
+    fs::write(dir.join("variant.yaml"), "name: v\nselects: [core]\n").unwrap();
+    fs::write(
+        dir.join("bindings.yaml"),
+        format!("bindings:\n  core:\n    artifacts: []\n    source:\n      - glob: {glob}\n"),
+    )
+    .unwrap();
+}
+
+fn manifest_args(dir: &std::path::Path, extra: &[&str]) -> Vec<String> {
+    let mut a = vec![
+        "--project".to_string(),
+        dir.to_str().unwrap().to_string(),
+        "variant".to_string(),
+        "manifest".to_string(),
+        "--model".to_string(),
+        dir.join("model.yaml").to_str().unwrap().to_string(),
+        "--variant".to_string(),
+        dir.join("variant.yaml").to_str().unwrap().to_string(),
+        "--binding".to_string(),
+        dir.join("bindings.yaml").to_str().unwrap().to_string(),
+    ];
+    a.extend(extra.iter().map(|s| s.to_string()));
+    a
+}
+
+/// REQ-265c: a source glob whose literal base directory does not exist on
+/// disk is surfaced as a loud stderr warning AND a JSON `source_warnings`
+/// entry — but without `--strict` the command still exits 0.
+#[test]
+fn manifest_warns_on_missing_source_base() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_min_manifest_fixture(tmp.path(), "src/absent/**");
+    // `src/absent` is deliberately NOT created under tmp.
+
+    let output = Command::new(rivet_bin())
+        .args(manifest_args(tmp.path(), &["--format", "json"]))
+        .output()
+        .expect("rivet variant manifest");
+
+    assert!(
+        output.status.success(),
+        "must exit 0 without --strict. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning") && stderr.contains("src/absent"),
+        "expected a loud missing-source warning. stderr: {stderr}"
+    );
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    let warns = v["source_warnings"]
+        .as_array()
+        .expect("source_warnings array");
+    assert_eq!(warns.len(), 1, "exactly one missing base. json: {v}");
+    assert_eq!(warns[0]["missing_base"], "src/absent");
+    assert_eq!(warns[0]["feature"], "core");
+}
+
+/// REQ-265c: `--strict` escalates a missing source base to a nonzero exit.
+#[test]
+fn manifest_strict_fails_on_missing_source_base() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_min_manifest_fixture(tmp.path(), "src/absent/**");
+
+    let output = Command::new(rivet_bin())
+        .args(manifest_args(tmp.path(), &["--strict"]))
+        .output()
+        .expect("rivet variant manifest --strict");
+
+    assert!(
+        !output.status.success(),
+        "--strict must exit nonzero when a source base is missing"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--strict") && stderr.contains("missing base"),
+        "expected a strict-mode error. stderr: {stderr}"
+    );
+}
+
+/// REQ-265c guard: a source glob whose base directory DOES exist produces no
+/// warning and an empty `source_warnings` list — verification must not flag
+/// valid sources.
+#[test]
+fn manifest_no_warning_when_source_base_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_min_manifest_fixture(tmp.path(), "src/present/**");
+    fs::create_dir_all(tmp.path().join("src").join("present")).unwrap();
+
+    let output = Command::new(rivet_bin())
+        .args(manifest_args(tmp.path(), &["--strict", "--format", "json"]))
+        .output()
+        .expect("rivet variant manifest");
+
+    assert!(
+        output.status.success(),
+        "a present source base must not warn or fail, even under --strict. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid json");
+    assert_eq!(
+        v["source_warnings"].as_array().expect("array").len(),
+        0,
+        "no warnings expected for an existing base. json: {v}"
+    );
+}


### PR DESCRIPTION
## REQ-265 slice c — disk-verify the variant source manifest (v0.29.0)

`rivet variant manifest` (the audit-facing per-feature source manifest) emitted
each binding's `source:` globs **unverified** — a manifest pointing at
nonexistent directories exited 0, so an auditor relying on it couldn't tell the
sources were absent. DD-077 slice (c).

### Change
The command now verifies every glob's **literal base directory** (the leading
path components before the first `*` / `?` / `[` / `{`) against disk under the
project root:
- **always WARNS loudly** on stderr for a missing base (text + json modes), and
  adds a `source_warnings` array to the JSON output;
- under a new **`--strict`** flag, escalates a missing base to a **nonzero
  exit** — mirroring `validate --strict-variants` (REQ-261).

A wildcard-leading pattern is anchored at the root and skipped; a literal path
with no metacharacters is checked whole. Verification is **host-side
(rivet-cli)** — the composition core and wasm seam are untouched.

### Tests
- `manifest_warns_on_missing_source_base` — warns on stderr + JSON, exits 0.
- `manifest_strict_fails_on_missing_source_base` — `--strict` → nonzero exit.
- `manifest_no_warning_when_source_base_exists` — a present base is silent.

### Verification
variant_manifest suite **6 pass** (3 new + 3 regression) · cli_commands **157
pass** (clap-change guard) · `clippy --all-targets` (1.97.0) clean · `rivet
validate` + `docs check` PASS.

Slice (d) `export --variant` + serve manifest-surfacing remain; **REQ-265 stays
`proposed`** until they land.

Refs: REQ-265, DD-077

🤖 Generated with [Claude Code](https://claude.com/claude-code)
