### PR TITLE
fix(ci): mutation gate must not fail on an empty diff or a shallow base (REQ-288 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -809,6 +809,10 @@ jobs:
         # `continue-on-error: true`, so honest numbers surface without blocking.
         run: |
           REPORT=mutants-out/mutants.out
+          if [ ! -s pr.diff ]; then
+            echo "no Rust changes in this diff — nothing to mutate, nothing to check"
+            exit 0
+          fi
           if [ ! -f "$REPORT/outcomes.json" ]; then
             echo "::error::no $REPORT/outcomes.json — cargo-mutants crashed or its layout changed; not reporting a pass over missing evidence"
             ls -R mutants-out 2>/dev/null || echo "(no mutants-out/ at all)"
@@ -857,6 +861,11 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+        with:
+          # REQ-288: --in-diff needs the PR base commit present locally; a
+          # shallow clone makes `git diff <base>...HEAD` fail and (previously,
+          # silently) yield an empty diff.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -881,7 +890,10 @@ jobs:
           git fetch --no-tags origin "${{ github.event.pull_request.base.sha || 'main' }}" 2>/dev/null || true
           BASE="${{ github.event.pull_request.base.sha }}"
           if [ -z "$BASE" ]; then BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"; fi
-          git diff "$BASE"...HEAD -- '*.rs' > pr.diff || true
+          if ! git diff "$BASE"...HEAD -- '*.rs' > pr.diff; then
+            echo "::error::could not diff $BASE...HEAD — the base commit is not present (shallow clone?); refusing to run a mutation gate over an unknown diff"
+            exit 1
+          fi
           echo "diff lines: $(wc -l < pr.diff | tr -d ' ')"
       - name: Run cargo-mutants
         # #590 memory guard (see mutants-core above): cap address space at
@@ -897,6 +909,7 @@ jobs:
           ulimit -v 50331648
           if [ ! -s pr.diff ]; then
             echo "no Rust changes in this diff — nothing to mutate"
+            exit 0
           fi
           cargo mutants -p rivet-cli --timeout 60 --jobs 2 --output mutants-out --in-diff pr.diff || true
       - name: Check surviving mutants
@@ -907,6 +920,10 @@ jobs:
         # covers a crashed run being scored as a good one).
         run: |
           REPORT=mutants-out/mutants.out
+          if [ ! -s pr.diff ]; then
+            echo "no Rust changes in this diff — nothing to mutate, nothing to check"
+            exit 0
+          fi
           if [ ! -f "$REPORT/outcomes.json" ]; then
             echo "::error::no $REPORT/outcomes.json — cargo-mutants crashed or its output layout changed; refusing to report a pass over missing evidence"
             ls -R mutants-out 2>/dev/null || echo "(no mutants-out/ at all)"


### PR DESCRIPTION
My REQ-288 change (#773) made the rivet-cli mutation gate **able to fail** — and it promptly failed on #779 for the wrong reason, blocking the merge queue. This fixes it. Three defects, all mine:

**1. Shallow checkout.** `--in-diff` needs the PR base commit present locally, but the job checks out without `fetch-depth: 0`, so `git diff <base>...HEAD` could not resolve the base.

**2. The failure was swallowed.** That diff ran as `... > pr.diff || true`, so the error became an *empty* `pr.diff` instead of a stop. That is precisely the silent-swallow anti-pattern this whole v0.33 line of work exists to remove — committed by me, in the same PR that removes it elsewhere. Worth stating plainly rather than quietly patching.

**3. Empty diff read as missing evidence.** cargo-mutants writes no report when there is nothing to mutate, so the "absent `outcomes.json` is RED" guard fired on the legitimate no-Rust-changes case.

Observed on #779:
```
diff lines: 0
cargo mutants … --in-diff pr.diff || true
::error::no mutants-out/mutants.out/outcomes.json — refusing to report a pass over missing evidence
```

## Fixes
- `fetch-depth: 0` on the `mutants-cli` checkout
- the diff step **fails loudly** (`::error::` + `exit 1`) when the base cannot be resolved, instead of proceeding over an unknown diff
- an empty diff short-circuits to **PASS** in both the run and the check steps

## Negative control
Re-ran the check logic over the three cases that matter:

| case | result |
|---|---|
| empty diff (the #779 blocker) | **PASS** — nothing to mutate |
| diff + report with 2 survivors | **FAIL** — gate bites |
| diff + no report (crashed run) | **FAIL** — missing evidence |

So the gate keeps the property REQ-288 gave it (it can still fail, and still refuses to pass over a missing report) while no longer failing on "no Rust changed". `yamllint` clean.

Merge this **before** #779 — it is what unblocks it.

Refs: REQ-288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
