### PR TITLE
ci(changes): fail closed + derive embedded-asset build inputs (#771)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           fetch-depth: 0
       - id: filter
         run: |
+          set -o pipefail
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
             echo "wasm=true" >> "$GITHUB_OUTPUT"
@@ -54,22 +55,69 @@ jobs:
             exit 0
           fi
           base="${{ github.event.pull_request.base.sha }}"
-          changed="$(git diff --name-only "$base"...HEAD)"
-          echo "changed files:"; echo "$changed"
-          if echo "$changed" | grep -qE '(\.rs$)|((^|/)Cargo\.(toml|lock)$)|(^\.github/workflows/)'; then
+          # REQ-291 / #771: fail CLOSED. Previously an errored `git diff`
+          # (bad/absent base sha, shallow fetch) or an empty `changed` left
+          # both filters false — the error path was the "skip everything"
+          # path, and on GitHub a skipped required context is
+          # indistinguishable from a passed one. Any doubt about the diff
+          # now runs the full matrix.
+          if ! changed="$(git diff --name-only "$base"...HEAD)"; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
-            echo "→ Rust/Cargo/workflow changes present; running full matrix"
+            echo "wasm=true" >> "$GITHUB_OUTPUT"
+            echo "→ git diff failed against base=$base; failing closed to full matrix"
+            exit 0
+          fi
+          if [ -z "$changed" ]; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "wasm=true" >> "$GITHUB_OUTPUT"
+            echo "→ git diff returned no paths; failing closed to full matrix"
+            exit 0
+          fi
+          echo "changed files:"; echo "$changed"
+          # REQ-291 / #771: derive the "rust build inputs" file set from
+          # the source rather than retyping it. Anything a Rust file
+          # embeds via `include_str!`/`include_bytes!`/`include_dir!` is
+          # compiled INTO the binary — a change to it can silently break
+          # the test suite, so it MUST trigger the compile matrix even
+          # when the diff carries no .rs / Cargo / workflow file. Extract
+          # the path arg of every include_*!("<path>") in the Rust source,
+          # resolve it relative to the containing file, and dedupe to a
+          # sorted set of repo-root-relative paths.
+          embedded=$(
+            grep -rEHn --include='*.rs' 'include_(str|bytes|dir)!\("[^"]+"\)' \
+              rivet-core rivet-cli etch 2>/dev/null \
+              | while IFS= read -r match; do
+                  file="${match%%:*}"
+                  arg=$(printf '%s' "${match#*:}" \
+                    | sed -nE 's/.*include_(str|bytes|dir)!\("([^"]+)"\).*/\2/p')
+                  [ -z "$arg" ] && continue
+                  resolved=$(realpath -m --relative-to=. "$(dirname "$file")/$arg" 2>/dev/null) || continue
+                  echo "$resolved"
+                done | sort -u
+          )
+          echo "derived embedded assets:"; printf '  %s\n' $embedded
+          # Base filter: Rust source, workspace manifests, workflow files,
+          # AND composite actions. Composite actions ARE build inputs — a
+          # change to `.github/actions/free-space/action.yml` used by a
+          # compile job can break that job, so it must trigger the matrix.
+          rust_re='(\.rs$)|((^|/)Cargo\.(toml|lock)$)|(^\.github/workflows/)|(^\.github/actions/)'
+          if echo "$changed" | grep -qE "$rust_re" \
+             || { [ -n "$embedded" ] && echo "$changed" | grep -Fxq -f <(echo "$embedded"); }; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "→ Rust/Cargo/workflow/action/embedded-asset changes present; running full matrix"
           else
             echo "rust=false" >> "$GITHUB_OUTPUT"
-            echo "→ no Rust/Cargo/workflow changes; skipping compile-heavy jobs"
+            echo "→ no Rust/Cargo/workflow/action/embedded-asset changes; skipping compile-heavy jobs"
           fi
           # REQ-268: the wasm SEAM (compose-witness component + WIT, the host
           # `wasm` feature / wasm_runtime, the composition core it wraps, and
           # the spar-wasm build assets) is consumed downstream (melded →
           # loomed → synth'd), so a change that rots it is a downstream break.
           # It is built only in release.yml today, so gate a cheap per-PR
-          # host-side build on these paths.
-          if echo "$changed" | grep -qE '(^compose-witness/)|(wasm_runtime\.rs$)|(feature_model\.rs$)|(\.wit$)|(scripts/build-wasm\.sh$)|(serve/js\.rs$)|(assets/wasm/)|(^\.github/workflows/)'; then
+          # host-side build on these paths. `.github/actions/` included on
+          # the same fail-closed logic as the rust filter — a composite
+          # action a wasm job depends on can break that job the same way.
+          if echo "$changed" | grep -qE '(^compose-witness/)|(wasm_runtime\.rs$)|(feature_model\.rs$)|(\.wit$)|(scripts/build-wasm\.sh$)|(serve/js\.rs$)|(assets/wasm/)|(^\.github/workflows/)|(^\.github/actions/)'; then
             echo "wasm=true" >> "$GITHUB_OUTPUT"
             echo "→ wasm-seam paths changed; running the wasm-seam build gate"
           else

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -8099,7 +8099,7 @@ artifacts:
   - id: REQ-291
     type: requirement
     title: "Detect-changed-areas filter is under-scoped and fails open: embedded schemas skip the compile matrix (#771, cf. spar#384)"
-    status: proposed
+    status: implemented
     description: "v0.33 gate-potency slice. A `rust=false` verdict from the `changes` job skips Clippy, Test, MSRV, Semver, Miri, Proptest, Coverage and wasm-seam — and on GitHub a SKIPPED required context is indistinguishable from a passed one. The classifier only matches `(\\.rs$)|(Cargo\\.(toml|lock)$)|(^\\.github/workflows/)`, which misses real build inputs: `schemas/*.yaml` are compiled INTO the binary via `include_str!` (rivet-core/src/embedded.rs), so a schema-only edit — which changes binary content and can break the suite — skips the entire compile matrix; `.github/actions/**` composite actions used BY those jobs likewise skip. Third, the error path is the permissive path: if `git diff` fails (bad/absent base sha, shallow fetch) `changed` is empty, nothing matches, and the step exits 0 with rust=false. Fix: add the real build inputs (derive include_str!/include_dir! sources rather than retyping them) and fail CLOSED — an errored or empty diff must set rust=true. Ported from spar#384."
     release: v0.33.0
     provenance:


### PR DESCRIPTION
Closes #771. Un-hides embedded-asset edits from the compile matrix, and turns the `git diff` error path into a fail-closed one.

## The three misses in `changes` today

The `changes` job's filter matches only `(\.rs$)|(Cargo\.(toml|lock)$)|(^\.github/workflows/)`. On GitHub, a **SKIPPED** required context is indistinguishable from a **passed** one, so any real build-affecting file the filter doesn't recognise silently skips Clippy, Test, MSRV, Semver, Miri, Proptest, Coverage, and the wasm-seam gate.

1. **`schemas/*.yaml` are compiled INTO the binary.** `rivet-core/src/embedded.rs` pulls every shipped schema in with `include_str!("../../schemas/…")` (40+ entries). A schema-only PR — which changes compiled binary content and can break the test suite — landed on `rust=false` and skipped the compile matrix.
2. **`.github/actions/**` composite actions.** Only `.github/workflows/` was matched, so an edit to `.github/actions/free-space/action.yml` (used BY the compile jobs) didn't trigger them.
3. **`git diff` errors → skip everything.** `changed="$(git diff --name-only "$base"...HEAD)"` — a bad/absent base sha or a shallow fetch left `changed` empty, nothing matched, and the step exited 0 with `rust=false`. The error path WAS the "skip everything" path.

## Fix — derive, don't retype; fail closed

- **Derive** the embedded-asset file set from the source at gate time. `grep` for every `include_str!` / `include_bytes!` / `include_dir!` in `rivet-core` / `rivet-cli` / `etch`, resolve the path arg against its containing file, and exact-match against changed files. A new `include_str!("…")` a future PR adds is auto-covered — no filter-list drift.
- **Add `.github/actions/`** to the rust regex AND to the wasm regex (same fail-safe reason).
- **Fail closed.** An erroring or empty `git diff` now sets `rust=true` AND `wasm=true` (full matrix) instead of silently skipping every gate.

## Acceptance criteria (from the issue body) → how satisfied

- [x] **Add the real build inputs to the filter: `schemas/`, `.github/actions/`, and any other `include_str!` / `include_dir!` source (derive it, don't retype it).** The filter now (a) matches `.github/actions/` in the base regex and (b) exact-matches changed files against a runtime-derived list of every path referenced by an `include_(str|bytes|dir)!` in the Rust source. Derived set on HEAD has 50 entries covering `schemas/*.yaml`, `schemas/migrations/*.yaml`, `schemas/*.bridge.yaml`, `rivet-cli/assets/*` (htmx, mermaid, fonts, svg-viewer, wasm/js/spar_wasm.*), `rivet-cli/src/quickstart.md`, `rivet-core/src/templates/{discovery,structural}/*.md`, `docs/artifact-types/ordeal-certificate.md`, `docs/design/tool-qualification-dossier.md`, `etch/src/html_interactivity.js`, and `rivet-core/src/externals.rs`. No retyping — the source is the source of truth.
- [x] **Fail closed: if `git diff` errors or returns nothing, set `rust=true` rather than skipping the matrix.** Two explicit early-exit branches added, both setting rust=true AND wasm=true and logging why. `set -o pipefail` added so a broken pipeline propagates rather than silently swallowing a failing sed inside the derive step.

## Verified locally

Simulated the classifier against representative paths — every result matches expectation:

| changed file | expected | got |
|---|---|---|
| `schemas/dev.yaml` (schema-only) | rust=true | rust=true |
| `schemas/migrations/dev-to-aspice.yaml` | rust=true | rust=true |
| `.github/actions/free-space/action.yml` | rust=true | rust=true |
| `docs/artifact-types/ordeal-certificate.md` | rust=true | rust=true |
| `docs/design/tool-qualification-dossier.md` | rust=true | rust=true |
| `rivet-core/src/templates/structural/emit.md` | rust=true | rust=true |
| `rivet-cli/assets/htmx.min.js`, `fonts.css` | rust=true | rust=true |
| `rivet-cli/assets/wasm/js/spar_wasm.js` | rust=true | rust=true |
| `rivet-cli/src/quickstart.md` | rust=true | rust=true |
| `rivet-cli/src/main.rs` | rust=true | rust=true |
| `Cargo.toml`, `.github/workflows/ci.yml` | rust=true | rust=true |
| `docs/design/status-gate-rules.md` (not embedded) | rust=false | rust=false |
| `docs/README.md`, `README.md`, `CHANGELOG.md` | rust=false | rust=false |
| `artifacts/requirements.yaml`, `rivet.yaml` | rust=false | rust=false |
| `docs/plans/*.md`, `docs/historical/*.md` | rust=false | rust=false |
| empty diff | rust=true (fail closed) | rust=true wasm=true |

## What this PR is NOT

- **Not a change to what any gate does.** The `fmt` / `Test` / `Miri` / etc. jobs are byte-identical; only the upstream `changes` job that gates them changed.
- **Not a change to the `on:` triggers.** The `if [ event_name != pull_request ]` branch is untouched — push, schedule, and workflow_dispatch still run the full matrix.
- **Not a fix for the runner-liveness gap.** #509 (self-hosted pool as SPOF) and #567 (disk exhaustion) are their own PRs on their own REQs.

REQ-291 flipped `proposed → implemented`. Ported from spar#384 (same class of under-scoping).

Fixes: REQ-291
Refs: #771

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mjd85UePLRJVHtb8haBGF8)_