### PR TITLE
fix(yaml-hir): preserve plain-scalar field values that contain commas (#747)

### DIFF
--- a/rivet-core/src/yaml_hir.rs
+++ b/rivet-core/src/yaml_hir.rs
@@ -1420,11 +1420,21 @@ fn node_to_yaml_value(value_node: &SyntaxNode) -> serde_yaml::Value {
         if let rowan::NodeOrToken::Token(t) = token {
             let k = t.kind();
             match k {
-                SyntaxKind::PlainScalar
-                | SyntaxKind::SingleQuotedScalar
-                | SyntaxKind::DoubleQuotedScalar => {
+                SyntaxKind::SingleQuotedScalar | SyntaxKind::DoubleQuotedScalar => {
                     let raw = t.text().to_string();
                     return scalar_to_yaml_value(k, &raw);
+                }
+                SyntaxKind::PlainScalar => {
+                    // The lexer breaks plain scalars at `,`, `]`, `}` (see
+                    // `lex_plain_scalar` in yaml_cst.rs). Reading only this
+                    // token would truncate a scalar like
+                    // `foo, bar` to `foo` and silently drop evidence — the
+                    // bug behind issue #747, where `test-name` values with
+                    // commas were losing every element after the first.
+                    // Reassemble via `scalar_text`, which walks sibling
+                    // tokens up to the next Newline / Comment.
+                    let raw = scalar_text(value_node).unwrap_or_else(|| t.text().to_string());
+                    return plain_scalar_to_value(&raw);
                 }
                 _ => {}
             }
@@ -2499,5 +2509,56 @@ artifacts:
         assert_eq!(indu.get("max-temp-c").and_then(|v| v.as_u64()), Some(100));
         // priority inherits from default
         assert_eq!(indu.get("priority").and_then(|v| v.as_str()), Some("must"));
+    }
+
+    /// Issue #747: the schema-driven parser must preserve plain-scalar
+    /// field values that contain commas. The CST lexer breaks plain
+    /// scalars at `,`, `]`, `}` (see `lex_plain_scalar` in yaml_cst.rs),
+    /// and `node_to_yaml_value` previously read only the first token —
+    /// so `test-name: a, b` truncated to `a` and evidence was silently
+    /// lost. The fix reassembles the sibling tokens the lexer split.
+    #[test]
+    fn schema_driven_preserves_field_value_with_commas() {
+        let source = "\
+artifacts:
+  - id: VAL-010
+    type: requirement
+    title: Validation with two tests
+    fields:
+      method: unit-test
+      test-location: crates/x/src/y.rs
+      test-name: tests::first, tests::second
+";
+        let schema = crate::schema::Schema::merge(&[]);
+        let parsed = extract_schema_driven(source, &schema, None);
+        assert_eq!(parsed.artifacts.len(), 1);
+        let f = &parsed.artifacts[0].artifact.fields;
+        assert_eq!(
+            f.get("test-name").and_then(|v| v.as_str()),
+            Some("tests::first, tests::second"),
+            "comma-containing plain scalar must round-trip, not truncate at first comma"
+        );
+    }
+
+    /// Issue #747 (nested case): the truncation also hit unknown
+    /// top-level keys, which fall through to `node_to_yaml_value` the
+    /// same way. Anchor that path so it can't regress independently.
+    #[test]
+    fn schema_driven_preserves_unknown_key_value_with_commas() {
+        let source = "\
+artifacts:
+  - id: VAL-011
+    type: requirement
+    title: Unknown top-level with commas
+    covers: tests::a, tests::b, tests::c
+";
+        let schema = crate::schema::Schema::merge(&[]);
+        let parsed = extract_schema_driven(source, &schema, None);
+        assert_eq!(parsed.artifacts.len(), 1);
+        let f = &parsed.artifacts[0].artifact.fields;
+        assert_eq!(
+            f.get("covers").and_then(|v| v.as_str()),
+            Some("tests::a, tests::b, tests::c"),
+        );
     }
 }


### PR DESCRIPTION
Closes #747.

## Root cause

The CST lexer in `yaml_cst.rs::lex_plain_scalar` intentionally breaks
plain scalars at `,`, `]`, `}` (line 401). So a value like

```yaml
test-name: tests::boolean_matches_aadl_boolean, tests::boolean_mismatches_aadl_string
```

lands in the `Value` node as three sibling tokens:
`PlainScalar("tests::boolean_matches_aadl_boolean")` / `,` +
whitespace / `PlainScalar("tests::boolean_mismatches_aadl_string")`.

`scalar_text()` already handles this — it walks
`next_sibling_or_token()` until the next `Newline` / `Comment`. But
`node_to_yaml_value()` — the path taken for the `fields.*` mapping
and for unknown top-level keys — read only the first plain-scalar
token via `descendants_with_tokens()` and returned it verbatim. The
tail of the value was silently discarded, and the truncated result
rendered identically to a value that had only ever claimed one
element. Every comma-containing `test-name` in `spar` lost its
second entry; `stpa-yaml` never disagreed with `generic-yaml` on any
scalar that happened not to contain a comma, which is why it went
unnoticed.

## Fix

In `node_to_yaml_value`'s plain-scalar branch, reassemble the value
via `scalar_text(value_node)` before running type inference through
`plain_scalar_to_value`. Quoted scalars are unaffected — they arrive
as a single token and are still routed through
`scalar_to_yaml_value` unchanged.

The parser's inline-scalar branch already bumps every token up to
the newline as a direct child of `Value` (see `parse_mapping_entry`
in `yaml_cst.rs`), so `scalar_text`'s sibling walk sees the whole
run.

## Acceptance criteria (from the issue's "Expected" section)

- [x] **Preserve the scalar verbatim (`generic-yaml` behaviour).**
      A comma-containing plain scalar round-trips through
      `stpa-yaml` unchanged. Reproducer from the issue —
      `test-name: tests::first, tests::second` — now returns
      `"tests::first, tests::second"` instead of `"tests::first"`
      (regression test
      `schema_driven_preserves_field_value_with_commas`).
- [x] **No silent one-of-N truncation.** The bug hit the
      `fields.*` path *and* the unknown-top-level-key
      fallthrough (both delegate to `node_to_yaml_value`). Both are
      covered by regression tests
      (`schema_driven_preserves_field_value_with_commas`,
      `schema_driven_preserves_unknown_key_value_with_commas`), so
      the two paths can't regress independently.

The alternative reading in the issue — "if comma-splitting into
`list` is intended for this field, emit all elements and declare
the field's type as a list" — is not adopted: the schema-driven
parser has no way to know a `dev`-schema custom field like
`test-name` should be list-typed, and doing so would break every
existing scalar consumer. Preserving the scalar matches
`generic-yaml`, matches the on-disk YAML, and is the only outcome
that's right under both readings the issue proposes.

## Test plan

- [x] `cargo test -p rivet-core --lib yaml_hir::tests::schema_driven_preserves`
      — 2/2 new tests pass
- [x] `cargo test -p rivet-core --lib` — 1184/1184 pass (no regressions)
- [x] `cargo test -p rivet-core --tests` — integration + proptest + YAML
      test-suite (83 in the last block) pass
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p rivet-core --lib -- -D warnings` clean (only
      the pre-existing MSRV note from `clippy.toml`)
- [x] `cargo run -p rivet-cli --release -- validate` — PASS (592
      warnings; no schema/artifact changes in this PR)

## Follow-ups (out of scope)

The issue's "Note on how it was found" mentions that
`rivet list --format json` (without `--full`) omits `fields`, so an
A/B on that output missed this class of change. That's a real sharp
edge but it's a separate CLI-output design decision — worth its own
issue if you want it tracked.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gZkABqLWYiTwTjY9x7tCn)_