### PR TITLE
feat(schema): dev-native verification type so requirements reach verified (#721)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7883,3 +7883,14 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-16T00:00:00Z
+
+  - id: REQ-270
+    type: requirement
+    title: "dev schema ships a native verification type so a requirement can mechanically reach verified (#721)"
+    status: implemented
+    description: "Maintainer-reported (#721, kiln). The dev schema declares rule `requirement-verification` (SR-46: every requirement should have an incoming `verifies` backlink) but shipped NO artifact type that can SOURCE a `verifies` link to a `requirement` — link emission is target-type authorized (validate.rs:911-918: a link is only allowed if the source type's link-field lists the target's type), and no type in common/dev declared `verifies -> requirement`. So `type: requirement` (dev) was structurally unable to reach `verified` on any project; the ASPICE bridge only reaches `sw-req`, and retyping requirement->sw-req cascades into `swe1-derives-from-sys` (needs a system layer). Fix (chosen over the aspice-bridge options as the root-cause fix): add a dev-native `verification` type with a required `verifies -> [requirement]` link-field, so a lightweight dev-only project can close its own V. Bumps dev@0.2.0 -> 0.3.0. Schema-only change; wasm seam untouched."
+    release: v0.29.0
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-07-17T00:00:00Z

--- a/rivet-core/tests/docs_schema.rs
+++ b/rivet-core/tests/docs_schema.rs
@@ -54,6 +54,32 @@ fn embedded_schema_dev_loads() {
     );
 }
 
+/// #721 / REQ-270: the dev schema ships a `verification` type that can source
+/// a `verifies` link to a `requirement`, so a lightweight dev-only project can
+/// mechanically satisfy the `requirement-verification` rule (SR-46) — closing
+/// the right side of the V — without adopting a heavier process schema.
+// rivet: verifies REQ-270
+#[test]
+fn dev_verification_type_can_verify_requirement() {
+    let schema_file =
+        rivet_core::embedded::load_embedded_schema("dev").expect("dev schema must load");
+    let verification = schema_file
+        .artifact_types
+        .iter()
+        .find(|t| t.name == "verification")
+        .expect("dev schema must define a `verification` type (#721)");
+    let verifies = verification
+        .link_fields
+        .iter()
+        .find(|lf| lf.link_type == "verifies")
+        .expect("`verification` must declare a `verifies` link-field");
+    assert!(
+        verifies.target_types.iter().any(|t| t == "requirement"),
+        "`verification.verifies` must target `requirement` (got {:?})",
+        verifies.target_types
+    );
+}
+
 /// All known embedded schemas load successfully.
 // rivet: verifies REQ-010
 #[test]

--- a/rivet-core/tests/integration.rs
+++ b/rivet-core/tests/integration.rs
@@ -1359,7 +1359,9 @@ fn test_schema_metadata_loading() {
     let dev = Schema::load_file(&dev_path).expect("load dev schema");
     assert_eq!(dev.schema.name, "dev");
     // 0.2.0: added the requirement-verification rule (#555 / REQ-222).
-    assert_eq!(dev.schema.version, "0.2.0");
+    // 0.3.0: added the `verification` type (verifies -> requirement) so a
+    // requirement can mechanically reach verified (#721 / REQ-270).
+    assert_eq!(dev.schema.version, "0.3.0");
     assert!(
         dev.schema.description.is_some(),
         "dev schema should have a description"

--- a/schemas/dev.yaml
+++ b/schemas/dev.yaml
@@ -5,7 +5,7 @@
 
 schema:
   name: dev
-  version: "0.2.0"
+  version: "0.3.0"
   extends: [common]
   description: >
     Software development tracking types. Used to manage requirements,
@@ -146,6 +146,58 @@ artifact-types:
       - name: implements
         link-type: implements
         cardinality: zero-or-many
+
+  - name: verification
+    description: >
+      A test or verification activity that checks a requirement — the right
+      side of the dev V-model. A `verification` with a `verifies` link to a
+      requirement is what satisfies the `requirement-verification` rule
+      (SR-46), so a lightweight dev-only project can mechanically close its V
+      and reach `verified` WITHOUT adopting a heavier process schema (ASPICE,
+      etc.). Before this type, `dev` declared the rule but shipped no type
+      that could source a `verifies` link to a `requirement`, making the rule
+      structurally unsatisfiable (issue #721).
+    fields:
+      - name: method
+        type: string
+        required: false
+        allowed-values:
+          - test
+          - automated-test
+          - manual-test
+          - review
+          - analysis
+          - inspection
+          - demonstration
+        description: How the verification is performed.
+      - name: baseline
+        type: string
+        required: false
+        description: Version baseline this verification belongs to
+      - name: cited-source
+        type: cited-source
+        required: false
+        description: >
+          Typed cited-source reference to the verification evidence (e.g. the
+          test file that runs it). See `rivet docs schema-cited-sources`.
+    link-fields:
+      - name: verifies
+        link-type: verifies
+        target-types: [requirement]
+        required: true
+        cardinality: one-or-many
+    common-mistakes:
+      - problem: "Verification not linked to any requirement — it verifies nothing"
+        fix-command: "rivet link VER-XXX verifies REQ-XXX"
+    example: |
+      - id: VER-001
+        type: verification
+        title: Schema validation integration test
+        status: verified
+        method: automated-test
+        links:
+          - type: verifies
+            target: REQ-001
 
 link-types:
   - name: depends-on


### PR DESCRIPTION
## Fix #721 — dev schema can now close its own V-model

The dev schema declared rule `requirement-verification` (SR-46: every requirement
should have an incoming `verifies` backlink) but shipped **no artifact type that
could source a `verifies` link to a `requirement`**. Link emission is
target-type authorized, so with no `verifies → requirement` producer the rule
was **structurally unsatisfiable** — `type: requirement` (dev) could never
mechanically reach `verified`. The ASPICE bridge only reaches `sw-req`, and
retyping cascades into `swe1-derives-from-sys` (a whole system layer).

### Fix (root-cause, per @avrabe's ranking this is the dev-native path)
Add a dev-native **`verification`** type with a required `verifies → [requirement]`
link-field:

```yaml
- name: verification
  fields: [method, baseline, cited-source]
  link-fields:
    - name: verifies
      link-type: verifies
      target-types: [requirement]
      required: true
      cardinality: one-or-many
```

A lightweight dev-only project can now close the right side of its own V without
adopting ASPICE. Bumps **dev@0.2.0 → 0.3.0**. Schema-only — composition core and
wasm seam untouched.

### Verified
On a scaffolded `--preset dev` project: a `verification` that `verifies` a
requirement is **authorized** (no forbidden-target error) and **clears SR-46**,
while an unverified requirement still warns. docs_schema **27 pass** (incl. new
`dev_verification_type_can_verify_requirement`) · clippy `--all-targets` clean ·
`rivet validate` + `docs check` PASS · schema-version-bump OK.

Closes #721 · Implements: REQ-270 · Refs: REQ-010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
