### PR TITLE
feat(export): --variant applies the per-variant field overlay (REQ-265d)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7839,7 +7839,7 @@ artifacts:
   - id: REQ-265
     type: requirement
     title: "variant source-linkage completeness (externals, binding source globs, export --variant)"
-    status: proposed
+    status: implemented
     description: "P3 (DD-076). Local variant scoping preserves source_file correctly (confirmed). It degrades at every boundary beyond one repo: (a) external artifact source links are dead — resolve_source_file (api.rs:388) can't strip_prefix an out-of-project absolute path and /source rejects it (render/source.rs:281,294); (b) externals bypass variant scoping entirely (api.rs:538-563 never consults variant_scope) — a scope leak; (c) binding `source:` globs (ResolvedVariant.source_manifest via solve_with_bindings, feature_model.rs:1413) never reach serve or `variant solve` (which call plain solve()), and are emitted unverified against disk (missing dirs, exit 0); (d) no `export --variant` — a variant-scoped compliance export is impossible without hand-translating IDs to an s-expr --filter. Address as slices."
     release: v0.29.0
     provenance: {created-by: ai-assisted, model: claude-opus-4-8, timestamp: 2026-07-15T00:00:00Z}

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -741,6 +741,13 @@ enum Command {
         #[arg(long)]
         filter: Option<String>,
 
+        /// Variant name (or path to a variant YAML) whose per-variant field
+        /// overlay is applied before export, so a variant-scoped compliance
+        /// export needs no hand-translation of IDs into an s-expr --filter.
+        /// Mirrors `list --variant` / `query --variant` (REQ-265).
+        #[arg(long)]
+        variant: Option<String>,
+
         /// Install rivet_* shortcode templates into templates/shortcodes/ (Zola only)
         #[arg(long)]
         shortcodes: bool,
@@ -2513,6 +2520,7 @@ fn run(cli: Cli) -> Result<bool> {
             baseline,
             prefix,
             filter,
+            variant,
             shortcodes,
             clean,
         } => cmd_export(
@@ -2528,6 +2536,7 @@ fn run(cli: Cli) -> Result<bool> {
             baseline.as_deref(),
             prefix,
             filter.as_deref(),
+            variant.as_deref(),
             *shortcodes,
             *clean,
         ),
@@ -9763,6 +9772,7 @@ fn cmd_export(
     baseline_name: Option<&str>,
     prefix: &str,
     sexpr_filter: Option<&str>,
+    variant_arg: Option<&str>,
     shortcodes: bool,
     clean: bool,
 ) -> Result<bool> {
@@ -9777,6 +9787,13 @@ fn cmd_export(
             "zola",
         ],
     )?;
+    // Resolve `--variant` (name or path) to a variant name ONCE, so every
+    // export format applies the same per-variant field overlay (REQ-265).
+    let variant_name: Option<String> = match variant_arg {
+        Some(arg) => Some(resolve_variant_arg(&cli.project, arg)?.1),
+        None => None,
+    };
+    let variant = variant_name.as_deref();
     if format == "zola" {
         return cmd_export_zola(
             cli,
@@ -9786,6 +9803,7 @@ fn cmd_export(
             shortcodes,
             clean,
             baseline_name,
+            variant,
         );
     }
     if format == "html" {
@@ -9807,17 +9825,19 @@ fn cmd_export(
             version_label,
             versions_json,
             sexpr_filter,
+            variant,
         );
     }
 
     if format == "gherkin" {
-        return cmd_export_gherkin(cli, output, baseline_name);
+        return cmd_export_gherkin(cli, output, baseline_name, variant);
     }
 
     use rivet_core::adapter::{Adapter, AdapterConfig};
 
     let ctx = ProjectContext::load(cli)?;
     let store = apply_baseline_scope(ctx.store, baseline_name, &ctx.config);
+    let store = apply_variant_overlay(store, variant);
     // Sorted by id so the exported artifact (ReqIF/etc.) is byte-reproducible
     // across runs (REQ-159 / #415; the store is HashMap-ordered).
     let artifacts: Vec<_> = store.iter_sorted().cloned().collect();
@@ -9877,6 +9897,7 @@ fn cmd_export(
 /// Writes content/<prefix>/artifacts/*.md with TOML frontmatter and
 /// data/<prefix>/*.json with aggregate data. Additive-only: never
 /// modifies existing files outside the prefix namespace.
+#[allow(clippy::too_many_arguments)]
 fn cmd_export_zola(
     cli: &Cli,
     output: Option<&std::path::Path>,
@@ -9885,9 +9906,11 @@ fn cmd_export_zola(
     shortcodes: bool,
     clean: bool,
     baseline_name: Option<&str>,
+    variant: Option<&str>,
 ) -> Result<bool> {
     let ctx = ProjectContext::load_with_docs(cli)?;
     let store = apply_baseline_scope(ctx.store, baseline_name, &ctx.config);
+    let store = apply_variant_overlay(store, variant);
     let doc_store = ctx.doc_store.unwrap_or_default();
     let graph = rivet_core::links::LinkGraph::build(&store, &ctx.schema);
 
@@ -10365,6 +10388,7 @@ fn cmd_export_gherkin(
     cli: &Cli,
     output: Option<&std::path::Path>,
     baseline_name: Option<&str>,
+    variant: Option<&str>,
 ) -> Result<bool> {
     let ctx = ProjectContext::load(cli)?;
     let baselines = ctx.config.baselines.as_deref().unwrap_or(&[]);
@@ -10373,6 +10397,7 @@ fn cmd_export_gherkin(
     } else {
         ctx.store.clone()
     };
+    let store = apply_variant_overlay(store, variant);
 
     let out_dir = output.unwrap_or(std::path::Path::new("features"));
     std::fs::create_dir_all(out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
@@ -10618,6 +10643,7 @@ fn cmd_export_html(
     _version_label: Option<&str>,
     _versions_json: Option<&str>,
     sexpr_filter: Option<&str>,
+    variant: Option<&str>,
 ) -> Result<bool> {
     use crate::render::styles;
     use crate::serve::components::ViewParams;
@@ -10629,8 +10655,16 @@ fn cmd_export_html(
         .unwrap_or_else(|_| cli.project.clone());
 
     // Load project state using the same pipeline as `rivet serve`.
-    let state = serve::reload_state(&project_path, &schemas_dir, 0)
+    let mut state = serve::reload_state(&project_path, &schemas_dir, 0)
         .context("loading project for export")?;
+
+    // Apply the variant's per-variant field overlay to the store so the
+    // compliance bundle reflects variant-scoped field values (REQ-265). The
+    // link graph is rebuilt so any downstream trace view stays consistent.
+    if variant.is_some() {
+        state.store = apply_variant_overlay(state.store, variant);
+        state.graph = rivet_core::links::LinkGraph::build(&state.store, &state.schema);
+    }
 
     // ── Single-page mode (audit-bundle shape) ────────────────────────
     //
@@ -15532,6 +15566,29 @@ fn apply_baseline_scope(
         eprintln!("warning: --baseline specified but no baselines defined in rivet.yaml");
         store
     }
+}
+
+/// Apply a variant's per-variant field overlay to every artifact in the store
+/// (REQ-265). For each artifact that declares a `fields_per_variant` entry for
+/// `variant_name`, its `fields` map is replaced with the merged view
+/// (`fields_for_variant`), so the export sees variant-scoped field values.
+/// Mirrors the in-place rewrite `query --variant` performs before the
+/// s-expression filter runs. A `None` variant is a no-op.
+fn apply_variant_overlay(mut store: Store, variant_name: Option<&str>) -> Store {
+    let Some(name) = variant_name else {
+        return store;
+    };
+    let ids: Vec<String> = store.iter().map(|a| a.id.clone()).collect();
+    for id in ids {
+        if let Some(art) = store.get(&id) {
+            if art.fields_per_variant.contains_key(name) {
+                let mut updated = art.clone();
+                updated.fields = updated.fields_for_variant(Some(name)).into_owned();
+                store.upsert(updated);
+            }
+        }
+    }
+    store
 }
 
 // ── Oracle subcommands: `rivet check …` ─────────────────────────────────

--- a/rivet-cli/tests/variant_phase2.rs
+++ b/rivet-cli/tests/variant_phase2.rs
@@ -402,3 +402,72 @@ fn coverage_stamps_variant_name_in_json() {
     let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
     assert_eq!(v["variant"], "industrial");
 }
+
+/// REQ-265 slice (d): `rivet export --variant <NAME>` applies the per-variant
+/// field overlay before export, so a variant-scoped compliance export needs no
+/// hand-translation of IDs into an s-expr `--filter`. Mirrors
+/// `query --variant`: the default `max-temp-c` is "80"; only under the
+/// `industrial` variant does it resolve to "100".
+#[test]
+fn export_variant_applies_field_overlay() {
+    let (_keep, dir) = setup_phase2_project();
+    let out_file = dir.join("export-industrial.yaml");
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "--schemas",
+            dir.join("schemas").to_str().unwrap(),
+            "export",
+            "--format",
+            "generic-yaml",
+            "--output",
+            out_file.to_str().unwrap(),
+            "--variant",
+            "industrial",
+        ])
+        .output()
+        .expect("rivet export --variant");
+    assert!(
+        out.status.success(),
+        "export --variant must succeed. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let exported = std::fs::read_to_string(&out_file).expect("read export");
+    // The industrial overlay replaces the top-level max-temp-c "80" with
+    // "100", so the default value "80" no longer appears anywhere (no variant
+    // in the fixture uses 80). The generic-yaml export also round-trips the
+    // `fields-per-variant` block, so "100" alone is not a discriminator.
+    assert!(
+        exported.contains("100"),
+        "industrial overlay must put max-temp-c=100 in the export. got:\n{exported}"
+    );
+    assert!(
+        !exported.contains("'80'") && !exported.contains(": 80"),
+        "the default value 80 must be overwritten by the industrial overlay. got:\n{exported}"
+    );
+
+    // Without --variant, the top-level field keeps its default value "80".
+    let out_default = dir.join("export-default.yaml");
+    let out2 = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dir.to_str().unwrap(),
+            "--schemas",
+            dir.join("schemas").to_str().unwrap(),
+            "export",
+            "--format",
+            "generic-yaml",
+            "--output",
+            out_default.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rivet export (no variant)");
+    assert!(out2.status.success());
+    let exported_default = std::fs::read_to_string(&out_default).expect("read default export");
+    assert!(
+        exported_default.contains("'80'") || exported_default.contains(": 80"),
+        "without --variant the default max-temp-c=80 must be exported at top level. got:\n{exported_default}"
+    );
+}


### PR DESCRIPTION
## REQ-265 slice d — `export --variant` (completes REQ-265, v0.29.0)

`rivet export` gains `--variant <NAME>` (name or path). A variant-scoped
compliance export no longer needs hand-translation of IDs into an s-expr
`--filter`.

### How
The variant is resolved **once** in `cmd_export` (shared `resolve_variant_arg`,
matching `list`/`query`), and a new `apply_variant_overlay` helper — mirroring
the in-place rewrite `query --variant` performs — replaces each artifact's
top-level `fields` with its `fields_for_variant` merged view before export.
Applied after baseline scope in **every** export path:
- `reqif` / `generic-yaml` (`cmd_export`)
- `zola`
- `gherkin`
- `html` — the compliance-bundle path overlays `state.store` and rebuilds the
  link graph, so the single-page audit bundle is variant-scoped too (no silent
  drop of `--variant` on the format that matters most for compliance).

A `None` variant is a no-op.

### REQ-265 now fully implemented
(a) honest external source links · (b) no variant scope leak · (c) disk-verified
source manifest · **(d) export --variant**.

### Verified
On the phase2 fixture (`max-temp-c` 80 default → 100 under `industrial`):
`export --variant industrial` bakes 100 into the top-level field; plain export
keeps 80. variant_phase2 **9 pass** (incl. new `export_variant_applies_field_overlay`),
export_zola / export_reqif regression green, cli_commands **157** (clap-change
guard), `clippy --all-targets` (1.97.0) clean, `rivet validate` + `docs check`
PASS. **rivet-cli only — wasm seam untouched.**

Implements: REQ-265 · Refs: DD-077

🤖 Generated with [Claude Code](https://claude.com/claude-code)
