### PR TITLE
fix(mutate): modify --add-tag drops the WHOLE FILE when a tag needs quoting (REQ-287, P0 data loss)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -8051,3 +8051,14 @@ artifacts:
       created-by: ai-assisted
       model: claude-opus-4-8
       timestamp: 2026-08-05T00:00:00Z
+
+  - id: REQ-287
+    type: requirement
+    title: "P0 data loss: modify --add-tag/--remove-tag drops the whole file when a tag needs quoting"
+    status: implemented
+    description: "Mutation-path stress test (user-reported: 'we very often get into failures' modifying artifacts) found a P0. rivet-core/src/yaml_edit.rs:828 re-emitted the tag flow list via `current_tags.join(\", \")` WITHOUT quoting individual tags — unlike the hardened sibling setters (set_title/status/field via yaml_quote_inline_scalar, #687) and the `add` path (mutate.rs). Any tag carrying a YAML flow indicator (`: `, `,`, `[`, `]`, `#`) breaks: a legitimately-quoted `\"release: v1.0\"` read back from the store is re-emitted bare (`release: v1.0`), turning the flow list into a map so the WHOLE FILE fails to parse — silently dropping EVERY artifact in it — while `modify` exits 0 reporting 'modified'. Reproduced: 2 artifacts -> benign `--add-tag simpletag` -> 0 artifacts. Same tag-mutation fragility class as #625, on the quoting axis. Fix: quote each tag via yaml_quote_inline_scalar before joining, mirroring the add path. Regression test (rivet-cli integration) asserts both artifacts survive + the quoted tag stays quoted. Also a silent-split variant (`--add-tag \"a,b\"` stored two tags) is closed by the same quoting."
+    release: v0.32.0
+    provenance:
+      created-by: ai-assisted
+      model: claude-opus-4-8
+      timestamp: 2026-08-05T00:00:00Z

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -7921,6 +7921,74 @@ fn modify_help_has_no_duplicated_summary() {
     );
 }
 
+/// REQ-287 (P0 DATA LOSS regression): `rivet modify --add-tag` must not corrupt
+/// the file when the artifact already carries a tag that needs quoting (e.g.
+/// `"release: v1.0"`). The buggy path re-emitted the tag list unquoted
+/// (`[alpha, release: v1.0, …]`), turning the flow list into a map so the WHOLE
+/// FILE failed to parse — silently dropping EVERY artifact in it — while
+/// `modify` still exited 0 reporting success.
+///
+/// rivet: verifies REQ-287
+#[test]
+fn modify_add_tag_preserves_quoted_tags_and_does_not_drop_the_file() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: p\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    // REQ-100 carries a legitimately-quoted tag with a `: ` flow indicator.
+    std::fs::write(
+        dir.join("artifacts/a.yaml"),
+        "artifacts:\n  \
+         - id: REQ-100\n    type: requirement\n    title: T\n    status: draft\n    \
+             tags: [alpha, \"release: v1.0\", needs-review]\n  \
+         - id: REQ-101\n    type: requirement\n    title: U\n    status: draft\n",
+    )
+    .unwrap();
+
+    // A benign, unrelated add-tag — must not touch the pre-existing quoted tag.
+    let out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "modify",
+            "REQ-100",
+            "--add-tag",
+            "simpletag",
+        ])
+        .output()
+        .expect("modify --add-tag");
+    assert!(out.status.success(), "modify --add-tag should succeed");
+
+    // The whole file must still parse: BOTH artifacts survive (0 = data loss).
+    let list = Command::new(rivet_bin())
+        .args(["--project", dirs, "list", "--format", "json"])
+        .output()
+        .expect("list");
+    let v: serde_json::Value = serde_json::from_slice(&list.stdout).expect("json");
+    let ids: Vec<&str> = v["artifacts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|a| a["id"].as_str())
+        .collect();
+    assert!(
+        ids.contains(&"REQ-100") && ids.contains(&"REQ-101"),
+        "both artifacts must survive an --add-tag; got {ids:?} (0/partial = whole-file data loss)"
+    );
+    // The quoted tag must remain quoted on disk so the file stays parseable.
+    let on_disk = std::fs::read_to_string(dir.join("artifacts/a.yaml")).unwrap();
+    assert!(
+        on_disk.contains("\"release: v1.0\""),
+        "the pre-existing quoted tag must stay quoted; file now:\n{on_disk}"
+    );
+}
+
 /// `rivet query --format json` must carry the same `command` envelope field as
 /// list/stats/coverage/validate, and expose the keys query-output.schema.json
 /// documents. REQ-189 (envelope consistency).

--- a/rivet-core/src/yaml_edit.rs
+++ b/rivet-core/src/yaml_edit.rs
@@ -825,7 +825,21 @@ pub fn modify_artifact_yaml(
                 editor.lines.remove(tags_line);
             }
         } else {
-            let tags_value = format!("[{}]", current_tags.join(", "));
+            // Quote each tag before re-emitting the flow list. Without this, a
+            // tag carrying a YAML flow indicator (`: `, `,`, `[`, `]`, `#`, …) —
+            // e.g. a legitimately-quoted `"release: v1.0"` read back from the
+            // store — is re-emitted bare (`release: v1.0`), which turns the flow
+            // list into a map and makes the WHOLE FILE unparseable, silently
+            // dropping every artifact in it. Mirrors the hardened `add` path
+            // (mutate.rs) which quotes each tag via `yaml_quote_inline_scalar`.
+            let tags_value = format!(
+                "[{}]",
+                current_tags
+                    .iter()
+                    .map(|t| yaml_quote_inline_scalar(t))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
             editor
                 .set_field(id, "tags", &tags_value)
                 .map_err(Error::Validation)?;


### PR DESCRIPTION
**P0 silent data loss** found by a mutation-path stress test (your report: modifying artifacts "very often" fails).

## The bug
`rivet-core/src/yaml_edit.rs` re-emitted the tag flow list via `current_tags.join(", ")` **without quoting individual tags** — unlike the hardened setters (title/status/field, #687) and the `add` path. Any tag with a YAML flow indicator (`: `, `,`, `[`…) breaks.

**Worst case — corruption from a benign operation:** an artifact with a legitimately-quoted tag `"release: v1.0"`, hit by an *unrelated* `--add-tag simpletag`, gets the quotes stripped → `[alpha, release: v1.0, …]` → the flow list becomes a map → the **whole file fails to parse** → **every artifact in it vanishes** — while `modify` exits 0 reporting "modified".

Reproduced: **2 artifacts → benign `--add-tag` → 0 loadable.**

## The fix
Quote each tag via `yaml_quote_inline_scalar` before joining (one-line change mirroring the already-hardened `add` path). Also closes a silent-split variant (`--add-tag "a,b"` stored two tags).

## Verification
- Reproduced the data loss, confirmed the fix restores 2/2 artifacts and keeps `"release: v1.0"` quoted.
- New rivet-cli regression test (`verifies REQ-287`); all 38 `yaml_edit` unit tests still pass.
- validate PASS, docs check 0 violations, clippy `--all-targets -D warnings` 0, fmt clean.

## Context
Same tag-mutation fragility class as #625, on the quoting axis. The broader mutation-path audit found **only this** live defect — `set-field`/`link`/`unlink`/`sql UPDATE`/`add` all preserved rich content faithfully (the surgical `yaml_edit.rs` editor was already hardened elsewhere). Part of v0.32.

Fixes: REQ-287

🤖 Generated with [Claude Code](https://claude.com/claude-code)