### PR TITLE
fix(ci): un-vacuum the mutants-core gate; dedupe the v0.33.0 changelog section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,10 +857,6 @@ jobs:
         # `continue-on-error: true`, so honest numbers surface without blocking.
         run: |
           REPORT=mutants-out/mutants.out
-          if [ ! -s pr.diff ]; then
-            echo "no Rust changes in this diff — nothing to mutate, nothing to check"
-            exit 0
-          fi
           if [ ! -f "$REPORT/outcomes.json" ]; then
             echo "::error::no $REPORT/outcomes.json — cargo-mutants crashed or its layout changed; not reporting a pass over missing evidence"
             ls -R mutants-out 2>/dev/null || echo "(no mutants-out/ at all)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,6 @@ ran, reported green, and could not go red. Ported from spar's gate audit
   (`/` and `fuzz/`); the root check passed while `fuzz/` carried real drift in 5
   tracked files. The gate now derives the workspace list so a new nested
   workspace cannot silently escape it.
-- **The anti-rot check ran in no workflow** (REQ-290, #770) —
-  `rivet check verification-evidence` exists precisely to catch artifacts citing
-  tests that no longer exist, and nothing invoked it. Now wired into the
-  Traceability job, and its zero-steps case no longer prints a checkmark over an
-  empty scan.
 - **Changed-areas filter was under-scoped and failed open** (REQ-291, #771) — a
   `rust=false` verdict skips Clippy/Test/MSRV/Semver/Miri/Proptest, and on GitHub
   a *skipped* required context is indistinguishable from a passed one. Embedded
@@ -47,7 +42,6 @@ ran, reported green, and could not go red. Ported from spar's gate audit
   commit broke it. Externals are now emitted before locals. A failed external
   load also no longer degrades silently to "no externals".
 
-### Fixed
 - **`rivet check verification-evidence` is now wired into CI + no longer scores
   an empty scan as a pass** (REQ-290, #770) — the anti-rot check for stale
   `cargo test <filter>` names (REQ-236, hardened again in REQ-280 for nextest


### PR DESCRIPTION
Two findings from the **v0.33.0 pre-tag clean-room audit** (9/9 claims passed; these were flagged alongside). Neither blocks the tag — the first is nightly + `continue-on-error`, the second cosmetic — but the first is the exact defect class this release exists to remove, so it should not outlive the release that introduced it.

## 1. `mutants-core` was made unconditionally vacuous — by my own REQ-288 follow-up

The empty-diff short-circuit (`if [ ! -s pr.diff ]; then … exit 0`) belongs to `mutants-cli`, which computes `pr.diff`. My patch applied it to **every** matching check step, and `mutants-core` has no step that writes `pr.diff` — different job, different runner label, and `actions/checkout` cleans untracked files anyway. So the guard always fired and the job **never evaluated `outcomes.json` or `missed.txt`** for rivet-core. The in-file comment claiming *"honest numbers surface without blocking"* was false as written.

Root cause worth naming plainly: **a string replace without a count**. The fix for a vacuous gate introduced a vacuous gate one job over — inside the release whose thesis is that a gate which cannot fail is not a gate.

Guard removed from `mutants-core`; `mutants-cli` keeps it (correct there). Verified: `mutants-core` now has **0** `pr.diff` references, `mutants-cli` retains **5**.

## 2. Duplicated `### Fixed` in the [0.33.0] changelog

The section carried two `### Fixed` subheads and documented REQ-290 twice (my summary plus #776's fuller entry). Collapsed to one, keeping the detailed entry. A duplicated section in a release about honest reporting is worth fixing before the tag rather than after.

Now: one `### Fixed`, REQ-290 mentioned once, all of REQ-288/289/290/291 present.

`yamllint` clean · `docs check` 0 violations.

Refs: REQ-288
