### PR TITLE
chore(release): v0.32.0 — weak-green hardening + mutation reliability + security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-08-05
+
+Weak-green hardening + mutation reliability + security. This release began as a
+deliberate audit of rivet's own "green that proves less than it appears."
+
+### Fixed
+- **P0 data loss: `rivet modify --add-tag`/`--remove-tag` could drop the whole
+  file** (REQ-287) — the tag flow list was re-emitted without quoting individual
+  tags (unlike the hardened `set-field`/`add` paths). A tag carrying a YAML flow
+  indicator — e.g. a legitimately-quoted `"release: v1.0"` read back from the
+  store — was re-emitted bare, turning the flow list into a map so the WHOLE file
+  failed to parse and **every artifact in it silently vanished**, while `modify`
+  exited 0 reporting success. A benign, unrelated `--add-tag` was enough to
+  trigger it. Each tag is now quoted via `yaml_quote_inline_scalar`; a regression
+  test guards it. (Found by a mutation-path stress audit that otherwise cleared
+  `set-field`/`link`/`unlink`/`sql UPDATE`/`add` as faithful.)
+- **Embedded docs no longer contradict the binary** (REQ-284) — a docs
+  countercheck found 8 truth-drifts that `rivet docs check` (token hygiene only)
+  passed clean: the `json-output` doc claimed a `{command, data:{…}}` envelope no
+  command emits (payload keys are top-level); three diagnostics docs used
+  `modify --field` (the flag is `--set-field`); `known-type` used a non-existent
+  `modify --type`; `broken-link` used a wrong `add` signature; `unknown-link-type`
+  pointed at a non-existent `rivet docs links` topic (it is `rivet schema links`);
+  and a coverage jq recipe used a stale `.entries[]` key (`.rules[]`).
+
+### Security
+- **wasmtime + wasmtime-wasi 45 → 47** — clears **RUSTSEC-2026-0222** (stores can
+  mix up type indices between engines) in the host wasm seam. `rkyv`'s
+  RUSTSEC-2026-0235 is a justified `cargo-audit` ignore: it is an optional feature
+  of `rust_decimal` that rivet does not enable (never compiled into any binary).
+
 ## [0.31.0] - 2026-08-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.31.0"
+version = "0.32.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release-prep for **v0.32.0**. Bumps `0.31.0 → 0.32.0` + CHANGELOG.

## Scope (all merged to main)
| REQ | What | PR |
|-----|------|----|
| **REQ-287** | P0 data-loss fix: `modify --add-tag` no longer drops the whole file | #765 |
| **REQ-284** | 8 embedded-doc truth-drift fixes | #764 |
| Security | wasmtime 45→47, RUSTSEC-2026-0222 cleared | #762 |

## Theme
This release began as a deliberate audit of rivet's own **"weak green"** — a green that proves less than it appears. It surfaced (and fixed) a silent whole-file data-loss on tag mutation, 8 docs that contradicted the binary, and cleared a real wasmtime advisory. Main's Security Audit is green again.

## Verification
Build, `rivet validate` PASS, `docs check` 0 violations. All three scope PRs verified green (correctness gates) before merge; the P0 fix carries a regression test + 38 passing yaml_edit unit tests.

## Queued for next (v0.33)
REQ-285 (`docs check` parses snippets — the meta-fix), REQ-286 (`release status` loudness), REQ-282 (`sql --schema`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)