### PR TITLE
chore(trace): flip REQ-284 proposed → implemented (clean-room pre-tag fix)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -8022,7 +8022,7 @@ artifacts:
   - id: REQ-284
     type: requirement
     title: "embedded docs truth-drift: diagnostics 'how to fix' snippets + json-output envelope contradict the binary"
-    status: proposed
+    status: implemented
     description: "Weak-green audit (embedded-docs countercheck, v0.31.0) found 8 divergences across 5 topics in rivet-cli/src/docs.rs where the doc claims behavior the binary does not have — invisible to `rivet docs check` (token/format hygiene only). WRONG: (1) json-output doc (docs.rs:712-717) claims a `{command, data:{...}}` envelope, but NO command emits `data` — payload keys are top-level siblings of `command` (misleads integrators most); (2/3/4) diagnostics/required-field, allowed-values, unknown-field snippets use `rivet modify … --field K=V` — the flag is `--set-field` (`--field` errors); (5) diagnostics/known-type uses `rivet modify --type` which does not exist (no CLI type-change at all — YAML edit only); (6) diagnostics/broken-link uses `rivet add requirement REQ-099 --title` — wrong signature (`add --type requirement --title`) and ids are auto-generated (no custom-id flag); (7) unknown-link-type points to `rivet docs links` — topic does not exist (it's `rivet schema links`). STALE: (8) json-output coverage recipe uses `.entries[]` — key is `.rules[]`. All diagnostic severities + message strings are truthful (strong). Fix each snippet to match the binary; part of the weak-green audit ledger."
     release: v0.32.0
     provenance:


### PR DESCRIPTION
The v0.32.0 clean-room pre-tag audit caught **REQ-284 left at `status: proposed`** while its embedded-doc corrections were already merged (#764). Status now matches shipped reality before the v0.32.0 tag. Artifact-only; `rivet validate` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)