### PR TITLE
chore(release): v0.30.0 — CI resilience + compliance-export robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-07-23
+
+CI resilience + compliance-export robustness.
+
+### Added
+- **Per-PR WASM-seam CI gate** (REQ-268) — the composition core is exposed as a
+  Wasm component (`compose-witness/` + the host `wasm` feature via wasmtime), but
+  per-PR CI only ever built the default features; a break in the host-side wasm
+  seam was invisible until `release.yml` ran on a tag. Adds a `wasm-seam` job
+  (gated by a paths-filter on `compose-witness/`, `wasm_runtime.rs`,
+  `feature_model.rs`, `*.wit`, the wasm build script, and `assets/wasm/`) that runs
+  `cargo build -p rivet-cli --features wasm` on every PR touching the seam.
+- **Self-hosted runner disk cleanup** (REQ-271, #567) — a reusable
+  `.github/actions/free-space` composite action prunes docker/bazel/cargo caches
+  and `/tmp`, reporting before/after free space, so long-lived self-hosted runners
+  stop failing compile-heavy jobs on a full disk. (Currently wired into the
+  `wasm-seam` job; broadening to all compile-heavy jobs is queued for v0.31.)
+- **Hosted traceability fallback** (REQ-272, #509) — a `push`-only
+  `traceability-hosted-fallback` job on `ubuntu-latest` runs `rivet validate`, so a
+  self-hosted-pool outage can no longer silently zero out main's traceability
+  enforcement. Skipped on PRs (self-hosted carries the per-PR gate). Complements the
+  runner-liveness alert workflow shipped earlier.
+
+### Fixed
+- **AADL diagrams no longer stuck on "Loading…" forever in static export**
+  (REQ-273, #468) — the static compliance report embedded an AADL placeholder that
+  only `rivet serve` could fill client-side (spar-WASM + `/source-raw` + `/wasm`
+  endpoints a static bundle lacks), so the report looked broken. Static export now
+  emits an honest fallback — a "rendered interactively in `rivet serve`" note plus
+  the AADL source in a `<details>` block — and the fix lands at the render source,
+  so the prior post-hoc text replacements become harmless no-ops. Real inline SVG
+  still activates automatically once a non-stub spar-wasm component is embedded
+  (cross-repo, spar#259), with no further code change.
+
 ## [0.29.0] - 2026-07-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release-prep for **v0.30.0**. Bumps workspace `0.29.0 → 0.30.0` (rivet-core, rivet-cli, etch) + vscode-rivet, adds the CHANGELOG entry.

## Scope (all `implemented` + merged, CI-green)
| REQ | What | PR | Issue |
|-----|------|----|-------|
| REQ-268 | Per-PR wasm-seam CI gate | #732 | — |
| REQ-271 | Self-hosted runner disk cleanup | #732 | #567 |
| REQ-272 | Hosted traceability fallback | #732 | #509 |
| REQ-273 | Honest AADL static-export fallback | #734 | #468 |

## Theme
CI resilience (the seam is now gated per-PR; runners self-clean; a hosted floor survives a self-hosted outage) + compliance-export robustness (the static AADL forever-spinner is replaced with an honest source-embedding fallback).

## Verification
- Local self-verify green on both feature branches before merge: build, `rivet validate`, `rivet docs check` (0 violations), `clippy --all-targets -D warnings` exit 0.
- Release-prep re-verified: build OK, docs check 0 violations, validate PASS.

## Follow-ups filed (v0.31)
- Broaden `free-space` beyond `wasm-seam` to all compile-heavy jobs (#734 re-hit disk-full on Docs Check).
- Configure `release.ready-when` so `rivet release status` matches ship-at-implemented practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)