### PR TITLE
chore(release): v0.33.0 — gate potency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-11
+
+Gate potency — *a gate that cannot fail is not a gate*. Four required CI checks
+ran, reported green, and could not go red. Ported from spar's gate audit
+(spar#381/#383/#384/#388) and each reproduced here with direct evidence.
+
+### Fixed
+- **Mutation gate could never fail** (REQ-288, #768) — the rivet-cli *hard* gate
+  read `mutants-out/missed.txt`, a path cargo-mutants has never written (it
+  writes `<output>/mutants.out/`), so `MISSED` stayed `0` and the gate passed
+  regardless of survivors. Evidence: an uploaded artifact's real `missed.txt`
+  lists 5 survivors while the job printed `Surviving mutants: 0`. Two further
+  rivet-only defects compounded it: the gate ran `-- --lib` against a crate with
+  **no lib target** (`cargo test -p rivet-cli --lib` errors), so no test ever
+  exercised any mutant and all 29 integration test files were excluded; and the
+  artifact-upload globs never matched, so no rivet-cli mutants report had ever
+  been produced. Now reads the real path, **fails loudly when the report is
+  absent** (a missing report must never read as a clean one), drops `--lib`, and
+  scopes the per-PR run with `--in-diff` so a correct gate fits the time budget.
+- **Format gate was blind to a whole workspace** (REQ-289, #769) —
+  `cargo fmt --all` covers *this* workspace, not the repo. rivet has two
+  (`/` and `fuzz/`); the root check passed while `fuzz/` carried real drift in 5
+  tracked files. The gate now derives the workspace list so a new nested
+  workspace cannot silently escape it.
+- **The anti-rot check ran in no workflow** (REQ-290, #770) —
+  `rivet check verification-evidence` exists precisely to catch artifacts citing
+  tests that no longer exist, and nothing invoked it. Now wired into the
+  Traceability job, and its zero-steps case no longer prints a checkmark over an
+  empty scan.
+- **Changed-areas filter was under-scoped and failed open** (REQ-291, #771) — a
+  `rust=false` verdict skips Clippy/Test/MSRV/Semver/Miri/Proptest, and on GitHub
+  a *skipped* required context is indistinguishable from a passed one. Embedded
+  schemas (`include_str!`) and composite actions did not match the filter, and an
+  errored `git diff` yielded the permissive verdict. Now derives the real build
+  inputs and fails **closed**.
+- **Externals fell off the end of `/artifacts`** (#778) — external artifacts were
+  appended after every local one and then paginated, so once a project's local
+  count exceeded the page window they became unreachable while `total` still
+  counted them, and every visible row read `origin: local`. Growth-triggered: no
+  commit broke it. Externals are now emitted before locals. A failed external
+  load also no longer degrades silently to "no externals".
+
 ### Fixed
 - **`rivet check verification-evidence` is now wired into CI + no longer scores
   an empty scan as a pass** (REQ-290, #770) — the anti-rot check for stale

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "etch"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "petgraph 0.7.1",
 ]
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cli"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-core"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["compose-witness"]
 
 [workspace.package]
-version = "0.32.0"
+version = "0.33.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -8035,7 +8035,7 @@ artifacts:
     title: "rivet docs check: parse embedded doc snippets + resolve doc-topic references (catch truth-drift mechanically)"
     status: proposed
     description: "Meta-fix for the weak-green docs class (REQ-284): `rivet docs check` today validates token/format hygiene, so a doc snippet whose flags don't parse or that references a non-existent `rivet docs <topic>` passes clean. Add two invariants: (a) shell every fenced ```bash rivet …``` snippet in the embedded docs through the clap parser (arg-validation / --help level, no execution) and fail on unknown args/subcommands; (b) assert every `rivet docs <topic>` / `rivet schema <name>` reference in doc prose resolves to a real topic. The countercheck showed this would have caught 6 of 8 REQ-284 divergences mechanically — turning an expensive human audit into a gate. This is the 'weak green' fix at the meta level: make the green prove the snippets are true, not just well-formed."
-    release: v0.33.0
+    release: v0.34.0
     provenance:
       created-by: ai-assisted
       model: claude-opus-4-8
@@ -8046,7 +8046,7 @@ artifacts:
     title: "rivet release status: be LOUD about which artifacts block a cut (and whether they are in-scope vs backlog)"
     status: proposed
     description: "User-reported: when a release's scope contains artifacts not in a ready status (draft/proposed, or implemented-not-verified), `rivet release status <v>` reports not-cuttable — which may be correct, but the block should be LOUD and actionable, not a terse 'NOT cuttable'. Surface, per blocking artifact: its id, current status, the target status it needs, and (critically) whether it is genuinely IN THIS RELEASE'S SCOPE vs backlog that merely carries the release: field or none — so the user can act (promote it, or move it out of the release) instead of being stuck. Ties to release.ready-when (REQ-240) and the ship-at-implemented gap (the release-status gate is stricter than actual practice). Part of the weak-green/unclear-signal family: a RED that doesn't clearly say why or what to do about it."
-    release: v0.33.0
+    release: v0.34.0
     provenance:
       created-by: ai-assisted
       model: claude-opus-4-8

--- a/vscode-rivet/package.json
+++ b/vscode-rivet/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rivet SDLC",
   "description": "SDLC artifact traceability with live validation, hover info, and embedded dashboard",
   "publisher": "pulseengine",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release-prep for **v0.33.0** — *gate potency*.

## Theme: a gate that cannot fail is not a gate

Four **required** CI checks ran, reported green, and could not go red. All four were ported from spar's gate audit (spar#381/#383/#384/#388) and independently reproduced here with direct evidence.

| REQ | What could not fail | Issue |
|-----|---------------------|-------|
| **REQ-288** | Mutation gate — read a path cargo-mutants never writes; also ran `-- --lib` against a crate with **no lib target** (so no test exercised any mutant, and all 29 integration test files were excluded); upload globs never matched, so no rivet-cli report had ever existed | #768 |
| **REQ-289** | Format gate — `cargo fmt --all` covers one workspace, not the repo; `fuzz/` carried real drift in 5 tracked files | #769 |
| **REQ-290** | `check verification-evidence` — the anti-rot checker ran in **no workflow** | #770 |
| **REQ-291** | Changed-areas filter — under-scoped (embedded `include_str!` schemas, composite actions) and **failed open**; a *skipped* required context is indistinguishable from a passed one | #771 |

Evidence highlight: an uploaded mutants artifact's real `missed.txt` lists **5 survivors** while the job printed `Surviving mutants: 0`.

Each gate now also treats **missing evidence as red** — an absent report never defaults to a clean count.

## Also carried: the #778 externals fix (#779)

Downstream **sigil is waiting on this specific fix**: it has **1242 local artifacts**, ~12× the default page window, so its `synth`/`kiln` external rows are currently dropped from `/artifacts` while `total` still counts them — exactly the cross-repo linkage its embedded trust chain (sigil#187) depends on. The fix is on `main` but in **no release**, so sigil cannot pin its way out. That is why this cut is not waiting for the rest of the v0.33 backlog.

## Scope moved deliberately

**REQ-285** (docs check parses snippets) and **REQ-286** (release status loudness) → **v0.34.0**. Both still `proposed`; the release's own theme is complete without them. Logged rather than silently dropped.

Final scope is 4/4 `implemented`, and all four issues (#768–#771) are already closed.

## Verification
`rivet validate` PASS · `docs check` 0 violations · binary reports `rivet 0.33.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
