### PR TITLE
fix(verify): verification-evidence no longer false-errors on nextest -E filtersets (REQ-280, v0.30.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@
   Docs: `rivet docs schema/ordeal-certificate`.
 
 ## [0.30.0] - 2026-07-23
+## [0.30.1] - 2026-08-04
+
+### Fixed
+- **`rivet check verification-evidence` no longer false-errors on nextest
+  filtersets** (REQ-280) — a verification step whose `run` selects tests via a
+  `cargo nextest run -E`/`--filter-expr` filterset (e.g. `test(/message::/)` or a
+  set expression) was reported as a *missing test*. The parser did not treat
+  `-E`/`--filter-expr` as value-taking, so it grabbed the filterset expression —
+  literal shell quotes included — as if it were a plain positional substring
+  filter, then substring-matched it against bare `fn` names (which can never
+  contain a `test(/re/)` string or a `mod::path` segment) → a false negative that
+  wrongly blocked a `verified` requirement. Reported downstream against v0.30.0.
+  The parser now uses a quote-aware tokenizer and consumes the filterset value, so
+  it can never surface as a bogus filter; a filterset step is reported as
+  **skipped (not verified)** — a skipped safety check must never read as a passed
+  one — rather than errored. Actually evaluating filtersets is tracked as REQ-281.
 
 CI resilience + compliance-export robustness.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.30.0"
+version = "0.30.1"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7974,3 +7974,36 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-07-30T04:11:24Z
+
+  - id: REQ-280
+    type: requirement
+    title: "rivet check verification-evidence: nextest -E filtersets false-error as missing tests (downstream Ford/linc-mesh)"
+    status: implemented
+    description: "Downstream bug report (Ford linc-mesh, v0.30.0): `rivet check verification-evidence` emitted 22 false `no test matching` findings for verification steps whose `run` uses a nextest filterset, e.g. `cargo nextest run -p x --lib -E 'test(/message::/)'`. Root cause in rivet-core verification_evidence.rs: `-E`/`--filter-expr` was not in VALUE_FLAGS, so the parser (split_whitespace) grabbed the filterset expression — literal quotes included — as a bogus positional substring filter, then substring-matched it against bare `fn` names (which can never contain a `test(/re/)` string or a `mod::path` segment) → false negative → false `verified`-blocking error. Fix: (1) quote-aware tokenizer strips shell quotes and keeps a quoted filterset as one token; (2) `-E`/`--filter-expr` are value-taking, so the expression is consumed and never surfaces as a filter; (3) a nextest filterset step is detected and reported as SKIPPED (not verified) rather than errored — a skipped safety check must never read as passed. Reproduced + regression-tested (rivet-core unit + rivet-cli integration). Ships as v0.30.1. Does not evaluate filtersets (see REQ-281)."
+    release: v0.30.1
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-08-04T00:00:00Z
+
+  - id: REQ-281
+    type: requirement
+    title: "rivet check verification-evidence: actually evaluate nextest filterset expressions (not just skip)"
+    status: proposed
+    description: "Follow-up to REQ-280. The named-test-exists checker scans a universe of leaf `fn` names, which cannot satisfy nextest filterset predicates that address full test PATHS/regexes (`test(/message::/)`, `test(=mod::name)`, `package()/binary()/kind()` + set operators). v0.30.1 conservatively SKIPS such steps (never false-errors) but therefore does not verify them. Give the check real filterset evaluation. Decision to record (DD): either (a) build qualified test paths by tracking `mod` nesting during the source scan and evaluate the filterset grammar ourselves — a maintenance commitment to track nextest's grammar; or (b) shell out to `cargo nextest list -E <expr>` and assert a non-zero match count, making nextest itself the oracle (correct for all forms, but requires a compiled project + nextest installed, changing the check from a pure static scan to a build-dependent one). Prefer (b) behind an opt-in flag so the default stays fast + build-free. Restores coverage of the steps REQ-280 skips."
+    release: v0.31.0
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-08-04T00:00:00Z
+
+  - id: REQ-282
+    type: requirement
+    title: "rivet sql: self-describing schema (SHOW TABLES / --schema) + discoverability from --help"
+    status: proposed
+    description: "Downstream question (Ford linc-mesh): 'there is nowhere documentation about the sql tables and formats and what can be queried.' The schema IS documented (docs/getting-started.md 'SQL over the artifact store': tables artifacts/links/fields/provenance + columns, output table|json|csv, read/write rules) but is unreachable from where a user looks — `rivet sql --help` doesn't point to it and the engine can't describe itself. Make `rivet sql` self-describing: support `rivet sql --schema` (and/or `.tables` / `SHOW TABLES` / `.schema`) to print the projected tables + columns, and reference the schema doc from `rivet sql --help`. A query engine that can't enumerate its own tables is a real discoverability gap. Small, docs+CLI-help slice; no engine change beyond a schema dump."
+    release: v0.31.0
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-08-04T00:00:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -8099,6 +8099,24 @@ fn collect_rust_fn_names(dir: &std::path::Path, out: &mut std::collections::BTre
     }
 }
 
+/// REQ-280: true when `run` is a `cargo nextest run` invocation that selects
+/// tests via a filterset expression (`-E` / `--filter-expr`), e.g.
+/// `test(/message::/)` or `test(a) & package(b)`. Such expressions address full
+/// test PATHS / regexes, which the leaf-`fn`-name scanner in
+/// `verification_evidence` cannot satisfy — the CLI reports these steps as
+/// *skipped (not verified)* rather than false-erroring them (REQ-281 tracks real
+/// filterset evaluation). Detection only, so a plain whitespace split suffices.
+fn is_nextest_filterset(run: &str) -> bool {
+    let tokens: Vec<&str> = run.split_whitespace().collect();
+    let has_nextest_run = tokens
+        .windows(2)
+        .any(|w| w[0] == "nextest" && w[1] == "run");
+    has_nextest_run
+        && tokens
+            .iter()
+            .any(|t| *t == "-E" || t.starts_with("--filter-expr"))
+}
+
 /// #556 (REQ-236 pt2): assert that a verification artifact's named-test steps
 /// (`fields.steps[].run: "cargo test … <filter>"`) reference tests that
 /// actually exist in the scanned Rust sources — catching the silent-drift case
@@ -8139,7 +8157,14 @@ fn cmd_check_verification_evidence(
         filter: String,
         command: String,
     }
+    #[derive(serde::Serialize)]
+    struct Skipped {
+        artifact: String,
+        command: String,
+        reason: String,
+    }
     let mut missing: Vec<Missing> = Vec::new();
+    let mut skipped: Vec<Skipped> = Vec::new();
     let mut checked = 0usize;
     let mut sorted: Vec<&rivet_core::model::Artifact> = ctx.store.iter().collect();
     sorted.sort_by(|a, b| a.id.cmp(&b.id));
@@ -8151,16 +8176,31 @@ fn cmd_check_verification_evidence(
             let Some(run) = step.get("run").and_then(|v| v.as_str()) else {
                 continue;
             };
-            let Some(filter) = ve::parse_cargo_test_filter(run) else {
-                continue;
-            };
-            checked += 1;
-            if !ve::filter_matches_any(&filter, &fn_names) {
-                missing.push(Missing {
-                    artifact: a.id.clone(),
-                    filter,
-                    command: run.to_string(),
-                });
+            match ve::parse_cargo_test_filter(run) {
+                Some(filter) => {
+                    checked += 1;
+                    if !ve::filter_matches_any(&filter, &fn_names) {
+                        missing.push(Missing {
+                            artifact: a.id.clone(),
+                            filter,
+                            command: run.to_string(),
+                        });
+                    }
+                }
+                None => {
+                    // A nextest filterset (`-E 'test(/re/)'`) addresses full test
+                    // PATHS/regexes, which this leaf-fn-name scanner cannot satisfy.
+                    // Report it as SKIPPED (not verified) — never a false error.
+                    if is_nextest_filterset(run) {
+                        skipped.push(Skipped {
+                            artifact: a.id.clone(),
+                            command: run.to_string(),
+                            reason: "nextest filterset expression (-E/--filter-expr) \
+                                     not evaluable by the fn-name scanner"
+                                .to_string(),
+                        });
+                    }
+                }
             }
         }
     }
@@ -8170,28 +8210,42 @@ fn cmd_check_verification_evidence(
             "command": "check verification-evidence",
             "named_test_steps_checked": checked,
             "missing": missing,
+            "skipped": skipped,
             "ok": missing.is_empty(),
         });
         println!("{}", serde_json::to_string_pretty(&obj)?);
-    } else if missing.is_empty() {
-        println!(
-            "\u{2713} verification-evidence: {checked} named-test step(s) all reference an existing test."
-        );
     } else {
-        println!(
-            "\u{2717} verification-evidence: {} named-test step(s) reference a test that does not exist:",
-            missing.len()
-        );
-        for m in &missing {
+        if missing.is_empty() {
             println!(
-                "  {} — no test matching `{}` found (from `{}`)",
-                m.artifact, m.filter, m.command
+                "\u{2713} verification-evidence: {checked} named-test step(s) all reference an existing test."
+            );
+        } else {
+            println!(
+                "\u{2717} verification-evidence: {} named-test step(s) reference a test that does not exist:",
+                missing.len()
+            );
+            for m in &missing {
+                println!(
+                    "  {} — no test matching `{}` found (from `{}`)",
+                    m.artifact, m.filter, m.command
+                );
+            }
+            println!(
+                "\n  A `cargo test <filter>` that matches nothing exits 0 with \"0 passed\", so this\n  \
+                 would otherwise keep the requirement silently `verified`. Fix the filter or the test name."
             );
         }
-        println!(
-            "\n  A `cargo test <filter>` that matches nothing exits 0 with \"0 passed\", so this\n  \
-             would otherwise keep the requirement silently `verified`. Fix the filter or the test name."
-        );
+        if !skipped.is_empty() {
+            println!(
+                "\n\u{26a0} {} step(s) SKIPPED — a nextest filterset (`-E`/`--filter-expr`) selects \
+                 tests by\n  full path/regex, which the fn-name scanner cannot evaluate. These are \
+                 NOT verified:",
+                skipped.len()
+            );
+            for s in &skipped {
+                println!("  {} — (from `{}`)", s.artifact, s.command);
+            }
+        }
     }
     Ok(missing.is_empty())
 }

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -792,6 +792,71 @@ fn check_verification_evidence_flags_missing_named_test() {
     assert_eq!(missing, vec!["renamed_or_typod_test"]);
 }
 
+/// REQ-280: a verification step that selects tests via a `cargo nextest run -E`
+/// FILTERSET (`test(/regex/)`, set operators) must NOT be reported as a missing
+/// test — the earlier parser leaked the filterset (quotes and all) as a bogus
+/// positional substring filter, false-erroring against Ford's linc-mesh. Such a
+/// step is reported as SKIPPED (not verified) and the check still exits 0.
+///
+/// rivet: verifies REQ-280
+#[test]
+fn check_verification_evidence_skips_nextest_filterset_not_errors() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: p\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src/lib.rs"),
+        "#[test]\nfn decode_message() { assert!(true); }\n",
+    )
+    .unwrap();
+    // A filterset step (must be skipped, not errored) + a real positional step.
+    std::fs::write(
+        dir.join("artifacts/a.yaml"),
+        "artifacts:\n  \
+         - id: FV-001\n    type: requirement\n    title: v\n    status: implemented\n    \
+             fields:\n      steps:\n        \
+             - run: \"cargo nextest run -p p --lib -E 'test(/message::/)'\"\n        \
+             - run: \"cargo test -p p decode_message\"\n",
+    )
+    .unwrap();
+
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "check",
+            "verification-evidence",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("check");
+    assert!(
+        out.status.success(),
+        "a nextest filterset must be skipped, not false-errored"
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json");
+    assert_eq!(v["ok"], true);
+    // The filterset step is not counted as a checked positional filter.
+    assert_eq!(v["named_test_steps_checked"], 1);
+    assert!(v["missing"].as_array().unwrap().is_empty());
+    let skipped = v["skipped"].as_array().unwrap();
+    assert_eq!(
+        skipped.len(),
+        1,
+        "the filterset step is reported as skipped"
+    );
+    assert_eq!(skipped[0]["artifact"], "FV-001");
+}
+
 /// #547 (REQ-238): `rivet trace-results <req>` walks FORWARD from a requirement
 /// to the test results that cover it (the reverse of the authored `verifies`
 /// direction) and rolls up a pass/fail verdict — the data behind the graphical

--- a/rivet-core/src/verification_evidence.rs
+++ b/rivet-core/src/verification_evidence.rs
@@ -42,19 +42,19 @@ use std::collections::BTreeSet;
 /// own args (everything after is passed to the test binary), so a filter after
 /// `--` (`cargo test -- --exact name`) is handled too.
 pub fn parse_cargo_test_filter(command: &str) -> Option<String> {
-    let tokens: Vec<&str> = command.split_whitespace().collect();
+    let tokens = shell_tokens(command);
     // Must be a cargo test / cargo nextest run invocation.
-    let mut i = tokens.iter().position(|t| *t == "cargo")?;
+    let mut i = tokens.iter().position(|t| t == "cargo")?;
     i += 1;
     // Optional `+toolchain`.
     if tokens.get(i).is_some_and(|t| t.starts_with('+')) {
         i += 1;
     }
-    match tokens.get(i).copied() {
+    match tokens.get(i).map(String::as_str) {
         Some("test") => i += 1,
         Some("nextest") => {
             i += 1;
-            if tokens.get(i).copied() != Some("run") {
+            if tokens.get(i).map(String::as_str) != Some("run") {
                 return None;
             }
             i += 1;
@@ -62,29 +62,9 @@ pub fn parse_cargo_test_filter(command: &str) -> Option<String> {
         _ => return None,
     }
 
-    // Value-taking cargo flags whose following token is a VALUE, not the filter.
-    const VALUE_FLAGS: &[&str] = &[
-        "-p",
-        "--package",
-        "--exclude",
-        "--test",
-        "--bin",
-        "--example",
-        "--bench",
-        "--features",
-        "--manifest-path",
-        "--target",
-        "--target-dir",
-        "--profile",
-        "-j",
-        "--jobs",
-        "--color",
-        "-F",
-    ];
-
     let mut past_dashdash = false;
     while i < tokens.len() {
-        let tok = tokens[i];
+        let tok = tokens[i].as_str();
         if !past_dashdash && tok == "--" {
             past_dashdash = true;
             i += 1;
@@ -93,7 +73,10 @@ pub fn parse_cargo_test_filter(command: &str) -> Option<String> {
         if tok.starts_with('-') {
             // A `--flag=value` carries its own value; a bare value-flag consumes
             // the next token. Test-binary flags after `--` (e.g. `--exact`,
-            // `--nocapture`) are not filters and are skipped.
+            // `--nocapture`) are not filters and are skipped. `-E` /
+            // `--filter-expr` carry a nextest FILTERSET (a test-path/regex
+            // expression) — consumed here so it can never surface as a bogus
+            // positional substring filter (see `uses_unsupported_nextest_filterset`).
             if !past_dashdash && VALUE_FLAGS.contains(&tok) && !tok.contains('=') {
                 i += 1; // skip the value
             }
@@ -104,6 +87,70 @@ pub fn parse_cargo_test_filter(command: &str) -> Option<String> {
         return Some(tok.to_string());
     }
     None
+}
+
+/// Value-taking cargo/nextest flags whose following token is a VALUE, not the
+/// positional filter. `-E` / `--filter-expr` are nextest filterset flags.
+const VALUE_FLAGS: &[&str] = &[
+    "-p",
+    "--package",
+    "--exclude",
+    "--test",
+    "--bin",
+    "--example",
+    "--bench",
+    "--features",
+    "--manifest-path",
+    "--target",
+    "--target-dir",
+    "--profile",
+    "-j",
+    "--jobs",
+    "--color",
+    "-F",
+    "-E",
+    "--filter-expr",
+];
+
+/// Split a stored command string into tokens, treating single/double quoted spans
+/// as one token with the surrounding quotes removed. Not a full shell parser — it
+/// only groups quoted runs so a quoted filterset (`-E 'test(a) | test(b)'`) stays
+/// one argument and a positional filter copied verbatim from a shell (`'my_case'`)
+/// loses its quotes instead of substring-matching against them.
+fn shell_tokens(command: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut cur = String::new();
+    let mut in_tok = false;
+    let mut quote: Option<char> = None;
+    for c in command.chars() {
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None; // closing quote; the token continues
+                } else {
+                    cur.push(c);
+                }
+            }
+            None => {
+                if c == '\'' || c == '"' {
+                    quote = Some(c);
+                    in_tok = true;
+                } else if c.is_whitespace() {
+                    if in_tok {
+                        tokens.push(std::mem::take(&mut cur));
+                        in_tok = false;
+                    }
+                } else {
+                    cur.push(c);
+                    in_tok = true;
+                }
+            }
+        }
+    }
+    if in_tok {
+        tokens.push(cur);
+    }
+    tokens
 }
 
 /// Extract candidate test names from Rust source: every `fn <name>`. This
@@ -173,6 +220,38 @@ mod tests {
         assert_eq!(
             parse_cargo_test_filter("cargo test -p x -- --exact modx::named"),
             Some("modx::named".into())
+        );
+    }
+
+    #[test]
+    fn nextest_filterset_is_not_mistaken_for_a_positional_filter() {
+        // #REQ-280 regression: a nextest `-E` filterset expression addresses full
+        // test PATHS / regexes, not the leaf-`fn`-name universe this checker knows.
+        // It must NOT leak through as a bogus positional substring filter (which
+        // then substring-matches nothing and false-errors "test does not exist").
+        assert_eq!(
+            parse_cargo_test_filter("cargo nextest run -p linc-nm --lib -E 'test(/message::/)'"),
+            None
+        );
+        assert_eq!(
+            parse_cargo_test_filter("cargo nextest run -p x --filter-expr 'test(a) | test(b)'"),
+            None
+        );
+        // A plain positional filter on nextest is still extracted normally
+        // (only the `-E`/`--filter-expr` value is consumed, never leaked).
+        assert_eq!(
+            parse_cargo_test_filter("cargo nextest run -p x foo"),
+            Some("foo".into())
+        );
+    }
+
+    #[test]
+    fn surrounding_quotes_are_stripped_from_a_positional_filter() {
+        // #REQ-280: a stored command copied from a shell keeps literal quotes;
+        // they must not become part of the substring filter.
+        assert_eq!(
+            parse_cargo_test_filter("cargo test -p x 'my_case'"),
+            Some("my_case".into())
         );
     }
 

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the downstream bug report (Ford `linc-mesh`, v0.30.0): closes #756.

## Bug
`rivet check verification-evidence` emitted **22 false "no test matching" findings** for verification steps whose `run` selects tests with a nextest filterset — e.g. `cargo nextest run -p x --lib -E 'test(/message::/)'` — wrongly blocking `verified` requirements. Flagged filters kept literal quotes (`'test(x)'`).

**Root cause:** `parse_cargo_test_filter` did not treat `-E`/`--filter-expr` as value-taking, so `split_whitespace` grabbed the filterset (quotes and all) as a positional substring filter, then substring-matched it against bare `fn` names — which can never contain a `test(/re/)` string or a `mod::path` segment. Reproduced: it returned `Some("'test(/message::/)'")`.

## Fix
- **rivet-core** — quote-aware tokenizer; `-E`/`--filter-expr` consumed as value flags, so a filterset can never surface as a bogus filter; shell quotes stripped from a real positional filter. **Public API frozen** (behavior-only change → patch-safe).
- **rivet-cli** — a filterset step is reported as **SKIPPED (not verified)**, never errored. A skipped safety check must not read as a passed one, so it's surfaced distinctly in text + a `skipped` array in JSON.

## Verification
- Reproduced empirically before the fix.
- rivet-core: 6 unit tests (2 new regressions) green.
- rivet-cli: 2 integration tests (existing + new filterset-skip) green.
- Self-verify: `cargo fmt --check`, `clippy --all-targets -D warnings` (1.97.0) exit 0, `rivet validate` PASS, `rivet docs check` 0 violations.

## Scope / follow-ups
- REQ-277 (this, `implemented`, v0.30.1); bundles the version bump `0.30.0 → 0.30.1`.
- REQ-278 — actually *evaluate* filtersets (likely shell to `cargo nextest list -E`); v0.31.
- REQ-279 — `rivet sql` self-describing schema (the user's second question — schema IS documented in getting-started.md but unreachable from `--help`); v0.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)