### PR TITLE
docs(design): harvest 2 durable notes from the stale sphinx-needs branch

### DIFF
--- a/docs/design/eclipse-score-vs-pulseengine-approach.md
+++ b/docs/design/eclipse-score-vs-pulseengine-approach.md
@@ -1,0 +1,302 @@
+> **Harvested 2026-08-06** from the stale `feat/import-results-sphinx-needs`
+> branch (written 2026-06, base `86bf482`, never merged). Preserved as a
+> **historical design note**: its observations were true when written and have
+> **not** been re-verified against the current implementation. Read it as
+> context and as a proposal, not as current documentation.
+
+# Eclipse S-CORE vs pulseengine — way-of-working comparison
+
+**Status**: reference doc. Captures an observational comparison
+between two methodologies that solve overlapping problems with
+opposite defaults. Not a verdict — useful any time the rivet team
+needs to make a positioning decision against an external safety
+project.
+
+**Originating context**: the
+[`pulseengine/playground-eclipse-score`](https://github.com/pulseengine/playground-eclipse-score)
+workspace surfaced these observations while converting eclipse's
+sphinx-needs corpus into rivet typed YAML.
+
+## The big shape
+
+**Eclipse S-CORE** is a *document-centric* methodology built on the
+Sphinx ecosystem. Their atomic unit is the RST file: prose-with-
+embedded-directives that compiles into a published documentation
+site. The traceability graph emerges from sphinx-needs directives
+that authors hand-write *inside* the RST source. Operationally,
+"the work product" is the rendered HTML; "the data" is the
+directives that produce it.
+
+**Pulseengine** is a *graph-centric* methodology built on typed YAML.
+The atomic unit is a `.yaml` artifact: a structured record validated
+against a schema and stored in git. Documents are emitted *from* the
+graph, not the other way around. Operationally, "the work product"
+is the validated graph; rendering is a downstream concern
+(`rivet serve` / `rivet export --format html`).
+
+This is a real difference in default direction, not just storage
+format. Eclipse's authors write prose and accidentally form a graph;
+pulseengine's authors write graph nodes and rendering follows.
+
+## Axis-by-axis observations
+
+### Storage shape
+
+| | Eclipse | Pulseengine |
+|---|---|---|
+| Authoring surface | RST directives in `.rst` files | YAML artifacts in `.yaml` files |
+| Source-of-truth granularity | One file = one document = multiple needs | One file = many artifacts of mixed types, or one artifact per file (both supported) |
+| Mutation model | Edit RST in-place; sphinx rebuilds | Edit YAML in-place; rivet revalidates (incremental via salsa) |
+| Schema | `metamodel.yaml` interpreted by Python (`score_metamodel/yaml_parser.py`) at sphinx-build time | `schemas/*.yaml` loaded by Rust at validate time |
+
+### Validation philosophy
+
+Eclipse validates **at render time**: their `score_metamodel/checks/`
+Python module runs as Sphinx warnings during
+`bazel run //:docs_check`. The build fails if anything is off
+(`-W --keep-going`). Validation is a *side-effect of producing the
+docs*.
+
+Pulseengine validates **as an operation in its own right**:
+`rivet validate` reads the YAML, applies the schema, reports
+diagnostics. Docs can be built or not; validation runs either way.
+Validation is *first-class*.
+
+This shows up in how each side thinks about CI: eclipse's
+`docs_check` *is* the gate; pulseengine has `validate` *plus*
+`mutate` *plus* `coverage` *plus* `commits` *plus* `audit`, each
+callable independently and each can fail-fast.
+
+### Cross-artifact rules
+
+Eclipse expresses cross-graph rules in **Python**
+(`graph_checks.py` with `local_check`/`graph_check` decorators) and
+small **YAML expressions** (`metamodel.yaml`'s `graph_checks:`
+section using `==/in/and` micro-DSL).
+
+Pulseengine expresses them in the **schema YAML** itself as
+declarative `traceability-rules:` entries with `required-link /
+required-backlink / source-type / target-types / severity`. Same
+rules ("QM can't satisfy ASIL") but the *language they're written in*
+is the same language used to declare the artifact types.
+
+### Process modelling
+
+Eclipse models the process **as needs**: workflows are `workflow::`
+directives, roles are `role::` directives, work products are
+`workproduct::` directives, methods are `gd_method::` directives.
+The development process IS data in the same graph as the
+requirements it produces. Reading
+`process_description/process/process_areas/safety_analysis/
+safety_analysis_workflow.rst` you find a typed workflow with
+`:input:`, `:output:`, `:responsible:`, `:approved_by:` links.
+
+Pulseengine models the process **as metadata around code**: commit
+trailers (`Implements: REQ-NNN`), `rivet commits` enforces them,
+`rivet audit` cross-checks AI-session provenance, `ai-session` and
+`ai-found-defect` artifacts capture AI authorship. The process
+artifacts are about who-authored-what-when, not about
+who-reviewed-what-by-whom-when. There's no `workflow` or `role`
+artifact type in any pulseengine schema except the eclipse-score
+ones added in `score.yaml` round 1.
+
+This is the most visible philosophy difference: eclipse describes the
+*human process*, pulseengine describes the *machine-checkable
+claims*.
+
+### Safety case
+
+Eclipse's safety case is a **rendered RST document** —
+`module_safety_package_fdr.rst` is the safety case, containing
+in-line `:need:` citations to ISO 26262 clauses, ASIL evidence, FMEA
+references. To assess compliance, an auditor reads the rendered HTML.
+
+Pulseengine's safety case is **a graph of typed artifacts** — STPA
+losses → hazards → constraints → UCAs → loss-scenarios, plus FMEA +
+DFA + verification + attestation. To assess compliance, an auditor
+runs `rivet matrix` / `rivet coverage` / `rivet export` and reads
+the *computed* report.
+
+Eclipse: safety case is authored. Pulseengine: safety case is
+computed.
+
+### Architecture modelling
+
+Eclipse made **the typed need-graph itself** the architecture model
+(see the audit at the corpus oracle: zero `.aadl`/`.sysml`/`.capella`
+files across 58 repos, 90+ architecture diagrams generated from the
+typed-graph via `score_draw_uml_funcs` registering `draw_feature` /
+`draw_component` / `draw_module` / `draw_interface` Jinja callables
+that walk typed links and emit PlantUML at sphinx-build time).
+Validation is **structural** (link integrity) but not **analytical**
+(no scheduling, no latency, no formal property check).
+
+Pulseengine has `spar` (AADL v2.3 frontend with 27+ analysis passes —
+scheduling, latency, ARINC 653 partitioning, EMV2 fault trees, ASIL
+decomposition solver, modal filtering, piecewise-affine arrival
+curves). The model is similarly typed-graph at the surface, but the
+analysis layer is much richer.
+
+Both committed to "model is typed graph, no separate modelling-tool
+file drifting away from the docs." Pulseengine adds the
+analysis-pass layer on top.
+
+### Tool qualification
+
+Eclipse qualifies tools **inside the same graph**: every tool
+(clang-tidy, clippy, gtest, etc.) is a `doc_tool::` directive with
+`:tcl: LOW`, `:safety_affected: ...`, `:realizes: wp__tool_
+verification_report`. The tool qualifies itself by being a node in
+the same graph it operates on. Recursive: docs-as-code qualifies
+docs-as-code (with `status: evaluated` and no TI/TD analysis — the
+ISO 26262 reviewer in our persona panel flagged this as an
+audit-day question).
+
+Pulseengine qualifies tools through **dedicated artifact types** and
+a published `SAFETY.md` self-claim. The qualification is a separate
+construct from the artifact graph; it sits alongside (also
+self-claimed today, per the DO-330 reviewer in our persona panel).
+
+### Compliance reporting
+
+Eclipse renders compliance reports **in-page**: `needpie::` and
+`needtable::` directives compute coverage live from the graph at
+sphinx-build time and embed it in the published HTML. ISO 26262
+coverage = a pie chart on the standards page.
+
+Pulseengine renders compliance through **multiple channels**:
+- `{{coverage}}` / `{{matrix}}` / `{{table}}` embeds in markdown docs
+- `rivet matrix` / `rivet coverage` CLI
+- `/api/v1/coverage` JSON API for Grafana
+- `rivet export --format html` static `matrix.html` / `coverage.html`
+- `rivet serve` live dashboard
+
+Eclipse: one rendering, in-doc. Pulseengine: many renderings, one
+data source.
+
+### Cross-repo composition
+
+Eclipse uses **sphinx-needs `external_needs`** plumbed through
+Bazel: each downstream repo Bazel-deps the upstream `needs.json`,
+which sphinx-needs loads at build time and merges into the local
+graph.
+
+Pulseengine uses **`externals:` in rivet.yaml** plumbed through git:
+each project declares upstream peers; `rivet sync` materialises them
+as `.rivet/repos/<name>/`; `rivet supplier` handles cross-org
+boundaries with `derives-from-external` links and content-addressed
+hashes. The playground demonstrates this at 58-external scale.
+
+Eclipse: Bazel-mediated, build-time merge.
+Pulseengine: git-mediated, declared-dependency model.
+
+### Variants / feature model
+
+Eclipse has **one stakeholder requirement** saying variant
+management is needed, with `rationale: tbd`. No metamodel construct.
+Their archived `inc_process_variant_management` repo (single-author
+experiment with `sphinx_ifelse` for OS-conditional doc rendering,
+archived 2025-08+) is the only attempt and was rendering-layer only.
+
+Pulseengine has a **first-class feature-model.yaml** with
+attribute-schema, constraints, alternative/or/mandatory groups, plus
+bindings + named variants + `rivet variant solve/matrix/explain`
+operating on it.
+
+This is the place where the directions diverge most: eclipse has the
+*requirement*, pulseengine has the *answer*. The playground's
+`variants/` directory is the worked starter example.
+
+### Source-code linking
+
+Eclipse links source to requirements via **comments in source**:
+`// req-Id: foo` scanned by `score_source_code_linker` extension at
+sphinx-build time, attached as `source_code_link` attributes on the
+matching need.
+
+Pulseengine links via **commit trailers**: `Implements: REQ-NNN` in
+the commit message body, enforced by `rivet commits` against a
+per-commit-message contract. The link is per-commit, not per-line.
+
+Eclipse: fine-grained (source line ↔ requirement). Pulseengine:
+coarse-grained (commit ↔ requirement). Both auditable; different
+granularity.
+
+### Documentation surface
+
+Eclipse: **the docs ARE the deliverable.** The published HTML site
+is what auditors read, what stakeholders cite. The data structure
+is in service of the document.
+
+Pulseengine: **the docs are A deliverable.** The data structure is
+the primary artifact; HTML export, dashboard, and Grafana embeds are
+alternative views. The graph survives independent of any rendering.
+
+## Where they're doing the *same thing* differently
+
+| Same problem | Eclipse | Pulseengine |
+|---|---|---|
+| "Tag all needs in this subtree" | `needextend :+tags:` at file-top | `tags: [...]` on each artifact (or schema-level base-tag) |
+| "Cite a requirement inline" | `:need:`foo`` RST role | `[[foo]]` or `{{artifact:foo}}` markdown |
+| "Show coverage per standard" | `needpie::` with filter function | `{{coverage:rule-name}}` embed or `/api/v1/coverage?rule=...` |
+| "Track who-did-what" | `workflow + role + workproduct` graph | `commit trailers + ai-session + audit` |
+| "Make tool qualification auditable" | `doc_tool` need type + TCL field | `tool-qualification` schema + signed attestation |
+| "Render the safety case" | RST → HTML | YAML → markdown → HTML |
+| "Cross-repo references" | sphinx-needs `external_needs` via Bazel | rivet `externals:` via git |
+
+## Where they're doing *different things*
+
+| Eclipse does, pulseengine doesn't | Pulseengine does, eclipse doesn't |
+|---|---|
+| In-page `needtable` / `needpie` widgets at sphinx-build time | Grafana JSON API for external dashboards |
+| `:safety:` enum enforced at write time by metamodel regex | STPA / STPA-Sec / STPA-AI schemas |
+| Process modelled as graph (workflow / role / workproduct) | Variant model + constraint solver |
+| Sphinx layout customisation (`needs_layouts`) | AI provenance + audit (`ai-session`, `ai-found-defect`) |
+| Source-line `// req-Id` comments scanned at build time | MC/DC truth tables via `witness` |
+| Bazel-driven cross-repo composition | Cross-org typed supplier boundary (`derives-from-external`) |
+| | Formal verification integration (Kani, Verus, Rocq) |
+| | Falsification methodology explicit in tooling |
+| | MCP server for agent-driven traceability |
+| | Self-application of qualification dossier as typed artifacts |
+
+## The meta-pattern
+
+Eclipse's setup feels like **a documentation system that became a
+requirements system**. Sphinx-needs grew out of Sphinx; the gravity
+is toward "make the docs better." Validation, traceability, and
+compliance are *features added to* the docs pipeline.
+
+Pulseengine's setup feels like **a verification system that grew
+documents**. Rivet started as a graph + schema + validator; docs
+were added later. The gravity is toward "make the graph more
+provable." Rendering is *features added to* the verification
+pipeline.
+
+Same problem space (safety-critical SDLC traceability). Opposite
+starting points. Different gravities.
+
+That's the comparison without the verdict.
+
+## When this matters for a rivet positioning decision
+
+Any time someone asks "should rivet adopt approach X from eclipse?"
+or "should rivet add a feature Y eclipse has?", the answer depends
+on which gravity well it lands in:
+
+- Features that strengthen the graph + analysis (more oracle gates,
+  more schema rigor, more typed claims) → aligned with pulseengine's
+  gravity, low resistance to land.
+- Features that strengthen the doc-rendering surface (more inline
+  widgets, richer layouts, sphinx-style live computation in pages)
+  → orthogonal to pulseengine's gravity. Land via embeds + the
+  Grafana API, not via making rivet docs more Sphinx-like.
+- Features that grow the typed metamodel (more standards schemas,
+  more cross-repo predicates) → directly in pulseengine's wheelhouse.
+- Features that grow the process surface (more workflow/role/
+  workproduct types) → tension. Pulseengine traditionally lets git
+  + the AI-provenance machinery cover process; eclipse-style
+  workflow modelling is a different design.
+
+When the rivet team adds a feature, asking "which gravity is this
+pulling toward?" is a quick way to spot whether it's a natural
+extension or a methodology drift.

--- a/docs/design/externals-kind-source.md
+++ b/docs/design/externals-kind-source.md
@@ -1,0 +1,193 @@
+> **Harvested 2026-08-06** from the stale `feat/import-results-sphinx-needs`
+> branch (written 2026-06, base `86bf482`, never merged). Preserved as a
+> **historical design note**: its observations were true when written and have
+> **not** been re-verified against the current implementation. Read it as
+> context and as a proposal, not as current documentation.
+
+# PROPOSAL: `externals.<name>.kind: source` — clone-only mode for non-rivet upstreams
+
+**Status**: design proposal, surface change to rivet-core externals loader
+**Originating context**: eclipse-score-fork workspace at
+`/Users/r/git/pulseengine/eclipse-score-fork/` declares 58 upstream
+eclipse-score repos as `externals:` so `rivet sync` + `rivet.lock`
+pin them reproducibly. Eclipse repos are not rivet projects — they
+have no `rivet.yaml`. Today this produces 58 WARN lines per
+`rivet validate` ("external project at ... has no rivet.yaml").
+**Estimated effort**: ~30 lines in `rivet-core/src/externals.rs` + doc
+note + 1 unit test
+
+## Today's behaviour (live-tested in eclipse-score-fork commit `5ba605e`)
+
+```yaml
+externals:
+  eclipse-score-score:
+    git: https://github.com/eclipse-score/score
+    ref: 0b8257991935...
+    prefix: score
+  # ... 57 more entries
+```
+
+```
+$ rivet sync
+  Synced eclipse-score-score → ./.rivet/repos/score
+  ... (×58)
+58 externals synced.
+
+$ rivet validate
+[WARN  rivet] could not load externals: IO error: external project at
+              ./.rivet/repos/score has no rivet.yaml — expected config
+              at ./.rivet/repos/score/rivet.yaml
+... (×58)
+warning: could not load externals for cross-repo validation: ...
+... (×58 warnings, no errors)
+
+No issues found.
+
+Result: PASS (2507 warnings)
+```
+
+Validation PASSes but every run prints ~58 noisy warnings. The
+underlying intent — "I want rivet to pin and sync these repos, but
+they aren't rivet projects, don't try to load them" — has no clean way
+to express itself.
+
+## Proposed addition
+
+A new optional field `kind:` on each external, two values:
+
+```yaml
+externals:
+  spar:
+    git: https://github.com/pulseengine/spar.git
+    ref: 84a7363
+    prefix: spar
+    # kind: rivet   (default, current behaviour: load rivet artifacts)
+
+  eclipse-score-score:
+    git: https://github.com/eclipse-score/score
+    ref: 0b8257991935...
+    prefix: score
+    kind: source    # NEW: clone-only, don't try to load rivet artifacts
+```
+
+| `kind:` | sync clones | tries to load rivet artifacts | cross-link `prefix:ID` resolves | useful for |
+|---|---|---|---|---|
+| `rivet` (default) | ✓ | ✓ | ✓ | Today's behaviour. Cross-repo rivet-aware dependencies (spar, meld, etc.) |
+| `source` (new) | ✓ | ✗ | ✗ (no artifacts to resolve to) | Pinned non-rivet sources: sphinx-needs projects, DOORS exports, raw RST/markdown trees, plain code repos that a converter reads |
+
+`kind: source` keeps every other field (git, ref, prefix, path)
+working unchanged. The semantic is "this entry is a pinned git
+checkout that some other tool will consume — rivet's job is to clone
+and pin, not to validate."
+
+## Why this is the right granularity
+
+- **Not a global flag** — a project can mix-and-match. `pulseengine/rivet`
+  itself depends on `spar` (rivet-aware, want validation) and could
+  someday depend on a non-rivet source repo (raw text, qualified-by-checksum).
+  Per-external opt-in covers both.
+- **Not a separate top-level block** (`source-externals:`) — the
+  conceptual relationship is identical (pinned git ref under rivet's
+  cache), only the loader behaviour differs. Mixing them in one block
+  with a kind field keeps `rivet sync` semantics uniform.
+- **Not inferred from "rivet.yaml absent"** — silent inference is the
+  failure mode the current behaviour falls into. Explicit `kind:` is
+  honest about intent and fails loudly if eclipse-score ever DOES ship
+  a rivet.yaml at the same path (then `kind: source` keeps ignoring it,
+  per the author's intent, vs. surprise mode-change).
+
+## What changes in code
+
+The `rivet-core` externals loader has one branch that today is:
+
+```rust
+// pseudo-code, real path: rivet-core/src/externals.rs
+let cfg_path = repo_dir.join("rivet.yaml");
+if !cfg_path.exists() {
+    return Err(Error::Io(format!(
+        "external project at {} has no rivet.yaml — expected config at {}",
+        repo_dir.display(), cfg_path.display(),
+    )));
+}
+// ... continue loading external project's artifacts
+```
+
+Add a guard:
+
+```rust
+if external.kind == ExternalKind::Source {
+    // `kind: source` — externally-pinned data, no rivet artifacts
+    // expected at this path. Sync clones; loading is a no-op.
+    return Ok(LoadedExternal::sourceonly(prefix));
+}
+let cfg_path = repo_dir.join("rivet.yaml");
+if !cfg_path.exists() {
+    return Err(...);
+}
+// ...
+```
+
+Plus the corresponding `ExternalKind` enum (`Rivet` | `Source`) with
+serde default `Rivet`, deserialisation, schema doc.
+
+## Tests
+
+1. Unit: `externals.kind: source` parses, defaults to `Rivet` when
+   absent.
+2. Integration: an external entry with `kind: source` and no rivet.yaml
+   at the target produces zero diagnostics on `rivet validate`.
+3. Integration: an external entry with `kind: rivet` (default) and no
+   rivet.yaml continues to produce the current "has no rivet.yaml" WARN.
+   (Backwards-compatibility floor.)
+4. Cross-check: an external with `kind: source` does NOT register a
+   cross-link namespace — `prefix:SOME_ID` references resolve to
+   `dangling-cross-ref` errors. (Documents the explicit no-cross-link
+   semantic.)
+
+## Documentation impact
+
+- `rivet docs cross-repo` — add a third row to the "Two cross-repo
+  mechanisms" table (it becomes "Three cross-repo mechanisms"), or
+  add a `kind:` axis to the existing table.
+- The proposal also slightly weakens the binary-choice framing of
+  `externals:` vs `external-anchor` (DD-067 / cross-git-investigation.yaml)
+  — `kind: source` is essentially "externals: with the convenience of
+  git cloning but the no-artifact semantic of external-anchor". Worth
+  noting in DD-067 that `kind: source` is the middle-ground option.
+
+## Where this lands in the wider ecosystem
+
+The eclipse-score-fork at `/Users/r/git/pulseengine/eclipse-score-fork/`
+is the first realistic consumer: 58 externals with `kind: source`
+turns the cosmetic 58-WARN noise into clean output AND makes the
+"rivet eats its own dogfood for cross-repo pinning" story complete.
+
+Any future pulseengine fork that tracks non-rivet upstream sources
+(DOORS export drops, a sphinx-needs project, a vendored doc tree, a
+git submodule replacement) gets the same clean treatment with one
+extra line per external.
+
+## Open questions
+
+1. **Naming.** `kind: source` reads cleanly. Alternatives considered:
+   `loader: none`, `mode: clone-only`, `non-rivet: true`. `kind:` matches
+   the rivet artifact-type convention (every artifact has a `type:`,
+   every external could have a `kind:`).
+
+2. **Future kinds.** Could we add `kind: reqif`, `kind: doors-export`,
+   `kind: oslc` that auto-invoke the appropriate adapter? Not in v1 —
+   keep `kind:` two-valued until at least one third-kind is concretely
+   needed.
+
+3. **`rivet sync --kind source` filter.** Should `rivet sync` grow a
+   filter so an integrator can sync just the source externals (the
+   non-rivet ones a converter consumes) without touching rivet-kind
+   ones (which might be slow to clone)? Probably yes as a follow-up,
+   not part of the minimal landing.
+
+4. **Cross-link resolution semantics.** If `kind: source` means no
+   cross-links resolve, what does `target: source-prefix:SOMETHING`
+   mean? Today it would be `dangling-cross-ref`. The proposal keeps
+   that; could alternately auto-warn "cross-link to a kind:source
+   external — did you mean to use kind:rivet?" Could be added later
+   if the failure mode bites.


### PR DESCRIPTION
Rescues the durable content from the stale `feat/import-results-sphinx-needs` worktree before deleting it (found by the `repo-hygiene` sweep — 10 unpushed commits, 2 months old, base `86bf482`, never PR'd).

## Most of that branch was already harvested by another route
| Branch content | Status on main |
|---|---|
| `examples/score-conversion/` | **present** |
| `schemas/score.yaml` (+574 ln) | **identical** (1404 lines both sides) |
| sphinx-needs import | **ships** as `import-results --format needs-json` |
| `rivet-core/src/formats/sphinx_needs.rs` (1344 ln) | **superseded** — not harvested |

So the feature landed; only the branch's *implementation* and its design docs were orphaned.

## Harvested (2 of 7 docs)
- **`eclipse-score-vs-pulseengine-approach.md`** — methodology comparison against Eclipse S-CORE. Positioning context behind `schemas/score.yaml`; not invalidated by code drift.
- **`externals-kind-source.md`** — proposes `externals.<name>.kind: source` (clone-only for non-rivet upstreams). **Still unimplemented**, names a live symptom (58 WARN lines per `rivet validate` in the eclipse-score fork) and estimates ~30 lines in `rivet-core/src/externals.rs`.

## Dropped, with reasons
`sphinx-needs-rowan-v2` + `sphinx-needs-rust-port-v1.2-catchup` (plans for the implementation that never landed) · `rivet-link-parse-bug` (that bug is **REQ-091, fixed in v0.13.1**) · `artifact-embed-with-fields` + `variant-subsystem-eclipse-evidence` (held back — the variant subsystem moved a lot in REQ-265a–d).

## Honesty guards
Both docs carry a dated **provenance banner** marking them historical notes whose claims have **not** been re-verified. Importing 2-month-old docs as current documentation would be the exact doc-truth-drift class fixed in REQ-284.

And the gate earned its keep: **`rivet docs check` rejected the import** with 2 `ConfigExampleFreshness` violations — an `...  # 57 more` placeholder and `← NEW:` arrow annotations that made the YAML blocks unparseable. I fixed the blocks to be valid YAML rather than relabelling the fence, so the invariant keeps checking them. Now `PASS (64 files, 0 violations)`.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
