### PR TITLE
chore(release): v0.29.0 — variant source-linkage + V-model bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-07-21
+
+### Added
+- **Dev-native `verification` type** (REQ-270, #721) — the `dev` schema declared
+  the `requirement-verification` rule but shipped no type that could
+  source a `verifies` link to a `requirement`, so `type: requirement` could never
+  mechanically reach `verified` on any dev-only project. Adds a `verification`
+  type with a required `verifies → [requirement]` link-field, so a lightweight
+  project closes the right side of its own V without adopting ASPICE. Bumps
+  `dev@0.2.0 → 0.3.0`.
+- **`export --variant <NAME>`** (REQ-265d) — a variant-scoped compliance export.
+  The variant's per-variant field overlay is baked into each artifact's top-level
+  fields before export, across all formats (reqif, generic-yaml, gherkin, zola,
+  and the html/single-page audit bundle) — no hand-translation of IDs into an
+  s-expr `--filter`. Mirrors `list --variant` / `query --variant`.
+- **`variant manifest` disk-verifies source globs** (REQ-265c) — every binding
+  `source:` glob's base directory is checked against disk; a missing base warns
+  loudly (stderr + JSON `source_warnings`), and `--strict` escalates it to a
+  nonzero exit.
+
+### Fixed (variant hardening, continued)
+- **Shared child no longer mis-reported as a cycle** (REQ-269) — a feature
+  reachable through two parents (a diamond / DAG) was rejected as a cycle;
+  `validate_tree` now tracks the current DFS path (recursion stack) instead of a
+  global visited set, so a diamond loads while a genuine back-edge cycle is still
+  rejected. Surfaced by REQ-266's coverage.
+- **`serve` variant scope no longer leaks externals** (REQ-265b) — external
+  artifacts (which have no binding to the project's feature model) are excluded
+  from `/artifacts` under an active variant instead of appearing unscoped.
+- **External source links are honest** (REQ-265a) — `resolve_source_file` returns
+  no link for an out-of-project path rather than emitting a dead link the
+  `/source` guard rejects.
+
+### Testing
+- **Constraint-solver property tests** (REQ-266) — the proptest strategies now
+  generate cross-tree constraints, fuzzing the solver's highest-risk paths
+  (`implies` propagation, `excludes`, REQ-257's fail-loud gate) with an
+  independent oracle that a green `solve()` never silently passes a violated
+  constraint. Previously zero constraint coverage.
+
 ## [0.28.0] - 2026-07-16
 
 ### Fixed (variant hardening P1 — DD-076: broken config must fail loud, not present as absent)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.28.0"
+version = "0.29.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.29.0 — variant source-linkage completeness + dev V-model bridge

Release-prep for **v0.29.0**. Bumps `[workspace.package]`, `Cargo.lock`, and the
VS Code extension to `0.29.0`; adds the CHANGELOG section.

### Scope (all `implemented` on main)
| REQ | What shipped |
|-----|--------------|
| REQ-265 | variant source-linkage completeness — (a) honest external source links, (b) no `serve` variant scope leak, (c) disk-verified `variant manifest`, (d) **`export --variant`** |
| REQ-266 | constraint-solver property-test coverage (previously zero) |
| REQ-269 | shared child (diamond/DAG) no longer mis-reported as a cycle |
| REQ-270 | dev-native `verification` type so a requirement can mechanically reach `verified` (dev@0.2.0 → 0.3.0, closes #721) |

### Self-verify (fresh 0.29.0 binary)
- `cargo build --release` — OK
- `rivet validate` — **PASS**
- `rivet docs check` — **PASS** (0 violations)

### Falsification statement
A dev-only project can now close its own V (a `verification` `verifies` a
`requirement`); a variant-scoped `export` reflects the variant's field overlay
across all formats incl. the html compliance bundle; a diamond feature model
loads while a genuine cycle is still rejected; and the constraint solver's
`Ok` verdict is independently checked against every generated constraint.

Next: signed `v0.29.0` tag → release.yml + release-npm.yml → verify GitHub assets + npm.

Implements: REQ-265, REQ-266, REQ-270 · Fixes: REQ-269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
