### PR TITLE
ci(traceability): wire rivet check verification-evidence + kill weak-green empty scan (#770)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,16 @@ jobs:
             cargo run --release -q -p rivet-cli -- validate --model "$model" --binding artifacts/bindings.yaml --strict-variants
             echo "::endgroup::"
           fi
+      # Gate 1c (REQ-290 / #770): the named-test-exists anti-rot check. rivet
+      # BUILT this checker (REQ-236, hardened again in REQ-280 for nextest
+      # filtersets) precisely to catch the silent-drift class from spar#388 —
+      # `cargo test <renamed_or_typod_filter>` exits 0 with "0 passed", so a
+      # `fields.steps[].run` naming a stale test kept the requirement falsely
+      # `verified`. Until this step landed, no workflow ran the check, so the
+      # protection was opt-in-by-memory. Reuses the release binary the two
+      # steps above already built, so no extra compile cost.
+      - name: rivet check verification-evidence (REQ-290)
+        run: cargo run --release -p rivet-cli -- check verification-evidence
       # Gate 2: no ORPHAN commits and no BROKEN trailer refs introduced by
       # THIS PR. Scoped to the PR's own commits (base..HEAD). NOT `--strict`,
       # which promotes whole-store "artifact has no commit coverage" findings
@@ -285,6 +295,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: rivet validate (fail on errors) — hosted floor
         run: cargo run --release -p rivet-cli -- validate
+      # REQ-290 / #770 mirror on the hosted floor: if the self-hosted pool is
+      # offline, main still gets the named-test-exists anti-rot check.
+      - name: rivet check verification-evidence — hosted floor (REQ-290)
+        run: cargo run --release -p rivet-cli -- check verification-evidence
 
   # ── Tests ─────────────────────────────────────────────────────────────
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 ## [Unreleased]
 
+### Fixed
+- **`rivet check verification-evidence` is now wired into CI + no longer scores
+  an empty scan as a pass** (REQ-290, #770) — the anti-rot check for stale
+  `cargo test <filter>` names (REQ-236, hardened again in REQ-280 for nextest
+  filtersets) BUILT the tool that catches spar#388's failure shape, but no
+  workflow ran it, so the protection was opt-in-by-memory. Two fixes: (1) the
+  Traceability job (both self-hosted and the hosted fallback) now runs `rivet
+  check verification-evidence`, reusing the release binary the neighboring
+  `validate` step already built; (2) an empty scan (`0 named-test step(s)`)
+  previously rendered as `✓ … all reference an existing test` — a checkmark
+  over nothing checked, the same weak-green shape the check exists to kill —
+  and now renders as an explicit `⚠ … no named-test step(s) found to check —
+  nothing was verified` with `empty_scan: true` in JSON output so a machine
+  can tell the vacuous case from a genuine pass.
+
 ## [0.32.0] - 2026-08-05
 
 Weak-green hardening + mutation reliability + security. This release began as a

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -8088,7 +8088,7 @@ artifacts:
   - id: REQ-290
     type: requirement
     title: "check verification-evidence runs in no workflow — the anti-rot check nothing enforces (#770, cf. spar#388)"
-    status: proposed
+    status: implemented
     description: "v0.33 gate-potency slice. spar#388 found 7 verification artifacts citing tests that never existed (`cargo test -- <no match>` exits 0, so the gate scored them passing). rivet BUILT the checker for exactly that class — `rivet check verification-evidence` (REQ-236, hardened again in REQ-280 for nextest filtersets) — and `grep verification-evidence .github/workflows/*.yml` returns nothing: no workflow runs it, so the protection is opt-in-by-memory. Second, smaller defect: on an empty scan it prints `✓ verification-evidence: 0 named-test step(s) all reference an existing test` — a checkmark over nothing checked, the same weak-green shape the check exists to kill. Fix: (1) run it in the Traceability job (the binary is already built there); (2) reword the zero-steps case so an empty scan does not render as a pass."
     release: v0.33.0
     provenance:

--- a/rivet-cli/src/main.rs
+++ b/rivet-cli/src/main.rs
@@ -8238,17 +8238,33 @@ fn cmd_check_verification_evidence(
         }
     }
 
+    // #770: an empty scan is not a pass. The old text was
+    //   `✓ verification-evidence: 0 named-test step(s) all reference an existing test.`
+    // — a checkmark over nothing checked, the same weak-green shape this check
+    // exists to kill. Report it as a distinct outcome instead.
+    let empty_scan = checked == 0 && skipped.is_empty();
+
     if format == "json" {
         let obj = serde_json::json!({
             "command": "check verification-evidence",
             "named_test_steps_checked": checked,
             "missing": missing,
             "skipped": skipped,
+            "empty_scan": empty_scan,
             "ok": missing.is_empty(),
         });
         println!("{}", serde_json::to_string_pretty(&obj)?);
     } else {
-        if missing.is_empty() {
+        if empty_scan {
+            println!(
+                "\u{26a0} verification-evidence: no named-test step(s) found to check — \
+                 nothing was verified.\n  \
+                 A verification artifact ties a requirement to a specific test via \
+                 `fields.steps[].run: \"cargo test … <filter>\"`.\n  \
+                 If this project uses that shape, none of its steps parsed as a \
+                 cargo/nextest filter; if it doesn't, this check is a no-op here."
+            );
+        } else if missing.is_empty() {
             println!(
                 "\u{2713} verification-evidence: {checked} named-test step(s) all reference an existing test."
             );

--- a/rivet-cli/tests/cli_commands.rs
+++ b/rivet-cli/tests/cli_commands.rs
@@ -931,6 +931,150 @@ fn check_verification_evidence_skips_nextest_filterset_not_errors() {
     assert_eq!(skipped[0]["artifact"], "FV-001");
 }
 
+/// #770 (REQ-290): the empty-scan case must not render as a pass. The pre-fix
+/// text was `✓ verification-evidence: 0 named-test step(s) all reference an
+/// existing test.` — a checkmark over nothing checked, the same weak-green
+/// shape the check exists to kill. On a project whose verification steps carry
+/// no `cargo test <filter>` invocations (or has no verification steps at all),
+/// stdout must NOT read as a ✓ / "all reference an existing test", and JSON
+/// must expose `empty_scan: true` so a machine can tell the vacuous case from
+/// a genuine pass. Exit code stays 0 (nothing was violated), matching the
+/// pre-fix contract used by callers.
+///
+/// rivet: verifies REQ-290
+#[test]
+fn check_verification_evidence_empty_scan_reads_as_vacuous_not_pass() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: p\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    // An artifact with a `steps` block that carries only non-cargo-test runs
+    // (make, python, etc.). The scanner parses none as a cargo/nextest filter,
+    // so `named_test_steps_checked` is 0 with no skipped-filterset entries —
+    // the vacuous-scan case #770 flagged.
+    std::fs::write(
+        dir.join("artifacts/a.yaml"),
+        "artifacts:\n  \
+         - id: FV-001\n    type: requirement\n    title: v\n    status: implemented\n    \
+             fields:\n      steps:\n        \
+             - run: \"make lint\"\n        \
+             - run: \"pytest -k something\"\n",
+    )
+    .unwrap();
+
+    // ── text output ───────────────────────────────────────────────────────
+    let text_out = Command::new(rivet_bin())
+        .args(["--project", dirs, "check", "verification-evidence"])
+        .output()
+        .expect("check");
+    assert!(
+        text_out.status.success(),
+        "empty-scan case must exit 0 — the check found nothing to violate"
+    );
+    let text = String::from_utf8_lossy(&text_out.stdout);
+    assert!(
+        !text.contains("\u{2713}") && !text.contains("all reference an existing test"),
+        "empty scan must NOT render as ✓ / 'all reference an existing test'; \
+         stdout was:\n{text}"
+    );
+    assert!(
+        text.contains("no named-test step(s) found") && text.contains("nothing was verified"),
+        "empty scan must state plainly that nothing was verified; stdout was:\n{text}"
+    );
+
+    // ── JSON output ───────────────────────────────────────────────────────
+    let json_out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "check",
+            "verification-evidence",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("check --format json");
+    assert!(json_out.status.success(), "empty-scan case must exit 0");
+    let v: serde_json::Value = serde_json::from_slice(&json_out.stdout).expect("json");
+    assert_eq!(v["named_test_steps_checked"], 0);
+    assert!(v["missing"].as_array().unwrap().is_empty());
+    assert!(v["skipped"].as_array().unwrap().is_empty());
+    assert_eq!(
+        v["empty_scan"], true,
+        "empty_scan must be true so a machine can distinguish the vacuous case \
+         from a genuine pass; JSON was:\n{v}"
+    );
+}
+
+/// #770 (REQ-290): a non-empty scan (real cargo-test steps, all pointing at
+/// existing tests) keeps the pre-fix ✓ / "all reference an existing test"
+/// wording and `empty_scan: false`. Guards against the new empty-scan branch
+/// accidentally shadowing the genuine-pass shape.
+///
+/// rivet: verifies REQ-290
+#[test]
+fn check_verification_evidence_non_empty_scan_still_reads_as_pass() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dir = tmp.path();
+    let dirs = dir.to_str().unwrap();
+    std::fs::create_dir_all(dir.join("artifacts")).unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("rivet.yaml"),
+        "project:\n  name: p\n  schemas: [common, dev]\n\
+         sources:\n  - path: artifacts\n    format: generic-yaml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src/lib.rs"),
+        "#[test]\nfn a_real_test() { assert!(true); }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("artifacts/a.yaml"),
+        "artifacts:\n  \
+         - id: FV-001\n    type: requirement\n    title: v\n    status: implemented\n    \
+             fields:\n      steps:\n        \
+             - run: \"cargo test -p p a_real_test\"\n",
+    )
+    .unwrap();
+
+    let text_out = Command::new(rivet_bin())
+        .args(["--project", dirs, "check", "verification-evidence"])
+        .output()
+        .expect("check");
+    assert!(text_out.status.success());
+    let text = String::from_utf8_lossy(&text_out.stdout);
+    assert!(
+        text.contains("\u{2713}") && text.contains("all reference an existing test"),
+        "a real pass must still render as ✓ / 'all reference an existing test'; \
+         stdout was:\n{text}"
+    );
+
+    let json_out = Command::new(rivet_bin())
+        .args([
+            "--project",
+            dirs,
+            "check",
+            "verification-evidence",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("check --format json");
+    let v: serde_json::Value = serde_json::from_slice(&json_out.stdout).expect("json");
+    assert_eq!(v["named_test_steps_checked"], 1);
+    assert_eq!(v["empty_scan"], false);
+    assert_eq!(v["ok"], true);
+}
+
 /// #547 (REQ-238): `rivet trace-results <req>` walks FORWARD from a requirement
 /// to the test results that cover it (the reverse of the authored `verifies`
 /// direction) and rolls up a pass/fail verdict — the data behind the graphical


### PR DESCRIPTION
Closes #770. Third implementation slice of v0.33 "gate potency" (after #774 fmt-gate and #773 mutation-gate). Two fixes for a single defect: the anti-rot check for stale `cargo test <filter>` names existed but was unenforced, and its empty-scan output rendered as a pass.

## The unenforced anti-rot check

`rivet check verification-evidence` (REQ-236, hardened again in REQ-280 for nextest filtersets) catches the class spar#388 found — verification steps whose `fields.steps[].run: "cargo test … <filter>"` names a test that no longer exists. `cargo test <renamed_or_typod>` exits 0 with `"0 passed"`, so the requirement keeps its `verified` status. rivet BUILT the checker for exactly that shape, and:

```
$ grep -n verification-evidence .github/workflows/*.yml
(no matches on HEAD)
```

No workflow ran it. Protection was opt-in-by-memory.

## The weak-green empty-scan case

On a project whose steps carry no `cargo test <filter>` runs (or has no steps at all), the pre-fix text was:

```
✓ verification-evidence: 0 named-test step(s) all reference an existing test.
```

A checkmark over nothing checked — the same weak-green shape the check exists to kill. On THIS repo, that's what HEAD prints today.

## Fixes

- **`.github/workflows/ci.yml`** — add `rivet check verification-evidence` to the `traceability` job (REQ-051 dogfooding gate) as **Gate 1c** and mirror it in `traceability-hosted-fallback` (REQ-272 / #509 SPOF mitigation), so a self-hosted-pool outage still leaves `main` gated on the anti-rot check. Reuses the release binary the neighboring `validate` step already built — no extra compile.
- **`rivet-cli/src/main.rs cmd_check_verification_evidence`** — an `empty_scan` branch renders as `⚠ verification-evidence: no named-test step(s) found to check — nothing was verified.` (with a plain sentence explaining what the check would look for) instead of the ✓ / `all reference an existing test` shape. JSON output gains `empty_scan: true` in that branch so a machine can distinguish the vacuous case from a genuine pass. Exit code stays `0` (nothing was violated) — this preserves the pre-fix contract used by every existing caller, so the new CI step is green on HEAD instead of accidentally red on day one.

Live on HEAD after the fix, on this repo:

```
$ ./target/release/rivet check verification-evidence
⚠ verification-evidence: no named-test step(s) found to check — nothing was verified.
  A verification artifact ties a requirement to a specific test via `fields.steps[].run: "cargo test … <filter>"`.
  If this project uses that shape, none of its steps parsed as a cargo/nextest filter; if it doesn't, this check is a no-op here.

$ ./target/release/rivet check verification-evidence --format json
{
  "command": "check verification-evidence",
  "empty_scan": true,
  "missing": [],
  "named_test_steps_checked": 0,
  "ok": true,
  "skipped": []
}
```

## Acceptance criteria (from the issue body → how satisfied)

- [x] **Add `rivet check verification-evidence` to the Traceability job in `ci.yml` (it is fast and needs no compile beyond the binary already built there).** Added as `Gate 1c` in the `traceability` job, between `validate` and `commits`. Also mirrored on `traceability-hosted-fallback` so the SPOF mitigation (REQ-272 / #509) covers this check too.
- [x] **Reword the zero-steps case so an empty scan does not render as a pass.** New `empty_scan` branch in `cmd_check_verification_evidence`: distinct `⚠` prefix, explicit "nothing was verified" wording, and `empty_scan: true` in JSON. Pinned by regression tests in both directions.

Two new regression tests in `rivet-cli/tests/cli_commands.rs`:

- `check_verification_evidence_empty_scan_reads_as_vacuous_not_pass` — a project whose only steps are `make lint` / `pytest -k` (parsed by neither the cargo nor the nextest branch) produces stdout that does NOT contain the ✓ / "all reference an existing test" shape and JSON with `empty_scan: true`.
- `check_verification_evidence_non_empty_scan_still_reads_as_pass` — a real `cargo test -p p a_real_test` step still renders as ✓ / "all reference an existing test" and JSON `empty_scan: false`. Guards the new branch against shadowing the genuine-pass shape.

REQ-290 flipped `proposed → implemented`. CHANGELOG entry added under `[Unreleased]`.

## Test plan

- [x] `cargo test -p rivet-cli --test cli_commands check_verification_evidence` — 4/4 pass (2 pre-existing + 2 new)
- [x] `cargo test -p rivet-cli --test cli_commands` — 162/162 pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p rivet-cli --tests -- -D warnings` clean (only the pre-existing MSRV note from `clippy.toml`)
- [x] `./target/release/rivet check verification-evidence` on this repo — renders as `⚠ … no named-test step(s) found to check`, exits 0 → the new CI step is green on HEAD
- [x] `./target/release/rivet validate` on this repo — PASS (635 warnings, unchanged; REQ-290 now shows in the "no downstream artifacts" set, same shape as its neighbours)
- [x] `./target/release/rivet commits --range origin/main..HEAD` — exit 0 (trailers recognized)

## What this PR is NOT

- Not a change to the `missing`-detection path — the same fn-name scanner runs over the same artifact walk. Only the empty-scan render + the CI wiring changed.
- Not a change to the exit-code contract. An empty scan still exits 0. If a future policy decision wants an empty scan to be RED (e.g. "a project claiming verification coverage MUST have at least one named-test step"), that's a separate REQ.
- Not a fix for #771 (`changes` filter under-scoped, REQ-291) or #557 (crates.io publishing). Same v0.33 slice, separate PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UD5As6pYghNkKHHZkiLyCG)_