### PR TITLE
ci(fmt): check every workspace in the Format gate, not just the root (#769)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,33 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - run: cargo fmt --all -- --check
+      # `cargo fmt --all` formats every member of THE workspace it is
+      # invoked in, not every crate in the repo. rivet has two workspaces
+      # (root + `fuzz/`) plus the standalone `compose-witness/` package
+      # (its own Cargo.lock, excluded from root). A single
+      # `cargo fmt --all` at the repo root leaves the fuzz workspace
+      # unchecked — see #769 for the drift that snuck through.
+      # Enumerate `[workspace]` manifests so a new nested workspace can't
+      # silently escape the gate.
+      - name: cargo fmt --check (every workspace)
+        run: |
+          set -euo pipefail
+          mapfile -t manifests < <(grep -rl --include=Cargo.toml --exclude-dir=target '^\[workspace\]' .)
+          if [ "${#manifests[@]}" -eq 0 ]; then
+            echo "no [workspace] Cargo.toml found — refusing to run a vacuous check"
+            exit 1
+          fi
+          for m in "${manifests[@]}"; do
+            echo "→ cargo fmt --manifest-path $m --all -- --check"
+            cargo fmt --manifest-path "$m" --all -- --check
+          done
+          # compose-witness is a standalone Wasm-component package (not a
+          # workspace, excluded from root). `cargo fmt` fails on it
+          # because its `bindings` module is generated at build time by
+          # cargo-component; rustfmt with skip_children formats the
+          # source without needing a build.
+          echo "→ rustfmt --check compose-witness/src/lib.rs (skip_children)"
+          rustfmt --check --edition 2024 --config skip_children=true compose-witness/src/lib.rs
 
   clippy:
     name: Clippy

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -8077,7 +8077,7 @@ artifacts:
   - id: REQ-289
     type: requirement
     title: "Format gate is green on unformatted tracked code: cargo fmt --all misses the fuzz/ workspace (#769, cf. spar#383)"
-    status: proposed
+    status: implemented
     description: "v0.33 gate-potency slice. The required `Format` check runs `cargo fmt --all -- --check`; `--all` means all members of THIS workspace, not all crates in the repo. rivet has two `[workspace]` manifests (root + `fuzz/`), and `compose-witness/` carries its own Cargo.lock as well. Live on HEAD: root `cargo fmt --all -- --check` exits 0 while `cargo fmt --manifest-path fuzz/Cargo.toml -- --check` exits 1 with real drift in tracked files (fuzz/examples/oracle_smoke.rs:44,258; fuzz/fuzz_targets/artifact_ids.rs:38,66; fuzz/fuzz_targets/cli_argv.rs:188). Fix: derive the workspace list (`grep -rl '^\\[workspace\\]' --include=Cargo.toml`) and check each, so a newly added nested workspace cannot silently escape the gate. Ported from spar#383."
     release: v0.33.0
     provenance:

--- a/fuzz/examples/oracle_smoke.rs
+++ b/fuzz/examples/oracle_smoke.rs
@@ -44,7 +44,10 @@ fn main() {
                     if !a.links.is_empty() {
                         eprintln!(
                             "    a[{i}].links = {:?}",
-                            a.links.iter().map(|l| (&l.link_type, &l.target)).collect::<Vec<_>>()
+                            a.links
+                                .iter()
+                                .map(|l| (&l.link_type, &l.target))
+                                .collect::<Vec<_>>()
                         );
                     }
                 }
@@ -258,9 +261,7 @@ fn probe(yaml: &str) -> Option<String> {
             }
             for l in &a.links {
                 if l.target.is_empty() {
-                    return Some(format!(
-                        "serde: phantom link (empty target)\nYAML:\n{yaml}"
-                    ));
+                    return Some(format!("serde: phantom link (empty target)\nYAML:\n{yaml}"));
                 }
                 if !yaml.contains(&l.target) {
                     return Some(format!(

--- a/fuzz/fuzz_targets/artifact_ids.rs
+++ b/fuzz/fuzz_targets/artifact_ids.rs
@@ -38,9 +38,7 @@ fuzz_target!(|data: &[u8]| {
     // escape those.
     let quoted = yaml_double_quote(&id_raw);
 
-    let yaml = format!(
-        "artifacts:\n  - id: {quoted}\n    type: requirement\n    title: Fuzz\n"
-    );
+    let yaml = format!("artifacts:\n  - id: {quoted}\n    type: requirement\n    title: Fuzz\n");
 
     let Ok(artifacts) = parse_generic_yaml(&yaml, None) else {
         return;
@@ -66,9 +64,7 @@ fuzz_target!(|data: &[u8]| {
 
     // Lookup by the id returned from the parser.
     let fetched = store.get(&parsed_id).unwrap_or_else(|| {
-        panic!(
-            "id-roundtrip: Store::insert succeeded but Store::get({parsed_id:?}) returned None"
-        )
+        panic!("id-roundtrip: Store::insert succeeded but Store::get({parsed_id:?}) returned None")
     });
 
     assert_eq!(

--- a/fuzz/fuzz_targets/cli_argv.rs
+++ b/fuzz/fuzz_targets/cli_argv.rs
@@ -188,11 +188,13 @@ fuzz_target!(|input: ArgvInput| {
                 let output = child
                     .wait_with_output()
                     .ok()
-                    .or_else(|| Some(std::process::Output {
-                        status,
-                        stdout: Vec::new(),
-                        stderr: Vec::new(),
-                    }))
+                    .or_else(|| {
+                        Some(std::process::Output {
+                            status,
+                            stdout: Vec::new(),
+                            stderr: Vec::new(),
+                        })
+                    })
                     .unwrap();
                 if json_mode && status.success() && !output.stdout.is_empty() {
                     let stdout = std::str::from_utf8(&output.stdout).unwrap_or("");

--- a/fuzz/fuzz_targets/yaml_footguns.rs
+++ b/fuzz/fuzz_targets/yaml_footguns.rs
@@ -169,9 +169,12 @@ fn probe(yaml: &str) {
     // serde_yaml happily materializes `target: null`, `target: ~`, and
     // `target: ""` as a link with a string-ish target that is not a real
     // artifact id.  This is the `yaml_hir.rs:530-549` bug class.
-    for list in [
-        serde_result.as_ref().ok().map(|v| v.as_slice()).unwrap_or(&[]),
-    ] {
+    for list in [serde_result
+        .as_ref()
+        .ok()
+        .map(|v| v.as_slice())
+        .unwrap_or(&[])]
+    {
         for a in list {
             for l in &a.links {
                 let t = l.target.trim();
@@ -237,7 +240,10 @@ fn probe(yaml: &str) {
 
 fn apply_footgun(yaml: &str, f: &Footgun) -> String {
     match f {
-        Footgun::Norway { which_field, variant } => {
+        Footgun::Norway {
+            which_field,
+            variant,
+        } => {
             let payload = norway_variant(*variant);
             // Replace the first scalar value at column 4+ that matches the
             // chosen field.  Keep it simple: pick one of id/title/status/
@@ -271,7 +277,9 @@ fn apply_footgun(yaml: &str, f: &Footgun) -> String {
             lines.join("\n") + "\n"
         }
         Footgun::MultiDocument => {
-            format!("{yaml}\n---\nartifacts:\n  - id: REQ-999\n    type: requirement\n    title: Second doc\n")
+            format!(
+                "{yaml}\n---\nartifacts:\n  - id: REQ-999\n    type: requirement\n    title: Second doc\n"
+            )
         }
         Footgun::NullShorthandLink { variant } => {
             let value = match variant % 3 {
@@ -286,9 +294,9 @@ fn apply_footgun(yaml: &str, f: &Footgun) -> String {
         }
         Footgun::UnknownTopLevelKey { variant } => {
             let key = match variant % 3 {
-                0 => "artifact:",    // singular typo
-                1 => "Artifacts:",   // case
-                _ => "artifcats:",   // misspelling
+                0 => "artifact:",  // singular typo
+                1 => "Artifacts:", // case
+                _ => "artifcats:", // misspelling
             };
             yaml.replacen("artifacts:", key, 1)
         }

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -40,8 +40,24 @@ cat > "$HOOKS_DIR/pre-commit" << 'HOOK'
 # This hook is convenience only; CI is the real gate (see REQ-051).
 if command -v cargo &>/dev/null \
     && git diff --cached --name-only --diff-filter=ACM | grep -q '\.rs$'; then
-    if ! cargo fmt --all -- --check; then
-        echo "cargo fmt: formatting issues. Run 'cargo fmt --all', then re-stage."
+    # `cargo fmt --all` only formats the invoking workspace. rivet has two
+    # workspaces (root + fuzz/) and one standalone package (compose-witness/);
+    # a single `--all` at the root leaves fuzz/ unchecked (#769).
+    fmt_failed=0
+    for m in $(grep -rl --include=Cargo.toml --exclude-dir=target '^\[workspace\]' .); do
+        if ! cargo fmt --manifest-path "$m" --all -- --check; then
+            fmt_failed=1
+        fi
+    done
+    if [ -f compose-witness/src/lib.rs ]; then
+        if ! rustfmt --check --edition 2024 --config skip_children=true \
+                compose-witness/src/lib.rs; then
+            fmt_failed=1
+        fi
+    fi
+    if [ "$fmt_failed" -ne 0 ]; then
+        echo "cargo fmt: formatting issues. Run 'cargo fmt --all' in each"
+        echo "workspace (root + fuzz/) and rustfmt on compose-witness, then re-stage."
         exit 1
     fi
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -5,9 +5,22 @@
 set -e
 
 echo "pre-commit: checking formatting..."
-cargo fmt --all -- --check 2>/dev/null
-if [ $? -ne 0 ]; then
-    echo "ERROR: cargo fmt check failed. Run 'cargo fmt --all' to fix."
+# `cargo fmt --all` only formats the invoking workspace. rivet has two
+# workspaces (root + fuzz/) and one standalone package (compose-witness/);
+# check them all so a drift in fuzz/ can't ship (#769).
+fmt_failed=0
+for m in $(grep -rl --include=Cargo.toml --exclude-dir=target '^\[workspace\]' .); do
+    if ! cargo fmt --manifest-path "$m" --all -- --check 2>/dev/null; then
+        fmt_failed=1
+    fi
+done
+if ! rustfmt --check --edition 2024 --config skip_children=true \
+        compose-witness/src/lib.rs 2>/dev/null; then
+    fmt_failed=1
+fi
+if [ "$fmt_failed" -ne 0 ]; then
+    echo "ERROR: cargo fmt check failed. Run 'cargo fmt --all' in each"
+    echo "workspace (root + fuzz/) and rustfmt on compose-witness/src/lib.rs."
     exit 1
 fi
 


### PR DESCRIPTION
Closes #769.

## The bug — the Format gate has never seen the fuzz workspace

`cargo fmt --all -- --check` at the repo root formats every member of **THIS** workspace, not every crate in the repo. rivet has two `[workspace]` manifests (root + `fuzz/`) plus the standalone `compose-witness/` package (its own `Cargo.lock`, excluded from the root workspace), so the required Format gate has been vacuous for `fuzz/` since it was added.

Live on HEAD before this PR:

```
$ cargo fmt --all -- --check                                 ; echo $?
0
$ cargo fmt --manifest-path fuzz/Cargo.toml --all -- --check ; echo $?
1
Diff in fuzz/examples/oracle_smoke.rs:44
Diff in fuzz/examples/oracle_smoke.rs:258
Diff in fuzz/fuzz_targets/artifact_ids.rs:38
Diff in fuzz/fuzz_targets/artifact_ids.rs:66
Diff in fuzz/fuzz_targets/cli_argv.rs:188
```

(Plus `fuzz/fuzz_targets/yaml_footguns.rs` — bonus drift not called out in the issue but caught by the same reformat.)

## Fix

Derive the workspace list dynamically so a **new** nested workspace can't silently escape the gate either:

```yaml
mapfile -t manifests < <(grep -rl --include=Cargo.toml --exclude-dir=target '^\[workspace\]' .)
for m in "${manifests[@]}"; do
  cargo fmt --manifest-path "$m" --all -- --check
done
rustfmt --check --edition 2024 --config skip_children=true compose-witness/src/lib.rs
```

- `compose-witness/` is a standalone Wasm-component package that `cargo fmt` can't traverse — its `bindings` module is generated at build time by cargo-component — so `rustfmt` with `skip_children=true` handles it without a build.
- The step fails loudly (`exit 1`) if the workspace enumeration returns zero manifests, so a future refactor can't silently make the gate vacuous again.
- The same bug shape existed in `scripts/pre-commit` and `scripts/install-hooks.sh` (both called `cargo fmt --all -- --check` at the root). Both now use the same enumeration so local dev doesn't push code that the fixed CI gate would reject. Per REQ-051 the hooks are convenience only — CI stays the real gate.

## Negative control — the point of this REQ

Injected a synthetic drift into `fuzz/fuzz_targets/artifact_ids.rs` and ran both gates:

| Scenario | old gate (`cargo fmt --all` at root) | new gate |
|---|---|---|
| fuzz drift present | **exit 0** (vacuous green) | **exit 1** (drift caught) |
| tree clean | exit 0 | exit 0 |

## Acceptance criteria (from the issue body → how satisfied)

- [x] **Every `[workspace]` manifest in the repo is checked, not just the root.** Fix uses `grep -rl '^\[workspace\]' --include=Cargo.toml` exactly as the issue suggests, so a newly added nested workspace is automatically covered.
- [x] **`compose-witness/` (standalone, its own `Cargo.lock`) is also checked.** Handled via direct `rustfmt --config skip_children=true` because its `bindings` module is build-time generated and `cargo fmt` fails on it without a build.
- [x] **Real drift in `fuzz/` tracked files is caught.** All five sites listed in the issue (`oracle_smoke.rs:44,258`; `artifact_ids.rs:38,66`; `cli_argv.rs:188`) are reformatted; `cargo fmt --manifest-path fuzz/Cargo.toml --all -- --check` now exits 0. `yaml_footguns.rs` was drifted too and is included.
- [x] **New gate would have caught the drift.** Negative-control table above; captured from a live run before/after the fix.

## Test plan

- [x] `cargo fmt --manifest-path ./Cargo.toml --all -- --check` → clean
- [x] `cargo fmt --manifest-path ./fuzz/Cargo.toml --all -- --check` → clean
- [x] `rustfmt --check --edition 2024 --config skip_children=true compose-witness/src/lib.rs` → clean
- [x] `cargo check --manifest-path fuzz/Cargo.toml --all-targets` → clean (reformatted files still compile)
- [x] Synthetic-drift negative control (see table above) — old gate green, new gate red
- [x] Grep enumeration surfaces `./Cargo.toml` and `./fuzz/Cargo.toml`; the empty-set guard would fire if it didn't

## What this PR is NOT

- Not a fix for the broader "detect-changed-areas filter is under-scoped" gate-audit finding (#771) — that's a separate defect (the `changes` job's Rust filter missing `schemas/**` and composite actions) and warrants its own PR.
- Not a fix for the `check verification-evidence` no-workflow-runs-it finding (#770) — same shape, different check.
- Not a rewrite of the pre-commit hooks beyond swapping the broken `cargo fmt --all` call for the enumeration. Everything else in those scripts (clippy, rivet validate) is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_014NmwwtE8WWfcTLsfNNKfLC)_