### PR TITLE
feat(schema): ordeal-certificate evidence artifact type (#693 Part 2, ordeal#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 
 ## [Unreleased]
 
+### Added
+- **`ordeal-certificate` evidence artifact type** (REQ-277, #693 Part 2,
+  ordeal#67) — new embedded schema `schemas/ordeal-certificate.yaml` describing an
+  ordeal-cert/v1 bundle (ordeal v0.17.0, `cert-bundle` feature): `produced-by` /
+  `checked-by` tool blocks, `attests-kind`/`attests-claim`/`attests-standards`,
+  `cnf-sha256`/`proof-sha256` content addressing, and a structured `recheck`
+  block (`command`, `expect-exit`). A typed `attests-transform` link-field
+  (inverse `transform-attested-by`) enforces allowed targets via the existing
+  `link-target-type` check. Coverage semantics: a RE-CHECKED certificate
+  (`verification-result: pass`) is a verification link whose `verifies`
+  backlinks count toward `requirement-verification`; a never-re-checked
+  certificate that claims `verifies` is a validation error
+  (`V-ordeal-cert-recheck-gates-verifies`). The honest SAT boundary
+  (self-checked model, warning as a `verifies` source) and the v1 inline-only
+  reader boundary (`cnf-ref`/`proof-ref` → legible Unsupported-class error
+  mirroring ordeal's `BundleError::Unsupported`) are baked into the schema.
+  Docs: `rivet docs schema/ordeal-certificate`.
+
 ## [0.30.0] - 2026-07-23
 
 CI resilience + compliance-export robustness.

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7960,3 +7960,17 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-23T00:00:00Z
+
+  - id: REQ-277
+    type: requirement
+    title: "ordeal-certificate evidence artifact type — ingest ordeal-cert/v1 bundles as re-checkable verification links (#693 Part 2, ordeal#67)"
+    status: implemented
+    description: "rivet#693 Part 2 (unblocked by ordeal v0.17.0 / ordeal PR #107). Declare an `ordeal-certificate` embedded schema describing an ordeal-cert/v1 bundle: produced-by / checked-by tool blocks, attests (kind + claim + standards), cnf-sha256/cnf-ref + proof-sha256/proof-ref content addressing, and a structured recheck block (command, expect-exit). Typed `attests-transform` link-field with allowed-target enforcement via the existing link-target-type machinery. Coverage semantics: rivet validate treats a RE-CHECKED certificate (recheck run, exit per expect-exit, recorded as verification-result: pass) as a verification link whose `verifies` backlinks count toward requirement-verification coverage; a never-re-checked certificate that claims `verifies` is a validation ERROR (a claimed status, not evidence). Honest SAT boundary baked in: sat verdicts carry a self-checked model (warning when used as a verifies source; UNSAT is the certificate-carrying verdict). v1 inline-only reader boundary: cnf-ref/proof-ref indirection surfaces as a legible Unsupported-class validation error mirroring ordeal's BundleError::Unsupported. Ships golden round-trip + link-target-type + coverage-split fixtures and the `rivet docs schema/ordeal-certificate` topic. Part 1 (--certify shell-out to ordeal) is explicitly out of scope here."
+    category: functional
+    priority: should
+    release: v0.31.0
+    upstream-ref: "https://github.com/pulseengine/rivet/issues/693"
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-07-30T04:11:24Z

--- a/docs/artifact-types/ordeal-certificate.md
+++ b/docs/artifact-types/ordeal-certificate.md
@@ -1,0 +1,129 @@
+<!-- rivet-docs-check: ignore OC-001 OC-002 REQ-001 FEAT-042 -->
+
+# `ordeal-certificate` — machine-re-checkable proof evidence
+
+The `ordeal-certificate` artifact type (schema `ordeal-certificate`,
+rivet#693 Part 2 / ordeal#67) describes an **ordeal-cert/v1 bundle**: the
+certificate [ordeal](https://github.com/pulseengine/ordeal) emits when its
+certified SAT core decides a query — a variant/feature-model consistency
+check, a loom rule proof, a synth codegen equivalence, a sigil overflow
+check, a spar layout, a gale bitvector query. The artifact makes that
+bundle a first-class piece of DO-178C / ISO 26262 / EU-AI-Act-Art-12
+evidence in the rivet traceability graph.
+
+The load-bearing idea: **a certificate is a verification link, not a
+claimed status**. rivet does not trust the solver; it trusts the recorded
+outcome of *re-running the trusted checker* over the bundle's payload.
+
+## Shape
+
+Fields mirror the upstream envelope recognizably:
+
+| Field                 | Upstream envelope            | Meaning |
+|-----------------------|------------------------------|---------|
+| `format`              | `format`                     | Always `ordeal-cert/v1` (pinned by `allowed-values`) |
+| `verdict`             | `verdict`                    | `unsat` (re-checkable) or `sat` (self-checked — see boundary) |
+| `produced-by`         | `produced_by {name,version}` | Producing tool, e.g. `{name: ordeal, version: 0.17.0}` |
+| `checked-by`          | `checked_by {name,version}`  | Trusted checker, e.g. `ordeal-lrat`; required for `unsat` |
+| `attests-kind`        | `attests.kind`               | Query class: `propositional_consistency`, `qf_bv_validity`, `equivalence` |
+| `attests-claim`       | `attests.claim`              | What is proven: `variant-consistent`, `variant-inconsistent`, … |
+| `attests-standards`   | `attests.standards`          | Standard clauses served, e.g. `EU-AI-Act:Art12` |
+| `cnf-sha256`          | `recheck.problem_sha256`     | sha256 of the canonical DIMACS clause text |
+| `proof-sha256`        | `recheck.proof_sha256`       | sha256 of the proof payload (LRAT for `unsat`) |
+| `cnf-ref`/`proof-ref` | (contract, deferred)         | External blobs — **not supported by the v1 reader**, see below |
+| `recheck`             | `recheck` block              | `{command, expect-exit}` — the recheck invocation contract |
+| `verification-result` | (rivet-side record)          | `pass`/`fail` outcome of actually running the recheck |
+| `rechecked-at`        | (rivet-side record)          | RFC 3339 timestamp of that run |
+
+Link fields:
+
+- `attests-transform` (typed link, inverse `transform-attested-by`) — the
+  artifact whose transform the certificate attests. Allowed targets:
+  `requirement`, `feature`, `design-decision`, `aadl-component`; anything
+  else is rejected by the `link-target-type` check.
+- `verifies` — the verification links the certificate provides *once
+  re-checked* (gated, see below).
+
+Use the base `cited-source` field to pin the bundle JSON file itself
+(sha256-stamped) when it is stored in the repo.
+
+## The recheck invocation contract
+
+`recheck.command` is the exact invocation of the trusted checker over the
+bundle's payload (upstream `recheck.cmd`, e.g.
+`ordeal-lrat check <problem> <proof>`), and `recheck.expect-exit` is the
+exit code that means "the mathematics re-checked" (normally `0`). Upstream,
+`Certificate::from_cert_v1` verifies both content sha256s **before**
+parsing returns, and `UnsatBundle::recheck()` re-runs the formally-verified
+LRAT checker — the hash check proves integrity, the recheck proves the
+mathematics.
+
+Coverage semantics in `rivet validate`
+(rule `V-ordeal-cert-recheck-gates-verifies`, severity error):
+
+- **Re-checked counts.** A certificate whose recheck command was actually
+  run and exited per `expect-exit` — recorded as
+  `verification-result: pass` — may source `verifies` links, and those
+  links satisfy `requirement-verification` coverage like any other
+  verification backlink.
+- **Never-re-checked does not.** A certificate without a recorded
+  successful recheck that claims `verifies` **fails validation**. It
+  cannot silently count as evidence.
+
+## The honest SAT boundary
+
+UNSAT is the certificate-carrying verdict: the bundle holds a DIMACS CNF
+plus an LRAT proof that an independent trusted checker validates. For SAT
+verdicts (e.g. `attests-claim: variant-consistent`, the "config is valid"
+answer) the proof payload is the **self-checked model** — checked against
+all constraints at solve time, but ordeal ships no independently
+re-checkable SAT witness yet. The schema flags a SAT certificate used as a
+`verifies` source with a warning (`V-ordeal-cert-sat-is-self-checked`)
+rather than passing it off as checker-validated evidence.
+
+## The v1 inline-only reader boundary
+
+`cnf-ref` / `proof-ref` external-blob indirection is part of the contract
+for MB-class proofs but deferred: ordeal's v1 reader rejects such bundles
+as `BundleError::Unsupported`. `rivet validate` mirrors the boundary — an
+`ordeal-certificate` using `cnf-ref` or `proof-ref` produces the legible
+error `V-ordeal-cert-v1-inline-only` instead of a mystery failure at
+recheck time.
+
+## Upstream serialization contract
+
+ordeal-cert/v1 as shipped:
+[ordeal PR #107](https://github.com/pulseengine/ordeal/pull/107)
+(ordeal v0.17.0, `cert-bundle` feature): `Certificate::to_cert_v1` /
+`Certificate::from_cert_v1` with both content sha256s verified before
+parse returns, and `UnsatBundle::recheck()` re-running the trusted
+checker. See `crates/ordeal/src/cert_bundle.rs` in that release.
+
+## Example
+
+```yaml
+- id: OC-001
+  type: ordeal-certificate
+  title: variant tls+nomalloc inconsistent with feature model
+  status: verified
+  fields:
+    format: ordeal-cert/v1
+    verdict: unsat
+    produced-by: {name: ordeal, version: 0.17.0}
+    checked-by: {name: ordeal-lrat, version: 0.17.0}
+    attests-kind: propositional_consistency
+    attests-claim: variant-inconsistent
+    attests-standards: [EU-AI-Act:Art12]
+    cnf-sha256: <64-hex sha256 of the DIMACS clause text>
+    proof-sha256: <64-hex sha256 of the LRAT body>
+    recheck:
+      command: ordeal-lrat check problem.cnf proof.lrat
+      expect-exit: 0
+    verification-result: pass
+    rechecked-at: 2026-07-30T00:00:00Z
+  links:
+    - type: attests-transform
+      target: FEAT-042
+    - type: verifies
+      target: REQ-001
+```

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -52,6 +52,7 @@ As of this writing the directory ships 21 domain schemas and 8 bridge schemas.
 | `score`          | Eclipse SCORE metamodel (ASIL-rated open-source software)         |
 | `supply-chain`   | Software supply chain: SBOM, build provenance, CVE tracking       |
 | `vv-coverage`    | Repo-level V&V technique coverage matrix                          |
+| `ordeal-certificate` | ordeal-cert/v1 machine-re-checkable proof evidence            |
 | `research`       | Market research, competitive analysis, patent landscape           |
 
 ### Bridge schemas

--- a/rivet-cli/src/docs.rs
+++ b/rivet-cli/src/docs.rs
@@ -340,12 +340,29 @@ const TOPICS: &[DocTopic] = &[
         content: embedded::SCHEMA_VV_COVERAGE,
     },
     DocTopic {
+        slug: "schema/ordeal-certificate",
+        title: "ordeal-certificate schema — machine-re-checkable proof evidence",
+        category: "Schemas",
+        content: ORDEAL_CERTIFICATE_DOC,
+    },
+    DocTopic {
         slug: "tool-qualification",
         title: "Tool qualification dossier — rivet (ISO 26262-8 §11.4.7)",
         category: "Reference",
         content: TOOL_QUALIFICATION_DOC,
     },
 ];
+
+const ORDEAL_CERTIFICATE_DOC: &str = concat!(
+    include_str!("../../docs/artifact-types/ordeal-certificate.md"),
+    r#"
+---
+
+## Schema source (`schemas/ordeal-certificate.yaml`)
+
+"#,
+    include_str!("../../schemas/ordeal-certificate.yaml"),
+);
 
 const TOOL_QUALIFICATION_DOC: &str =
     include_str!("../../docs/design/tool-qualification-dossier.md");

--- a/rivet-cli/tests/ordeal_certificate.rs
+++ b/rivet-cli/tests/ordeal_certificate.rs
@@ -1,0 +1,183 @@
+// SAFETY-REVIEW (SCRC Phase 1, DD-058): Integration test / bench code.
+// Tests legitimately use unwrap/expect/panic/assert-indexing patterns
+// because a test failure should panic with a clear stack. Blanket-allow
+// the Phase 1 restriction lints at crate scope; real risk analysis for
+// these lints is carried by production code.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::wildcard_enum_match_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::print_stderr
+)]
+
+//! End-to-end `rivet validate` runs over `ordeal-certificate` fixture
+//! projects (rivet#693 Part 2 / ordeal#67): the re-checked/pass case
+//! exits 0, the never-re-checked and `*-ref` indirection cases fail
+//! with legible diagnostics, and the docs topic is served.
+
+// rivet: verifies REQ-277
+
+use std::process::Command;
+
+fn rivet_bin() -> std::path::PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_rivet") {
+        return std::path::PathBuf::from(bin);
+    }
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest.parent().expect("workspace root");
+    workspace_root.join("target").join("debug").join("rivet")
+}
+
+/// Build a tmpdir project loading the embedded `ordeal-certificate`
+/// schema (plus common+dev) with the given artifacts file.
+fn cert_project(artifacts_yaml: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let dir = tmp.path();
+
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: ordeal-cert-test\n  version: \"0.1.0\"\n  \
+         schemas: [common, dev, ordeal-certificate]\nsources:\n  - path: artifacts\n    \
+         format: generic-yaml\n",
+    )
+    .expect("write rivet.yaml");
+
+    let artifacts_dir = dir.join("artifacts");
+    std::fs::create_dir_all(&artifacts_dir).expect("artifacts dir");
+    std::fs::write(artifacts_dir.join("certs.yaml"), artifacts_yaml).expect("write fixture");
+
+    tmp
+}
+
+const RECHECKED_CERT: &str = r#"artifacts:
+  - id: REQ-1
+    type: requirement
+    title: Variant tls+nomalloc must be rejected
+    status: implemented
+    description: Fail closed with a certificate.
+  - id: FEAT-1
+    type: feature
+    title: Consistency decision for tls+nomalloc
+    status: implemented
+    links:
+      - type: satisfies
+        target: REQ-1
+  - id: OC-1
+    type: ordeal-certificate
+    title: variant tls+nomalloc inconsistent with feature model
+    status: verified
+    fields:
+      format: ordeal-cert/v1
+      verdict: unsat
+      produced-by: {name: ordeal, version: 0.17.0}
+      checked-by: {name: ordeal-lrat, version: 0.17.0}
+      attests-claim: variant-inconsistent
+      cnf-sha256: 3f786850e387550fdab836ed7e6dc881de23001b8e6f5f9db38f3ba4a4f4a1a5
+      proof-sha256: 89e6c98d92887913cadf06b2adb97f26cde4849b4b1a3b7ec1cbb06cd261f4d9
+      recheck: {command: 'ordeal-lrat check problem.cnf proof.lrat', expect-exit: 0}
+      verification-result: pass
+    links:
+      - type: attests-transform
+        target: FEAT-1
+      - type: verifies
+        target: REQ-1
+"#;
+
+fn run_validate(tmp: &tempfile::TempDir) -> std::process::Output {
+    Command::new(rivet_bin())
+        .args(["--project", tmp.path().to_str().unwrap(), "validate"])
+        .output()
+        .expect("run rivet validate")
+}
+
+/// A re-checked (verification-result: pass) certificate validates clean:
+/// exit 0, and its `verifies` link satisfies coverage.
+#[test]
+fn recheck_pass_certificate_validates_clean() {
+    let tmp = cert_project(RECHECKED_CERT);
+    let out = run_validate(&tmp);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "re-checked certificate project must validate.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+/// Dropping the recorded recheck outcome flips the same project to a
+/// failing validate: a never-re-checked certificate must not count as a
+/// verification link.
+#[test]
+fn never_rechecked_certificate_fails_validate() {
+    let fixture = RECHECKED_CERT.replace("      verification-result: pass\n", "");
+    assert_ne!(fixture, RECHECKED_CERT, "fixture edit must apply");
+    let tmp = cert_project(&fixture);
+    let out = run_validate(&tmp);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "never-re-checked certificate with a verifies link must fail validate.\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("V-ordeal-cert-recheck-gates-verifies") || stdout.contains("never"),
+        "diagnostic must name the recheck gate.\nstdout:\n{stdout}"
+    );
+}
+
+/// `cnf-ref` indirection fails with the legible v1 inline-only boundary
+/// error (mirroring ordeal's BundleError::Unsupported), not a mystery
+/// deserialize failure.
+#[test]
+fn ref_indirection_fails_with_legible_unsupported_error() {
+    let fixture = RECHECKED_CERT.replace(
+        "      cnf-sha256: 3f786850e387550fdab836ed7e6dc881de23001b8e6f5f9db38f3ba4a4f4a1a5\n",
+        "      cnf-sha256: 3f786850e387550fdab836ed7e6dc881de23001b8e6f5f9db38f3ba4a4f4a1a5\n      \
+         cnf-ref: blobs/problem.cnf.zst\n",
+    );
+    assert_ne!(fixture, RECHECKED_CERT, "fixture edit must apply");
+    let tmp = cert_project(&fixture);
+    let out = run_validate(&tmp);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "cnf-ref indirection must fail validate.\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("unsupported") && stdout.contains("inline"),
+        "the boundary error must be legible.\nstdout:\n{stdout}"
+    );
+}
+
+/// The docs topic is served: `rivet docs schema/ordeal-certificate`
+/// explains the shape, the SAT boundary, and the recheck contract.
+#[test]
+fn docs_topic_is_served() {
+    let out = Command::new(rivet_bin())
+        .args(["docs", "schema/ordeal-certificate"])
+        .output()
+        .expect("run rivet docs");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "docs topic must exist: {stdout}");
+    for needle in [
+        "ordeal-cert/v1",
+        "SAT boundary",
+        "recheck",
+        "verification link",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "docs topic must mention `{needle}`:\n{stdout}"
+        );
+    }
+}

--- a/rivet-core/src/embedded.rs
+++ b/rivet-core/src/embedded.rs
@@ -36,6 +36,7 @@ pub const SCHEMA_DO_178C: &str = include_str!("../../schemas/do-178c.yaml");
 pub const SCHEMA_EN_50128: &str = include_str!("../../schemas/en-50128.yaml");
 pub const SCHEMA_IEC_61508: &str = include_str!("../../schemas/iec-61508.yaml");
 pub const SCHEMA_IEC_62304: &str = include_str!("../../schemas/iec-62304.yaml");
+pub const SCHEMA_ORDEAL_CERTIFICATE: &str = include_str!("../../schemas/ordeal-certificate.yaml");
 
 // ── Embedded migration recipes ──────────────────────────────────────────
 
@@ -89,6 +90,7 @@ pub const SCHEMA_NAMES: &[&str] = &[
     "en-50128",
     "iec-61508",
     "iec-62304",
+    "ordeal-certificate",
 ];
 
 /// Metadata for a built-in bridge schema.
@@ -217,6 +219,7 @@ pub fn embedded_schema(name: &str) -> Option<&'static str> {
         "en-50128" => Some(SCHEMA_EN_50128),
         "iec-61508" => Some(SCHEMA_IEC_61508),
         "iec-62304" => Some(SCHEMA_IEC_62304),
+        "ordeal-certificate" => Some(SCHEMA_ORDEAL_CERTIFICATE),
         _ => None,
     }
 }

--- a/rivet-core/tests/fixtures/ordeal-certificate.yaml
+++ b/rivet-core/tests/fixtures/ordeal-certificate.yaml
@@ -1,0 +1,53 @@
+# Golden fixture for the `ordeal-certificate` artifact type (rivet#693
+# Part 2 / ordeal#67). One fully-populated UNSAT certificate — the
+# certificate-carrying verdict — wired to the transform it attests and
+# the requirement it verifies. This file is the round-trip golden: the
+# CST parse must reproduce it byte-identically.
+artifacts:
+  - id: REQ-900
+    type: requirement
+    title: Variant tls+nomalloc must be rejected as inconsistent
+    status: implemented
+    description: >
+      The feature model forbids combining tls with nomalloc; the solve
+      must fail closed with a certificate.
+
+  - id: FEAT-900
+    type: feature
+    title: Feature-model consistency decision for variant tls+nomalloc
+    status: implemented
+    links:
+      - type: satisfies
+        target: REQ-900
+
+  - id: OC-900
+    type: ordeal-certificate
+    title: variant tls+nomalloc inconsistent with feature model
+    status: verified
+    description: >
+      ordeal-cert/v1 UNSAT bundle for the tls+nomalloc consistency query.
+      Re-checked with the trusted LRAT checker on 2026-07-30; exit 0.
+    fields:
+      format: ordeal-cert/v1
+      verdict: unsat
+      produced-by:
+        name: ordeal
+        version: 0.17.0
+      checked-by:
+        name: ordeal-lrat
+        version: 0.17.0
+      attests-kind: propositional_consistency
+      attests-claim: variant-inconsistent
+      attests-standards: [EU-AI-Act:Art12, ISO-26262:6-9]
+      cnf-sha256: 3f786850e387550fdab836ed7e6dc881de23001b8e6f5f9db38f3ba4a4f4a1a5
+      proof-sha256: 89e6c98d92887913cadf06b2adb97f26cde4849b4b1a3b7ec1cbb06cd261f4d9
+      recheck:
+        command: ordeal-lrat check problem.cnf proof.lrat
+        expect-exit: 0
+      verification-result: pass
+      rechecked-at: 2026-07-30T00:00:00Z
+    links:
+      - type: attests-transform
+        target: FEAT-900
+      - type: verifies
+        target: REQ-900

--- a/rivet-core/tests/ordeal_certificate_schema.rs
+++ b/rivet-core/tests/ordeal_certificate_schema.rs
@@ -1,0 +1,514 @@
+// SAFETY-REVIEW (SCRC Phase 1, DD-058): Integration test / bench code.
+// Tests legitimately use unwrap/expect/panic/assert-indexing patterns
+// because a test failure should panic with a clear stack. Blanket-allow
+// the Phase 1 restriction lints at crate scope; real risk analysis for
+// these lints is carried by production code in rivet-core/src and
+// rivet-cli/src, not by the test harnesses.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::wildcard_enum_match_arm,
+    clippy::match_wildcard_for_single_variants,
+    clippy::panic,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::print_stderr
+)]
+
+//! Integration tests for the `ordeal-certificate` schema (rivet#693
+//! Part 2 / ordeal#67): the evidence artifact type describing an
+//! `ordeal-cert/v1` bundle.
+//!
+//! Covers the acceptance criteria mechanically:
+//! - schema registration + parse,
+//! - golden-file byte-identical round-trip,
+//! - `attests-transform` allowed-target enforcement (`link-target-type`),
+//! - the coverage split: a RE-CHECKED certificate counts as a
+//!   verification link, a never-re-checked one fails validation,
+//! - the v1 inline-only reader boundary (`cnf-ref`/`proof-ref` →
+//!   legible Unsupported-class error),
+//! - the UNSAT "re-checkable pair" conditional rule and the honest SAT
+//!   boundary warning.
+
+// rivet: verifies REQ-277
+
+use std::collections::BTreeMap;
+
+use rivet_core::embedded::{SCHEMA_NAMES, embedded_schema, load_embedded_schema};
+use rivet_core::links::LinkGraph;
+use rivet_core::model::{Artifact, Link};
+use rivet_core::schema::{Schema, SchemaFile, Severity};
+use rivet_core::store::Store;
+use rivet_core::validate::{Diagnostic, validate};
+
+fn parse_schema(name: &str) -> SchemaFile {
+    let content =
+        embedded_schema(name).unwrap_or_else(|| panic!("embedded schema `{name}` not found"));
+    serde_yaml::from_str(content)
+        .unwrap_or_else(|e| panic!("schema `{name}` failed to parse as SchemaFile: {e}"))
+}
+
+/// Merged schema a consuming project would load: common + dev (for
+/// requirement/feature and the requirement-verification coverage rule)
+/// + ordeal-certificate.
+fn merged_schema() -> Schema {
+    Schema::merge(&[
+        parse_schema("common"),
+        parse_schema("dev"),
+        parse_schema("ordeal-certificate"),
+    ])
+}
+
+fn artifact(id: &str, art_type: &str, status: &str, links: &[(&str, &str)]) -> Artifact {
+    Artifact {
+        id: id.into(),
+        artifact_type: art_type.into(),
+        title: format!("Title {id}"),
+        description: Some(format!("Description {id}")),
+        status: Some(status.into()),
+        release: None,
+        tags: vec![],
+        links: links
+            .iter()
+            .map(|(lt, tgt)| Link {
+                link_type: (*lt).into(),
+                target: (*tgt).into(),
+                external: None,
+            })
+            .collect(),
+        fields: BTreeMap::new(),
+        fields_per_variant: Default::default(),
+        provenance: None,
+        source_file: None,
+    }
+}
+
+fn yaml(v: &str) -> serde_yaml::Value {
+    serde_yaml::Value::String(v.into())
+}
+
+/// A fully-populated, hash-carrying UNSAT certificate. `rechecked`
+/// controls whether the recheck outcome was recorded (`verification-
+/// result: pass`) — the axis the coverage split turns on.
+fn unsat_cert(id: &str, rechecked: bool, links: &[(&str, &str)]) -> Artifact {
+    let mut a = artifact(id, "ordeal-certificate", "implemented", links);
+    a.fields.insert("format".into(), yaml("ordeal-cert/v1"));
+    a.fields.insert("verdict".into(), yaml("unsat"));
+    a.fields.insert(
+        "produced-by".into(),
+        serde_yaml::from_str("{name: ordeal, version: 0.17.0}").unwrap(),
+    );
+    a.fields.insert(
+        "checked-by".into(),
+        serde_yaml::from_str("{name: ordeal-lrat, version: 0.17.0}").unwrap(),
+    );
+    a.fields
+        .insert("attests-claim".into(), yaml("variant-inconsistent"));
+    a.fields.insert(
+        "cnf-sha256".into(),
+        yaml("3f786850e387550fdab836ed7e6dc881de23001b8e6f5f9db38f3ba4a4f4a1a5"),
+    );
+    a.fields.insert(
+        "proof-sha256".into(),
+        yaml("89e6c98d92887913cadf06b2adb97f26cde4849b4b1a3b7ec1cbb06cd261f4d9"),
+    );
+    a.fields.insert(
+        "recheck".into(),
+        serde_yaml::from_str(
+            "{command: 'ordeal-lrat check problem.cnf proof.lrat', expect-exit: 0}",
+        )
+        .unwrap(),
+    );
+    if rechecked {
+        a.fields.insert("verification-result".into(), yaml("pass"));
+    }
+    a
+}
+
+fn run_validate(artifacts: Vec<Artifact>) -> Vec<Diagnostic> {
+    let schema = merged_schema();
+    let mut store = Store::default();
+    for a in artifacts {
+        store.upsert(a);
+    }
+    let graph = LinkGraph::build(&store, &schema);
+    validate(&store, &schema, &graph)
+}
+
+fn diags_for_rule<'a>(diags: &'a [Diagnostic], rule: &str) -> Vec<&'a Diagnostic> {
+    diags.iter().filter(|d| d.rule == rule).collect()
+}
+
+// ── Schema registration ─────────────────────────────────────────────────
+
+/// The embedded ordeal-certificate schema loads, is registered in
+/// SCHEMA_NAMES, and declares the artifact type, the typed link, the
+/// conditional rule, and all three validation rules.
+#[test]
+fn ordeal_certificate_schema_registered_and_declares_the_contract() {
+    assert!(
+        SCHEMA_NAMES.contains(&"ordeal-certificate"),
+        "SCHEMA_NAMES must include 'ordeal-certificate'"
+    );
+
+    let file = load_embedded_schema("ordeal-certificate")
+        .expect("ordeal-certificate schema must load and parse");
+    assert_eq!(file.schema.name, "ordeal-certificate");
+
+    let type_names: Vec<&str> = file
+        .artifact_types
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect();
+    assert_eq!(type_names, vec!["ordeal-certificate"]);
+
+    // The AC field list, mapped recognizably from the ordeal-cert/v1
+    // envelope.
+    let cert = &file.artifact_types[0];
+    let fields: Vec<&str> = cert.fields.iter().map(|f| f.name.as_str()).collect();
+    for expected in [
+        "format",
+        "verdict",
+        "produced-by",
+        "checked-by",
+        "attests-kind",
+        "attests-claim",
+        "attests-standards",
+        "cnf-sha256",
+        "cnf-ref",
+        "proof-sha256",
+        "proof-ref",
+        "recheck",
+        "verification-result",
+    ] {
+        assert!(fields.contains(&expected), "missing field `{expected}`");
+    }
+
+    // Typed attests-transform link with declared allowed targets.
+    let link = file
+        .link_types
+        .iter()
+        .find(|l| l.name == "attests-transform")
+        .expect("attests-transform link type must be declared");
+    assert_eq!(link.inverse.as_deref(), Some("transform-attested-by"));
+    assert!(
+        !link.target_types.is_empty(),
+        "attests-transform must declare allowed targets"
+    );
+
+    let rule_ids: Vec<&str> = file
+        .validation_rules
+        .iter()
+        .map(|r| r.id.as_str())
+        .collect();
+    for expected in [
+        "V-ordeal-cert-recheck-gates-verifies",
+        "V-ordeal-cert-v1-inline-only",
+        "V-ordeal-cert-sat-is-self-checked",
+    ] {
+        assert!(rule_ids.contains(&expected), "missing rule `{expected}`");
+    }
+    assert!(
+        file.conditional_rules
+            .iter()
+            .any(|r| r.name == "unsat-cert-carries-recheckable-pair"),
+        "missing conditional rule"
+    );
+}
+
+// ── Golden file: byte-identical round-trip ──────────────────────────────
+
+/// The golden fixture round-trips byte-identically through the lossless
+/// CST parser, parses into the expected artifact shape, and validates
+/// with zero errors against common+dev+ordeal-certificate.
+#[test]
+fn golden_fixture_roundtrips_byte_identical_and_validates_clean() {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/ordeal-certificate.yaml");
+    let source = std::fs::read_to_string(&path).expect("read golden fixture");
+
+    // Byte-identical CST round-trip.
+    let (green, errors) = rivet_core::yaml_cst::parse(&source);
+    assert!(
+        errors.is_empty(),
+        "golden fixture must parse cleanly: {errors:?}"
+    );
+    let root = rowan::SyntaxNode::<rivet_core::yaml_cst::YamlLanguage>::new_root(green);
+    assert_eq!(
+        root.text().to_string(),
+        source,
+        "golden fixture must round-trip byte-identically"
+    );
+
+    // Serde parse into artifacts with the expected shape.
+    let artifacts = rivet_core::formats::generic::parse_generic_yaml(&source, Some(&path))
+        .expect("golden fixture must parse as generic-yaml artifacts");
+    assert_eq!(artifacts.len(), 3, "REQ + FEAT + certificate");
+    let cert = artifacts
+        .iter()
+        .find(|a| a.artifact_type == "ordeal-certificate")
+        .expect("certificate artifact present");
+    assert_eq!(cert.id, "OC-900");
+    assert_eq!(
+        cert.fields.get("format").and_then(|v| v.as_str()),
+        Some("ordeal-cert/v1")
+    );
+    assert_eq!(
+        cert.fields.get("verdict").and_then(|v| v.as_str()),
+        Some("unsat")
+    );
+    let recheck = cert.fields.get("recheck").expect("recheck block present");
+    assert_eq!(
+        recheck.get("command").and_then(|v| v.as_str()),
+        Some("ordeal-lrat check problem.cnf proof.lrat")
+    );
+    assert_eq!(
+        recheck
+            .get("expect-exit")
+            .and_then(serde_yaml::Value::as_i64),
+        Some(0)
+    );
+    assert!(
+        cert.links
+            .iter()
+            .any(|l| l.link_type == "attests-transform" && l.target == "FEAT-900"),
+        "attests-transform link present"
+    );
+
+    // Zero errors when validated as a store.
+    let diags = run_validate(artifacts);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "golden fixture must validate error-free: {errors:?}"
+    );
+}
+
+// ── link-target-type enforcement ────────────────────────────────────────
+
+/// `attests-transform` may target a requirement/feature/design-decision/
+/// aadl-component; anything else draws a `link-target-type` error.
+#[test]
+fn attests_transform_allowed_targets_are_enforced() {
+    // Right-type target: a feature.
+    let feat = artifact(
+        "FEAT-1",
+        "feature",
+        "implemented",
+        &[("satisfies", "REQ-1")],
+    );
+    let req = artifact("REQ-1", "requirement", "implemented", &[]);
+    let good = unsat_cert(
+        "OC-1",
+        true,
+        &[("attests-transform", "FEAT-1"), ("verifies", "REQ-1")],
+    );
+    let diags = run_validate(vec![req.clone(), feat.clone(), good]);
+    assert!(
+        diags_for_rule(&diags, "link-target-type").is_empty(),
+        "feature is an allowed attests-transform target: {diags:?}"
+    );
+
+    // Wrong-type target: a dev `verification` artifact is NOT an allowed
+    // transform target.
+    let ver = artifact(
+        "VER-1",
+        "verification",
+        "implemented",
+        &[("verifies", "REQ-1")],
+    );
+    let bad = unsat_cert(
+        "OC-2",
+        true,
+        &[("attests-transform", "VER-1"), ("verifies", "REQ-1")],
+    );
+    let diags = run_validate(vec![req, feat, ver, bad]);
+    let hits = diags_for_rule(&diags, "link-target-type");
+    assert_eq!(
+        hits.len(),
+        1,
+        "wrong-type attests-transform target must fire link-target-type: {diags:?}"
+    );
+    assert!(
+        hits[0].message.contains("attests-transform"),
+        "{}",
+        hits[0].message
+    );
+}
+
+// ── Coverage split: re-checked counts, never-re-checked does not ────────
+
+/// A re-checked certificate (`verification-result: pass`) is a
+/// verification link: its `verifies` backlink satisfies the dev
+/// `requirement-verification` coverage rule and draws no gate error. A
+/// certificate whose recheck was never run fails validation when it
+/// claims `verifies` — it cannot silently count as coverage.
+#[test]
+fn recheck_split_governs_verification_coverage() {
+    let gate = "V-ordeal-cert-recheck-gates-verifies";
+
+    // REQ-A: verified by a RE-CHECKED certificate.
+    let req_a = artifact("REQ-A", "requirement", "implemented", &[]);
+    let cert_ok = unsat_cert("OC-A", true, &[("verifies", "REQ-A")]);
+
+    // REQ-B: "verified" by a NEVER-re-checked certificate.
+    let req_b = artifact("REQ-B", "requirement", "implemented", &[]);
+    let cert_unchecked = unsat_cert("OC-B", false, &[("verifies", "REQ-B")]);
+
+    // REQ-C: baseline — no verification at all.
+    let req_c = artifact("REQ-C", "requirement", "implemented", &[]);
+
+    let diags = run_validate(vec![req_a, cert_ok, req_b, cert_unchecked, req_c]);
+
+    // The re-checked certificate is clean and counts: no gate error on
+    // OC-A, no requirement-verification gap on REQ-A.
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.rule == gate && d.artifact_id.as_deref() == Some("OC-A")),
+        "re-checked certificate must not fire the gate: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|d| {
+            d.rule == "requirement-verification" && d.artifact_id.as_deref() == Some("REQ-A")
+        }),
+        "re-checked certificate must satisfy requirement-verification for REQ-A: {diags:?}"
+    );
+
+    // The never-re-checked certificate fails validation (error severity).
+    let unchecked_hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.rule == gate && d.artifact_id.as_deref() == Some("OC-B"))
+        .collect();
+    assert_eq!(
+        unchecked_hits.len(),
+        1,
+        "never-re-checked certificate with a verifies link must fire the gate: {diags:?}"
+    );
+    assert_eq!(unchecked_hits[0].severity, Severity::Error);
+    assert!(
+        unchecked_hits[0].message.contains("never"),
+        "gate message must say the recheck never ran: {}",
+        unchecked_hits[0].message
+    );
+
+    // Baseline: the coverage rule itself is active — REQ-C is flagged.
+    assert!(
+        diags.iter().any(|d| {
+            d.rule == "requirement-verification" && d.artifact_id.as_deref() == Some("REQ-C")
+        }),
+        "unverified REQ-C must be flagged by requirement-verification: {diags:?}"
+    );
+
+    // A certificate with NO verifies links and no recheck is fine — it is
+    // an ingested claim, just not verification evidence.
+    let req = artifact("REQ-D", "requirement", "implemented", &[]);
+    let dormant = unsat_cert("OC-D", false, &[]);
+    let diags = run_validate(vec![req, dormant]);
+    assert!(
+        diags_for_rule(&diags, gate).is_empty(),
+        "a certificate without verifies links needs no recheck record: {diags:?}"
+    );
+}
+
+// ── v1 inline-only reader boundary ──────────────────────────────────────
+
+/// `cnf-ref` / `proof-ref` indirection surfaces as a legible
+/// Unsupported-class validation error (mirroring ordeal's
+/// BundleError::Unsupported), not a mystery failure.
+#[test]
+fn ref_indirection_is_a_legible_unsupported_error() {
+    let rule = "V-ordeal-cert-v1-inline-only";
+    let req = artifact("REQ-1", "requirement", "implemented", &[]);
+
+    for ref_field in ["cnf-ref", "proof-ref"] {
+        let mut cert = unsat_cert("OC-REF", true, &[("verifies", "REQ-1")]);
+        cert.fields
+            .insert(ref_field.into(), yaml("blobs/problem.cnf.zst"));
+        let diags = run_validate(vec![req.clone(), cert]);
+        let hits = diags_for_rule(&diags, rule);
+        assert_eq!(hits.len(), 1, "`{ref_field}` must fire {rule}: {diags:?}");
+        assert_eq!(hits[0].severity, Severity::Error);
+        let msg = &hits[0].message;
+        assert!(
+            msg.contains("unsupported") && msg.contains("inline") && msg.contains("Unsupported"),
+            "the error must be legible about the v1 inline-only boundary: {msg}"
+        );
+    }
+
+    // Inline bundle: no boundary error.
+    let inline_cert = unsat_cert("OC-IN", true, &[("verifies", "REQ-1")]);
+    let diags = run_validate(vec![req, inline_cert]);
+    assert!(diags_for_rule(&diags, rule).is_empty(), "{diags:?}");
+}
+
+// ── UNSAT re-checkable pair + honest SAT boundary ───────────────────────
+
+/// An `unsat` certificate must carry the re-checkable pair (checker +
+/// both content hashes); a `sat` one is exempt (self-checked model).
+#[test]
+fn unsat_verdict_requires_the_recheckable_pair() {
+    let rule = "unsat-cert-carries-recheckable-pair";
+
+    // Strip the pair from an unsat cert → three required-field errors.
+    let mut bare = unsat_cert("OC-BARE", false, &[]);
+    bare.fields.remove("checked-by");
+    bare.fields.remove("cnf-sha256");
+    bare.fields.remove("proof-sha256");
+    let diags = run_validate(vec![bare]);
+    let hits = diags_for_rule(&diags, rule);
+    assert_eq!(
+        hits.len(),
+        3,
+        "unsat without checked-by/cnf-sha256/proof-sha256 must fire {rule} 3x: {diags:?}"
+    );
+
+    // A sat certificate does not need the pair.
+    let mut sat = unsat_cert("OC-SAT", false, &[]);
+    sat.fields.insert("verdict".into(), yaml("sat"));
+    sat.fields
+        .insert("attests-claim".into(), yaml("variant-consistent"));
+    sat.fields.remove("checked-by");
+    sat.fields.remove("cnf-sha256");
+    sat.fields.remove("proof-sha256");
+    let diags = run_validate(vec![sat]);
+    assert!(diags_for_rule(&diags, rule).is_empty(), "{diags:?}");
+}
+
+/// The honest SAT boundary: a `sat` certificate used as a `verifies`
+/// source draws a warning — the model is self-checked, not
+/// independently re-checked.
+#[test]
+fn sat_certificate_as_verifies_source_warns() {
+    let rule = "V-ordeal-cert-sat-is-self-checked";
+    let req = artifact("REQ-1", "requirement", "implemented", &[]);
+
+    let mut sat = unsat_cert("OC-SAT", true, &[("verifies", "REQ-1")]);
+    sat.fields.insert("verdict".into(), yaml("sat"));
+    sat.fields
+        .insert("attests-claim".into(), yaml("variant-consistent"));
+    let diags = run_validate(vec![req.clone(), sat]);
+    let hits = diags_for_rule(&diags, rule);
+    assert_eq!(hits.len(), 1, "SAT + verifies must warn: {diags:?}");
+    assert_eq!(hits[0].severity, Severity::Warning);
+    assert!(
+        hits[0].message.contains("self-checked"),
+        "{}",
+        hits[0].message
+    );
+
+    // An unsat certificate as a verifies source does not warn.
+    let unsat = unsat_cert("OC-U", true, &[("verifies", "REQ-1")]);
+    let diags = run_validate(vec![req, unsat]);
+    assert!(diags_for_rule(&diags, rule).is_empty(), "{diags:?}");
+}

--- a/rivet.yaml
+++ b/rivet.yaml
@@ -61,6 +61,10 @@ docs-check:
     # schemas/score.yaml's `external-clause` artifact description.
     # Stable standard-clause identifier, not a version.
     - "7.4.3"
+    # ordeal v0.17.0 — the upstream ordeal-cert/v1 contract release
+    # referenced by the ordeal-certificate schema + docs topic (#693).
+    # An ordeal version, not rivet's own.
+    - "0.17.0"
 
 results: results
 

--- a/schemas/ordeal-certificate.yaml
+++ b/schemas/ordeal-certificate.yaml
@@ -1,0 +1,353 @@
+# ordeal-certificate schema (rivet#693 Part 2 / ordeal#67).
+#
+# Declares the `ordeal-certificate` evidence artifact type: rivet's
+# description of an `ordeal-cert/v1` bundle — the machine-re-checkable
+# certificate ordeal emits for a verified transform (a variant/feature-model
+# consistency query, a loom rule proof, a synth codegen equivalence, a sigil
+# overflow check, a spar layout, a gale bitvector query).
+#
+# The upstream serialization contract is ordeal-cert/v1 as shipped in ordeal
+# v0.17.0 (`cert-bundle` feature: `Certificate::to_cert_v1` /
+# `from_cert_v1`, `UnsatBundle::recheck()` — ordeal PR #107). Field names
+# here correspond recognizably to that envelope:
+#
+#   envelope                     this artifact type
+#   ────────────────────────     ─────────────────────────────
+#   format                       format
+#   verdict                      verdict
+#   produced_by {name,version}   produced-by
+#   checked_by {name,version}    checked-by
+#   attests.kind                 attests-kind
+#   attests.claim                attests-claim
+#   attests.standards            attests-standards
+#   recheck.problem_sha256       cnf-sha256
+#   recheck.proof_sha256         proof-sha256
+#   recheck.cmd                  recheck.command
+#   (exit contract)              recheck.expect-exit
+#
+# Two boundaries are baked in, not papered over:
+#
+# 1. The honest SAT boundary. UNSAT is the certificate-carrying verdict:
+#    the bundle carries a DIMACS CNF + LRAT proof that an independent
+#    trusted checker re-validates. For SAT verdicts (e.g. `attests-claim:
+#    variant-consistent`) the proof-* fields describe the SELF-CHECKED
+#    model — ordeal ships no independently re-checkable SAT witness yet.
+#    A SAT certificate used as a `verifies` source draws a warning
+#    (rule `V-ordeal-cert-sat-is-self-checked`).
+#
+# 2. The v1 inline-only reader boundary. `cnf-ref` / `proof-ref`
+#    external-blob indirection is part of the contract for MB-class
+#    proofs but DEFERRED: ordeal's v1 reader rejects it as
+#    `BundleError::Unsupported`, and `rivet validate` mirrors that with a
+#    legible error (rule `V-ordeal-cert-v1-inline-only`) instead of a
+#    mystery failure downstream.
+#
+# Coverage semantics: `rivet validate` treats a RE-CHECKED certificate as
+# a verification link, not a claimed status. A certificate whose
+# `recheck.command` was actually run and exited per `recheck.expect-exit`
+# records `verification-result: pass`; only then may it source `verifies`
+# links (rule `V-ordeal-cert-recheck-gates-verifies`, severity error). A
+# never-re-checked certificate that claims `verifies` fails validation —
+# it cannot silently count toward requirement-verification coverage.
+
+schema:
+  name: ordeal-certificate
+  version: "0.1.0"
+  extends: [common]
+  description: >
+    Evidence artifact type for ordeal-cert/v1 certificate bundles: a
+    machine-re-checkable proof artifact (DIMACS CNF + LRAT for UNSAT;
+    self-checked model for SAT) attesting a verified transform, ingested
+    as DO-178C / ISO 26262 / EU-AI-Act-Art-12 evidence. Re-checked
+    certificates count as verification links; never-re-checked ones do
+    not.
+
+# ──────────────────────────────────────────────────────────────────────────
+# Artifact types
+# ──────────────────────────────────────────────────────────────────────────
+artifact-types:
+
+  - name: ordeal-certificate
+    description: >
+      An ordeal-cert/v1 certificate bundle ingested as evidence. Records
+      who produced and who checked the certificate, what it attests
+      (claim + standard clauses served), the sha256 content addresses of
+      the CNF problem and the proof, and the recheck contract (the exact
+      command an auditor runs, and the exit code that means "the
+      mathematics re-checked"). The certificate becomes a verification
+      link only after the recheck command was actually executed and the
+      outcome recorded in `verification-result`. Use the base
+      `cited-source` field to pin the bundle JSON file itself
+      (sha256-stamped) when it is stored in-repo.
+    fields:
+      - name: format
+        type: string
+        required: true
+        allowed-values: ["ordeal-cert/v1"]
+        description: >
+          Upstream envelope format identifier. Only ordeal-cert/v1 is
+          supported; the allowed-values pin makes a future v2 an explicit
+          schema change, not a silent reinterpretation.
+      - name: verdict
+        type: string
+        required: true
+        allowed-values: [sat, unsat]
+        description: >
+          The solver verdict the bundle carries. `unsat` is the
+          certificate-carrying verdict (CNF + LRAT, independently
+          re-checkable); `sat` carries a self-checked model only — see
+          the honest SAT boundary in the schema header.
+      - name: produced-by
+        type: mapping
+        required: true
+        description: >
+          Tool identification of the producer, mirroring the envelope's
+          `produced_by` block. Keys: `name` (e.g. `ordeal`), `version`
+          (e.g. `0.17.0`).
+      - name: checked-by
+        type: mapping
+        required: false
+        description: >
+          Tool identification of the trusted checker that validated the
+          certificate at emission time, mirroring `checked_by`. Keys:
+          `name` (e.g. `ordeal-lrat`), `version`. Required for `unsat`
+          verdicts (conditional rule `unsat-cert-carries-recheckable-pair`);
+          SAT bundles have no independent checker — that is the boundary.
+      - name: attests-kind
+        type: string
+        required: false
+        description: >
+          The envelope's `attests.kind` — the query class this
+          certificate belongs to. Upstream conventions:
+          `propositional_consistency`, `qf_bv_validity`, `equivalence`.
+      - name: attests-claim
+        type: string
+        required: true
+        description: >
+          The envelope's `attests.claim` — what this certificate proves.
+          Conventions: `variant-consistent` (SAT), `variant-inconsistent`
+          (UNSAT), or a free-form structured claim for other transform
+          classes (loom rule proofs, synth codegen equivalence, sigil
+          overflow, spar layout, gale bitvector).
+      - name: attests-standards
+        type: list<string>
+        required: false
+        description: >
+          Standard clauses this evidence serves, mirroring
+          `attests.standards` (e.g. `DO-178C:6.4`, `ISO-26262:6-9`,
+          `EU-AI-Act:Art12`).
+      - name: cnf-sha256
+        type: string
+        required: false
+        description: >
+          sha256 (hex) of the canonical DIMACS clause text of the CNF
+          problem — the envelope's `recheck.problem_sha256`. Upstream
+          verifies this hash BEFORE parsing returns; a mismatch means the
+          bundle was altered and must not be trusted. Required for
+          `unsat` verdicts.
+      - name: cnf-ref
+        type: string
+        required: false
+        description: >
+          External-blob reference for the CNF problem. Declared because
+          it is part of the contract for MB-class proofs, but NOT
+          SUPPORTED by the v1 inline-only reader — using it is a
+          validation error (`V-ordeal-cert-v1-inline-only`), mirroring
+          ordeal's BundleError::Unsupported.
+      - name: proof-sha256
+        type: string
+        required: false
+        description: >
+          sha256 (hex) of the proof payload — the envelope's
+          `recheck.proof_sha256`. For `unsat` this is the LRAT proof body
+          (required); for `sat` the proof payload is the self-checked
+          model per the honest boundary.
+      - name: proof-ref
+        type: string
+        required: false
+        description: >
+          External-blob reference for the proof. Same v1 inline-only
+          boundary as `cnf-ref`: declared, not supported, legible error.
+      - name: recheck
+        type: mapping
+        required: true
+        description: >
+          The recheck contract, mirroring the envelope's `recheck` block.
+          Keys: `command` (the exact invocation of the trusted checker,
+          e.g. `ordeal-lrat check <problem> <proof>` — upstream `recheck.cmd`)
+          and `expect-exit` (the exit code that means the certificate
+          re-checked, normally 0). For `sat` bundles upstream ships a
+          note instead of a command — record the note in `description`
+          and leave `command` empty.
+      - name: verification-result
+        type: string
+        required: false
+        allowed-values: [pass, fail]
+        description: >
+          Recorded outcome of actually RUNNING `recheck.command`: `pass`
+          when it exited with `recheck.expect-exit`, `fail` otherwise.
+          ABSENT means the recheck was never run — the certificate is
+          then a claim, not verification evidence, and must not source
+          `verifies` links (rule `V-ordeal-cert-recheck-gates-verifies`).
+      - name: rechecked-at
+        type: string
+        required: false
+        description: >
+          UTC timestamp of the recorded recheck run (RFC 3339). Optional
+          provenance for the `verification-result` value.
+    link-fields:
+      - name: attests-transform
+        link-type: attests-transform
+        target-types: [requirement, feature, design-decision, aadl-component]
+        cardinality: zero-or-one
+        description: >
+          The artifact whose transform this certificate attests — a
+          variant/feature-model configuration decision, a loom rule, a
+          synth codegen step, a sigil overflow check, a spar layout, a
+          gale bitvector query — as modelled in the consuming project
+          (typically a requirement, feature, design-decision, or
+          aadl-component). Allowed targets are enforced by the
+          `link-target-type` rule.
+      - name: verifies
+        link-type: verifies
+        cardinality: zero-or-many
+        description: >
+          Verification links this certificate provides once re-checked.
+          Gated by `V-ordeal-cert-recheck-gates-verifies`: only a
+          certificate with `verification-result: pass` may source these.
+    common-mistakes:
+      - problem: >-
+          Certificate sources a `verifies` link but the recheck was never
+          run — a claimed status is not a verification link
+        fix-command: >-
+          Run the recorded recheck.command, then
+          rivet modify OC-XXX --set-field verification-result=pass
+      - problem: >-
+          Using `cnf-ref` / `proof-ref` external blobs — the v1 reader is
+          inline-only and rejects them (BundleError::Unsupported upstream)
+        fix-command: >-
+          Inline the payloads in the bundle and record cnf-sha256 /
+          proof-sha256 instead
+      - problem: >-
+          Treating a SAT certificate as independently re-checkable — SAT
+          carries a self-checked model; UNSAT is the certificate-carrying
+          verdict
+        fix-command: "See the honest SAT boundary: rivet docs schema/ordeal-certificate"
+    example: |
+      - id: OC-001
+        type: ordeal-certificate
+        title: variant tls+nomalloc inconsistent with feature model
+        status: verified
+        fields:
+          format: ordeal-cert/v1
+          verdict: unsat
+          produced-by: {name: ordeal, version: 0.17.0}
+          checked-by: {name: ordeal-lrat, version: 0.17.0}
+          attests-kind: propositional_consistency
+          attests-claim: variant-inconsistent
+          attests-standards: [EU-AI-Act:Art12]
+          cnf-sha256: 6c8b2f…64-hex…
+          proof-sha256: 9a01d4…64-hex…
+          recheck:
+            command: ordeal-lrat check problem.cnf proof.lrat
+            expect-exit: 0
+          verification-result: pass
+          rechecked-at: 2026-07-30T00:00:00Z
+        links:
+          - type: attests-transform
+            target: FEAT-042
+          - type: verifies
+            target: REQ-001
+
+# ──────────────────────────────────────────────────────────────────────────
+# Link types
+# ──────────────────────────────────────────────────────────────────────────
+link-types:
+  - name: attests-transform
+    inverse: transform-attested-by
+    description: >
+      A certificate attests the transform performed/decided by the target
+      artifact. The typed counterpart of the envelope's `attests` block:
+      it points the evidence at the thing it is evidence OF.
+    source-types: [ordeal-certificate]
+    target-types: [requirement, feature, design-decision, aadl-component]
+
+# ──────────────────────────────────────────────────────────────────────────
+# Conditional rules
+# ──────────────────────────────────────────────────────────────────────────
+conditional-rules:
+  - name: unsat-cert-carries-recheckable-pair
+    description: >
+      UNSAT is the certificate-carrying verdict: the bundle must name the
+      trusted checker and carry both content hashes so the pair is
+      independently re-checkable.
+    when:
+      field: verdict
+      equals: unsat
+    then:
+      required-fields: [checked-by, cnf-sha256, proof-sha256]
+    severity: error
+
+# ──────────────────────────────────────────────────────────────────────────
+# Validation rules (s-expression status gates)
+# ──────────────────────────────────────────────────────────────────────────
+validation-rules:
+  - id: V-ordeal-cert-recheck-gates-verifies
+    description: >
+      A re-checked certificate is a verification link; a never-re-checked
+      one is a claimed status. Only a certificate whose recheck command
+      was actually executed with the expected exit code (recorded as
+      verification-result: pass) may source `verifies` links — so a
+      certificate that was never re-checked cannot count toward
+      requirement-verification coverage.
+    rule: |
+      (implies
+        (and (= type "ordeal-certificate")
+             (links-count "verifies" > 0))
+        (= verification-result "pass"))
+    severity: error
+    message: |
+      {id} (ordeal-certificate) sources `verifies` links but its recheck
+      was never recorded as executed with the expected exit code
+      (verification-result is absent or not `pass`). A never-re-checked
+      certificate is a claim, not verification evidence: run the
+      recheck command and record the outcome.
+
+  - id: V-ordeal-cert-v1-inline-only
+    description: >
+      The v1 reader boundary: ordeal-cert/v1 bundles are
+      inline-payload-only. `cnf-ref` / `proof-ref` external-blob
+      indirection is in the contract for MB-class proofs but deferred —
+      upstream rejects it as BundleError::Unsupported, and rivet surfaces
+      the same boundary as a legible validation error.
+    rule: |
+      (implies
+        (= type "ordeal-certificate")
+        (and (not (has-field "cnf-ref"))
+             (not (has-field "proof-ref"))))
+    severity: error
+    message: |
+      {id}: unsupported by the ordeal-cert/v1 reader — `cnf-ref` /
+      `proof-ref` external-blob indirection is not supported (v1 bundles
+      are inline-payload-only; upstream ordeal rejects such bundles as
+      BundleError::Unsupported). Inline the payload and record
+      cnf-sha256 / proof-sha256 instead.
+
+  - id: V-ordeal-cert-sat-is-self-checked
+    description: >
+      The honest SAT boundary: a `sat` verdict carries a model that was
+      self-checked at solve time — ordeal ships no independently
+      re-checkable SAT witness yet, so a SAT certificate used as a
+      `verifies` source is flagged (warning) rather than silently
+      treated as checker-validated evidence.
+    rule: |
+      (implies
+        (and (= type "ordeal-certificate")
+             (= verdict "sat"))
+        (not (links-count "verifies" > 0)))
+    severity: warning
+    message: |
+      {id} is a SAT certificate used as a `verifies` source: the model
+      was self-checked at solve time, not independently re-checked
+      (UNSAT is the certificate-carrying verdict). Keep the link only if
+      self-checked evidence is acceptable for this claim.


### PR DESCRIPTION
Implements Part 2 of #693 (the `ordeal-certificate` evidence artifact type), unblocked by ordeal v0.17.0 / pulseengine/ordeal#107 (`cert-bundle` feature). Implements REQ-277; refs pulseengine/ordeal#67.

## AC checklist → what implements it

- [x] **New embedded schema declaring the type + fields** — `schemas/ordeal-certificate.yaml` (registered in `rivet-core/src/embedded.rs`: `SCHEMA_ORDEAL_CERTIFICATE`, `SCHEMA_NAMES`, `embedded_schema()`). Chosen as a *separate schema file* (not a `common.yaml` extension) because that is what the loader composes cleanly (`extends: [common]`, same pattern as `vv-coverage`). Fields map recognizably onto the ordeal-cert/v1 envelope: `format` (pinned to `ordeal-cert/v1` via allowed-values), `verdict` (`sat`/`unsat`), `produced-by` / `checked-by` (mapping `{name, version}`), `attests-kind` / `attests-claim` / `attests-standards` (the envelope's `attests` block, flattened so the claim is reachable by validation rules), `cnf-sha256`/`cnf-ref`, `proof-sha256`/`proof-ref`, structured `recheck` mapping (`command`, `expect-exit`), plus the rivet-side recheck record `verification-result` (`pass`/`fail`) and `rechecked-at`. A conditional rule (`unsat-cert-carries-recheckable-pair`) requires `checked-by` + both hashes for `unsat` verdicts.
- [x] **Typed `attests-transform` link-field with allowed-target enforcement** — link type `attests-transform` (inverse `transform-attested-by`, source `ordeal-certificate`) and a link-field with `target-types: [requirement, feature, design-decision, aadl-component]`, enforced by the existing `link-target-type` check (no new machinery). Wrong-type targets produce the standard `link-target-type` error.
- [x] **Re-checked certificate = verification link; never-re-checked ≠ coverage** — schema-declared s-expression validation rule `V-ordeal-cert-recheck-gates-verifies` (severity **error**): an `ordeal-certificate` sourcing `verifies` links must carry `verification-result: pass` (the recorded outcome of running `recheck.command` with exit per `recheck.expect-exit`). A re-checked certificate's `verifies` backlink then satisfies the existing `requirement-verification` coverage rule like any other verification artifact; a never-re-checked one **fails `rivet validate`** — it cannot silently count. Note the honest mechanics: the structural coverage rule itself cannot express field conditions, so "does not count" is enforced as *validation failure on the claiming certificate* rather than as a silent coverage gap — strictly stronger (the store cannot be green while a non-re-checked cert claims `verifies`).
- [x] **Honest SAT boundary baked in** — documented in the schema header + field docs + docs topic, and mechanized as warning rule `V-ordeal-cert-sat-is-self-checked`: a `sat`-verdict certificate used as a `verifies` source is flagged (self-checked model, no independently re-checkable SAT witness; UNSAT is the certificate-carrying verdict). `sat` verdicts are exempt from the UNSAT re-checkable-pair conditional rule.
- [x] **v1 reader boundary as expected-error fixture** — error rule `V-ordeal-cert-v1-inline-only`: any `cnf-ref`/`proof-ref` use produces `ERROR: [OC-1] OC-1: unsupported by the ordeal-cert/v1 reader — … BundleError::Unsupported … inline the payload …` (exit 1), mirroring ordeal's `from_cert_v1` boundary. Covered by `ref_indirection_is_a_legible_unsupported_error` (core) and `ref_indirection_fails_with_legible_unsupported_error` (CLI, real `rivet validate` run).
- [x] **Golden-file + link-target-type + coverage-split tests** — `rivet-core/tests/fixtures/ordeal-certificate.yaml` (golden fixture) round-trips **byte-identically** through the lossless CST parser, parses to the expected shape, and validates error-free (`golden_fixture_roundtrips_byte_identical_and_validates_clean`); `attests_transform_allowed_targets_are_enforced` demonstrates allowed-targets enforcement (right-type clean / wrong-type errors); `recheck_split_governs_verification_coverage` demonstrates the split (re-checked → no gate error + `requirement-verification` satisfied; never-re-checked → error; unverified baseline → coverage warning). Plus 4 end-to-end CLI tests in `rivet-cli/tests/ordeal_certificate.rs` running the real `rivet validate` binary over tmpdir projects (pass exits 0; never-re-checked and `cnf-ref` cases exit 1 with legible diagnostics).
- [x] **`rivet docs` topic** — `rivet docs schema/ordeal-certificate` (follows the existing `schema/<name>` topic convention) serves `docs/artifact-types/ordeal-certificate.md` (shape table, SAT boundary, recheck invocation contract, link to ordeal-cert/v1 as shipped: pulseengine/ordeal#107, ordeal v0.17.0 `cert-bundle`) with the schema source appended. Listed in `docs/schemas.md`. Covered by the `docs_topic_is_served` test.
- [x] **Commit trailers** — `Implements: REQ-277` (new REQ appended to `artifacts/requirements.yaml`) + `Refs: ordeal#67, #693`.
- [x] **Part 1 explicitly out of scope** — no `--certify` flag, no shell-out to ordeal, no CI wiring, no `rules_ordeal` gate, no UNSAT-core diagnostics. This PR only defines/ingests the artifact type.

## Honest notes / limitations

- The dedicated `requirement-verification` traceability rule counts any `verifies` backlink structurally; the "never-re-checked does not count" semantics are enforced by making such a link a **validation error** on the certificate (see above), not by filtering the coverage count. If a future consumer needs warnings-only stores to exclude un-re-checked certs from coverage *silently*, that would need a field-conditional extension to `TraceabilityRule` — deliberately not invented here.
- `verification-result` is a recorded field, not an automatically captured execution result. Part 1 (out of scope) is where rivet would run the recheck itself and stamp the outcome; until then the field is written by whatever executes the recheck (CI step, auditor), and the schema documents that contract.
- `attests` is flattened to `attests-kind`/`attests-claim`/`attests-standards` (rather than one mapping) so the claim/verdict are reachable by the s-expression rule engine and `allowed-values` checks; the docs topic carries the exact envelope↔field correspondence table.

## Gates run locally

- `cargo test` (full workspace) — pass
- `cargo clippy --all-targets -- -D warnings` — pass; `cargo clippy -p rivet-cli --no-default-features -- -D warnings` — pass
- `cargo fmt --all -- --check` — pass
- `rivet validate` (this repo) — PASS (0 errors)
- `rivet docs check` — PASS (0 violations)
- `yamllint -c .yamllint.yaml schemas/ artifacts/ rivet.yaml .github/` — exit 0 (pre-existing line-length warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBJ6kdJ16E3hnsBbq9Lwf1
