### PR TITLE
chore(release): v0.31.0 — filterset fix + validate --strict + ordeal-certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-08-05
+
 ### Added
 - **`rivet validate --strict` — compliance-gate mode** (REQ-283) — `validate`
   PASS proves link integrity and required-field presence, but by default says
@@ -16,8 +18,6 @@
   design — a project may carry pre-existing violations, so the default stays
   lenient (same rationale as `--strict-orphans`). A persistent `rivet.yaml`
   `validate.strict` switch is a planned follow-on. Reported downstream.
-
-### Added
 - **`ordeal-certificate` evidence artifact type** (REQ-277, #693 Part 2,
   ordeal#67) — new embedded schema `schemas/ordeal-certificate.yaml` describing an
   ordeal-cert/v1 bundle (ordeal v0.17.0, `cert-bundle` feature): `produced-by` /
@@ -35,9 +35,6 @@
   mirroring ordeal's `BundleError::Unsupported`) are baked into the schema.
   Docs: `rivet docs schema/ordeal-certificate`.
 
-## [0.30.0] - 2026-07-23
-## [0.30.1] - 2026-08-04
-
 ### Fixed
 - **`rivet check verification-evidence` no longer false-errors on nextest
   filtersets** (REQ-280) — a verification step whose `run` selects tests via a
@@ -52,6 +49,8 @@
   it can never surface as a bogus filter; a filterset step is reported as
   **skipped (not verified)** — a skipped safety check must never read as a passed
   one — rather than errored. Actually evaluating filtersets is tracked as REQ-281.
+
+## [0.30.0] - 2026-07-23
 
 CI resilience + compliance-export robustness.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.30.1"
+version = "0.31.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -7980,7 +7980,7 @@ artifacts:
     title: "rivet check verification-evidence: nextest -E filtersets false-error as missing tests (downstream Ford/linc-mesh)"
     status: implemented
     description: "Downstream bug report (Ford linc-mesh, v0.30.0): `rivet check verification-evidence` emitted 22 false `no test matching` findings for verification steps whose `run` uses a nextest filterset, e.g. `cargo nextest run -p x --lib -E 'test(/message::/)'`. Root cause in rivet-core verification_evidence.rs: `-E`/`--filter-expr` was not in VALUE_FLAGS, so the parser (split_whitespace) grabbed the filterset expression — literal quotes included — as a bogus positional substring filter, then substring-matched it against bare `fn` names (which can never contain a `test(/re/)` string or a `mod::path` segment) → false negative → false `verified`-blocking error. Fix: (1) quote-aware tokenizer strips shell quotes and keeps a quoted filterset as one token; (2) `-E`/`--filter-expr` are value-taking, so the expression is consumed and never surfaces as a filter; (3) a nextest filterset step is detected and reported as SKIPPED (not verified) rather than errored — a skipped safety check must never read as passed. Reproduced + regression-tested (rivet-core unit + rivet-cli integration). Ships as v0.30.1. Does not evaluate filtersets (see REQ-281)."
-    release: v0.30.1
+    release: v0.31.0
     provenance:
       created-by: ai-assisted
       model: claude-opus-4-8

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release-prep for **v0.31.0**. Consolidates everything on main since v0.30.0.

## Why v0.31.0 (not v0.30.1)
The nextest-filterset fix was slated as a v0.30.1 patch, but two **v0.31-targeted features** had already merged to main alongside it — the `ordeal-certificate` schema type (#743) and `validate --strict` (#758). Shipping features in a patch is a semver smell, so the filterset fix folds into v0.31.0 (REQ-280 release retargeted). linc-mesh still gets the fix — just in v0.31.0.

## Scope
| REQ | What | PR |
|-----|------|----|
| REQ-280 | nextest `-E` filterset false-positive fix | #757 |
| REQ-283 | `validate --strict` compliance-gate mode | #758 |
| REQ-277 | ordeal-certificate evidence artifact type | #743 |

## Also
- **CHANGELOG repair** — a prior rebase auto-merge had nested v0.30.0's content under a misplaced `[0.30.1]` header; sections are now correctly ordered (`[Unreleased]` → `[0.31.0]` → `[0.30.0]`).
- Bumps workspace `0.30.1 → 0.31.0` + vscode-rivet.

## Known-red gate (pre-existing, orthogonal)
- **Security Audit** stays red on `wasmtime` RUSTSEC-2026-0222 + `rkyv` RUSTSEC-2026-0235 — pre-existing on main, a coupled wasmtime 45→47 bump tracked separately (ships next as v0.31.1). Not introduced by this release.

## Verification
Build, `rivet validate` PASS, `docs check` 0 violations, `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)