### PR TITLE
feat(validate): --strict compliance-gate mode (REQ-283, downstream Ford/linc-mesh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 ## [Unreleased]
 
 ### Added
+- **`rivet validate --strict` — compliance-gate mode** (REQ-283) — `validate`
+  PASS proves link integrity and required-field presence, but by default says
+  nothing about field *values* or *names*: a value outside a schema
+  `allowed-values` enum is only a Warning, and an undeclared field name only Info,
+  so the gate exits 0 over both (the `status` field's enum was uniquely an Error —
+  an asymmetry). `--strict` promotes `allowed-values` and `unknown-field`
+  diagnostics to errors so CI can enforce field-value/name correctness. Opt-in by
+  design — a project may carry pre-existing violations, so the default stays
+  lenient (same rationale as `--strict-orphans`). A persistent `rivet.yaml`
+  `validate.strict` switch is a planned follow-on. Reported downstream.
+
+### Added
 - **`ordeal-certificate` evidence artifact type** (REQ-277, #693 Part 2,
   ordeal#67) — new embedded schema `schemas/ordeal-certificate.yaml` describing an
   ordeal-cert/v1 bundle (ordeal v0.17.0, `cert-bundle` feature): `produced-by` /

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -8007,3 +8007,14 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-08-04T00:00:00Z
+
+  - id: REQ-283
+    type: requirement
+    title: "rivet validate --strict: compliance-gate mode escalates field-value/name lint rules to errors (downstream Ford/linc-mesh)"
+    status: implemented
+    description: "Downstream report (Ford linc-mesh): `rivet validate` PASS is used as a compliance gate, but it proves only link integrity + required-field presence — it says nothing about field VALUES or NAMES. A field value outside a schema `allowed-values` enum (`category: banana`) is only a Warning, and an undeclared field NAME (`bogus_field`) is only Info — so `validate` exits 0 over both. The `status` field's enum was uniquely an Error (`status-allowed-values`), an asymmetry with every other field. User chose (AskUserQuestion) an OPT-IN strict mode over flipping defaults, because a project may carry pre-existing violations (this repo has 5 `allowed-values` + 53 `unknown-field`) and a hard-error default would break dogfood `validate` — the same lesson as `--strict-orphans`. Slice 1 (implemented, this): a `rivet validate --strict` flag that promotes `allowed-values` + `unknown-field` diagnostics to Error before the PASS/FAIL + counts, so CI can enforce field-value/name correctness while the default stays lenient. Reproduced + regression-tested (default PASS, --strict FAIL with both rules as errors). Slice 2 (follow-on): a `rivet.yaml` `validate.strict` switch so the policy is persistent per-project, mirroring `release.ready-when`. Ships v0.31."
+    release: v0.31.0
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-08-04T00:00:00Z

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -411,6 +411,17 @@ enum Command {
         #[arg(long = "strict-orphans")]
         strict_orphans: bool,
 
+        /// REQ-283: compliance-gate mode. Promote the field-correctness lint
+        /// rules — `allowed-values` (a field's value is outside the schema's
+        /// declared enum) and `unknown-field` (a field name not declared in the
+        /// schema, i.e. a typo or drift) — from Warning/Info to ERROR, so
+        /// `validate` FAILS on them. Default keeps them non-fatal: a project may
+        /// carry pre-existing violations, so a hard-error default would break its
+        /// own dogfood run. Turn this on in CI when `validate` is your compliance
+        /// gate and field values/names must be enforced, not just link integrity.
+        #[arg(long)]
+        strict: bool,
+
         /// Also run `rivet validate` inside every linked external
         /// project and surface its diagnostics under a
         /// `cross_repo_diagnostics` array (JSON) / a "Cross-repo
@@ -2381,6 +2392,7 @@ fn run(cli: Cli) -> Result<bool> {
             strict_cited_source_stale,
             check_remote_sources,
             strict_orphans,
+            strict,
             with_externals_validate,
             structural,
         } => {
@@ -2409,6 +2421,7 @@ fn run(cli: Cli) -> Result<bool> {
                     *strict_cited_source_stale,
                     *check_remote_sources,
                     *strict_orphans,
+                    *strict,
                     *with_externals_validate,
                     *structural,
                 )
@@ -5458,6 +5471,7 @@ fn cmd_validate(
     strict_cited_source_stale: bool,
     check_remote_sources: bool,
     strict_orphans: bool,
+    strict: bool,
     with_externals_validate: bool,
     structural_only: bool,
 ) -> Result<bool> {
@@ -6081,6 +6095,25 @@ fn cmd_validate(
     // ID and is correctly kept; `artifact-parse-error` diagnostics carry
     // no artifact_id and are kept.
     diagnostics.retain(|d| !d.artifact_id.as_deref().is_some_and(|id| id.contains(':')));
+
+    // REQ-283: `--strict` is compliance-gate mode. Promote the field-correctness
+    // lint rules to Error BEFORE counting + PASS/FAIL, so the gate fails on them:
+    //   - `allowed-values`  — a field's value is outside the schema's enum
+    //     (declared but only a Warning by default; `status` alone was Error, an
+    //     asymmetry this removes under strict);
+    //   - `unknown-field`   — a field name not declared in the schema (a typo /
+    //     drift, only Info by default).
+    // Default leaves them non-fatal: a project may carry pre-existing violations,
+    // so a hard-error default would break its own dogfood `validate` (same lesson
+    // as `--strict-orphans`). `validate` PASS otherwise proves link integrity +
+    // required-fields, but says nothing about field values/names.
+    if strict {
+        for d in &mut diagnostics {
+            if d.rule == "allowed-values" || d.rule == "unknown-field" {
+                d.severity = Severity::Error;
+            }
+        }
+    }
 
     // REQ-161 / #408: `--structural` gates on graph/parse/type integrity only.
     // Retain just the structural diagnostics BEFORE counting/display, so the
@@ -11193,6 +11226,7 @@ fn cmd_diff(
                     strict_cited_source_stale: false,
                     check_remote_sources: false,
                     strict_orphans: false,
+                    strict: false,
                     with_externals_validate: false,
                     structural: false,
                 },
@@ -11221,6 +11255,7 @@ fn cmd_diff(
                     strict_cited_source_stale: false,
                     check_remote_sources: false,
                     strict_orphans: false,
+                    strict: false,
                     with_externals_validate: false,
                     structural: false,
                 },

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -792,6 +792,80 @@ fn check_verification_evidence_flags_missing_named_test() {
     assert_eq!(missing, vec!["renamed_or_typod_test"]);
 }
 
+/// REQ-283: `rivet validate --strict` is compliance-gate mode — it promotes the
+/// field-correctness lint rules (`allowed-values`: a value outside the schema
+/// enum; `unknown-field`: a typo'd/undeclared field name) from Warning/Info to
+/// ERROR, so the gate FAILS on them. The default run stays lenient (PASS), since
+/// a project may carry pre-existing violations. Without this, `validate` PASS
+/// proved link integrity + required-fields but said nothing about field values.
+///
+/// rivet: verifies REQ-283
+#[test]
+fn validate_strict_escalates_allowed_values_and_unknown_field_to_errors() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    // `category` is an allowed-values enum field on the base `requirement` type.
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: p\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("artifacts/a.yaml"),
+        "artifacts:\n  \
+         - id: REQ-1\n    type: requirement\n    title: t\n    status: draft\n    \
+             fields:\n      category: banana\n      bogus_field: x\n",
+    )
+    .unwrap();
+
+    // Default: lenient — the enum violation is a Warning, the unknown field Info.
+    let out = Command::new(rivet_bin())
+        .args(["--project", dirs, "validate"])
+        .output()
+        .expect("validate");
+    assert!(
+        out.status.success(),
+        "default validate must PASS over an out-of-enum value + unknown field"
+    );
+
+    // --strict: both are promoted to Error → the gate FAILS.
+    let strict = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "validate",
+            "--strict",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("validate --strict");
+    assert!(
+        !strict.status.success(),
+        "validate --strict must FAIL when a field value is out-of-enum or a field is unknown"
+    );
+    let v: serde_json::Value = serde_json::from_slice(&strict.stdout).expect("json");
+    let empty = vec![];
+    let rules: Vec<&str> = v["diagnostics"]
+        .as_array()
+        .unwrap_or(&empty)
+        .iter()
+        .filter(|d| d["severity"] == "error")
+        .filter_map(|d| d["rule"].as_str())
+        .collect();
+    assert!(
+        rules.contains(&"allowed-values"),
+        "allowed-values must be an ERROR under --strict, got errors: {rules:?}"
+    );
+    assert!(
+        rules.contains(&"unknown-field"),
+        "unknown-field must be an ERROR under --strict, got errors: {rules:?}"
+    );
+}
+
 /// REQ-280: a verification step that selects tests via a `cargo nextest run -E`
 /// FILTERSET (`test(/regex/)`, set operators) must NOT be reported as a missing
 /// test — the earlier parser leaked the filterset (quotes and all) as a bogus


### PR DESCRIPTION
Addresses the downstream report that **`rivet validate` PASS says nothing about field values or names** — only link integrity + required-field presence.

## The hole (empirically confirmed)
A severity ladder made the compliance gate silently tolerant:

| Rule | Default severity | Gates? |
|---|---|---|
| `required-field`, `status-allowed-values` | Error | ✅ |
| `allowed-values` (every *other* field's enum) | Warning | ❌ |
| `unknown-field` (typo'd / undeclared field name) | Info | ❌ |

So `category: banana` (out-of-enum) and `bogus_field` (unknown) both PASS. This repo already carries **5 `allowed-values` + 53 `unknown-field`** violations, invisible among 600 warnings.

## Fix — opt-in strict mode
Per the user's explicit choice (opt-in over flipping defaults, because projects carry pre-existing violations and a hard-error default would break dogfood `validate` — same lesson as `--strict-orphans`):

- **`rivet validate --strict`** promotes `allowed-values` + `unknown-field` to **Error** before PASS/FAIL + counts. Default stays lenient.

## Verification
- Reproduced: default `PASS`; `--strict` → `FAIL` (exit 1) with both rules as errors.
- New regression test (`verifies REQ-283`) + all 25 existing validate tests green.
- Self-verify: build, `rivet validate` PASS, `docs check` 0 violations, `fmt --check`, `clippy --all-targets -D warnings` exit 0.

## Follow-on
- Slice 2: a persistent `rivet.yaml` `validate.strict` switch (mirrors `release.ready-when`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)