### PR TITLE
fix(serve): don't silently swallow a failed external load (#778 follow-up)

### DIFF
--- a/rivet-cli/src/serve/mod.rs
+++ b/rivet-cli/src/serve/mod.rs
@@ -417,13 +417,41 @@ fn load_externals(config: &ProjectConfig, project_path: &std::path::Path) -> Vec
             let synced = ext_dir.join("rivet.yaml").exists();
             let mut ext_store = Store::new();
             if synced {
-                if let Ok((artifacts, _schema)) =
-                    rivet_core::externals::load_external_project(&ext_dir)
-                {
-                    for a in artifacts {
-                        ext_store.upsert(a);
+                // #778: this used to be `if let Ok(..)` with no else — a failed
+                // external load left an EMPTY store while `synced` stayed true,
+                // so the dashboard silently showed zero external artifacts and
+                // reported every row as origin=local. Missing evidence must be
+                // loud: surface the error instead of degrading to "no externals".
+                match rivet_core::externals::load_external_project(&ext_dir) {
+                    Ok((artifacts, _schema)) => {
+                        for a in artifacts {
+                            ext_store.upsert(a);
+                        }
+                        if ext_store.iter().count() == 0 {
+                            log::warn!(
+                                "external '{}' at {} loaded 0 artifacts — its rivet.yaml \
+                                 declares no sources, or they matched no files",
+                                ext.prefix,
+                                ext_dir.display()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "external '{}' at {} failed to load: {e} — the dashboard will \
+                             show no artifacts for this prefix",
+                            ext.prefix,
+                            ext_dir.display()
+                        );
                     }
                 }
+            } else {
+                log::warn!(
+                    "external '{}' is declared but not synced (no rivet.yaml at {}) — \
+                     run `rivet sync`",
+                    ext.prefix,
+                    ext_dir.display()
+                );
             }
             externals.push(ExternalInfo {
                 prefix: ext.prefix.clone(),


### PR DESCRIPTION
Small hardening salvaged from the closed #780. **Not** the #778 fix — that is #779.

## The defect

`load_externals` (serve/mod.rs) swallowed a failed external load:

```rust
if synced {
    if let Ok((artifacts, _schema)) = load_external_project(&ext_dir) {
        for a in artifacts { ext_store.upsert(a); }
    }
}          // <- no else
```

On `Err`, the external kept `synced: true` but got an **empty store**. The dashboard then showed zero artifacts for that prefix, with no diagnostic anywhere — indistinguishable from an external that legitimately has none, and indistinguishable from the pagination bug I was actually chasing.

## Change

- load error → `log::error!` naming the prefix, the path, and the error
- loaded-but-empty → `log::warn!` (its `rivet.yaml` declares no sources, or they matched no files)
- declared-but-unsynced → `log::warn!` pointing at `rivet sync`

## Honest scope

The external load **has been succeeding all along**; this fixes no current misbehaviour. Its value is that the next failure in this path announces itself instead of degrading silently to "no externals" — the same "missing evidence must be loud" rule the v0.33 gate-potency work is built on (REQ-288 applied it to a mutation gate that defaulted to `MISSED=0` when its report was absent).

I found it while pursuing a wrong hypothesis about #778. It is worth keeping on its own merits, which is why it is here rather than bundled into a fix it does not contribute to.

`fmt` and `clippy --all-targets -D warnings` clean. No behaviour change, so no new test — the branch does **not** make the `api_artifacts_external_excluded_under_variant_scope` failure go away; #779 does that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
